### PR TITLE
Step 1 : 모델 타입 구현 (Bam)

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3600910225911481001A724F /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3600910125911481001A724F /* Exposition.swift */; };
+		3600910625911A8A001A724F /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3600910525911A8A001A724F /* Item.swift */; };
+		3600910B25911BE6001A724F /* Items.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3600910A25911BE6001A724F /* Items.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
@@ -16,6 +19,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3600910125911481001A724F /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
+		3600910525911A8A001A724F /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		3600910A25911BE6001A724F /* Items.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Items.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +43,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		36009100259112D0001A724F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3600910125911481001A724F /* Exposition.swift */,
+				3600910525911A8A001A724F /* Item.swift */,
+				3600910A25911BE6001A724F /* Items.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		C79FF4A82589F401005FB0FD = {
 			isa = PBXGroup;
 			children = (
@@ -56,6 +72,7 @@
 		C79FF4B32589F401005FB0FD /* Expo1900 */ = {
 			isa = PBXGroup;
 			children = (
+				36009100259112D0001A724F /* Models */,
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B82589F401005FB0FD /* ViewController.swift */,
@@ -138,7 +155,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
+				3600910625911A8A001A724F /* Item.swift in Sources */,
+				3600910225911481001A724F /* Exposition.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
+				3600910B25911BE6001A724F /* Items.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900/Models/Exposition.swift
+++ b/Expo1900/Expo1900/Models/Exposition.swift
@@ -1,0 +1,21 @@
+//
+//  Exposition.swift
+//  Expo1900
+//
+//  Created by 임성민 on 2020/12/22.
+//
+
+import Foundation
+
+struct Exposition: Decodable {
+    let title: String
+    let visitorsNumber: Int
+    let location: String
+    let duration: String
+    let description: String
+    
+    enum CodingKeys: String, CodingKey {
+        case title, location, duration, description
+        case visitorsNumber = "visitors"
+    }
+}

--- a/Expo1900/Expo1900/Models/Exposition.swift
+++ b/Expo1900/Expo1900/Models/Exposition.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Exposition: Decodable {
     let title: String
-    let visitorsNumber: Int
+    let visitorsNumber: UInt
     let location: String
     let duration: String
     let description: String

--- a/Expo1900/Expo1900/Models/Item.swift
+++ b/Expo1900/Expo1900/Models/Item.swift
@@ -1,0 +1,22 @@
+//
+//  Items.swift
+//  Expo1900
+//
+//  Created by 임성민 on 2020/12/22.
+//
+
+import Foundation
+
+struct Item: Decodable {
+    let name: String
+    let imageName: String
+    let shortDescription: String
+    let description: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case imageName = "image_name"
+        case shortDescription = "short_desc"
+        case description = "desc"
+    }
+}

--- a/Expo1900/Expo1900/Models/Items.swift
+++ b/Expo1900/Expo1900/Models/Items.swift
@@ -1,0 +1,12 @@
+//
+//  Items.swift
+//  Expo1900
+//
+//  Created by 임성민 on 2020/12/22.
+//
+
+import Foundation
+
+struct Items: Decodable {
+    let items: [Item]
+}


### PR DESCRIPTION
JSON 파일을 저장할 3개의 모델 타입을 구현하였으며, 세부 사항은 아래와 같습니다.
- 박람회 정보를 저장할 Exposition struct 구현.
- 출품작 정보를 저장할 Item struct 구현.
- 출품작 정보의 배열을 저장할 Items struct 구현.