### PR TITLE
만국박람회 [Step1] EHD, Hosinging

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2BA1BBDE2695722C00DE3842 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA1BBDD2695722C00DE3842 /* Exposition.swift */; };
+		2BA1BBE02695724100DE3842 /* ExpositionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA1BBDF2695724100DE3842 /* ExpositionItem.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
@@ -16,6 +18,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2BA1BBDD2695722C00DE3842 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
+		2BA1BBDF2695724100DE3842 /* ExpositionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionItem.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -37,6 +41,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2BA1BBDC2695721800DE3842 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				2BA1BBDD2695722C00DE3842 /* Exposition.swift */,
+				2BA1BBDF2695724100DE3842 /* ExpositionItem.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		C79FF4A82589F401005FB0FD = {
 			isa = PBXGroup;
 			children = (
@@ -56,6 +69,7 @@
 		C79FF4B32589F401005FB0FD /* Expo1900 */ = {
 			isa = PBXGroup;
 			children = (
+				2BA1BBDC2695721800DE3842 /* Model */,
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B82589F401005FB0FD /* ViewController.swift */,
@@ -137,7 +151,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2BA1BBE02695724100DE3842 /* ExpositionItem.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
+				2BA1BBDE2695722C00DE3842 /* Exposition.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 			);

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -1,0 +1,16 @@
+//
+//  Exposition.swift
+//  Expo1900
+//
+//  Created by EHD, Hosinging on 2021/07/07.
+//
+
+import Foundation
+
+struct Exposition {
+    let title: String
+    let visitors: String
+    let location: String
+    let duration: String
+    let description: String
+}

--- a/Expo1900/Expo1900/Model/ExpositionItem.swift
+++ b/Expo1900/Expo1900/Model/ExpositionItem.swift
@@ -1,0 +1,26 @@
+//
+//  ExpositionItem.swift
+//  Expo1900
+//
+//  Created by EHD, Hosinging on 2021/07/07.
+//
+
+import Foundation
+
+struct ExpositionItem: Codable {
+    let items: [Item]
+}
+
+struct Item: Codable {
+    let name: String
+    let imageName: String
+    let shortDescription: String
+    let description: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case imageName = "image_name"
+        case shortDescription = "short_description"
+        case description = "desc"
+    }
+}


### PR DESCRIPTION
@라자냐
1. ExpositionItem 구조체를 만들고, items라는 Item타입의 배열을 만들어서 아이템이 담기는 타입과, 아이템 자체의 타입을 구분을 지었습니다.
json파일을 봤을 때 배열이 먼저 열리고, 그다음 객체가 열려서 이와 같이 작성을 했는데, 이 것이 적절한 표현인지 궁금합니다.

2. 1번과 같이 타입을 분리해서 적었을 때, ExpositionItem타입안에 Item타입을 넣어서 작성할 수 도 있었겠지만, 특별한 의도없이 분리해서 작성을 해봤는데요. 하나의 타입안에서 작성했을 때와 이와 같이 나눠서 작성했을 때 어떤 장,단점이 있을지 궁금합니다.

3. UML을 그리는데 ExpositionItem타입의 items라는 프로퍼티가 Item타입의 프로퍼티가 아닌 Item타입의 배열을 프로퍼티로 가지고 있기 때문에 연관 관계가 아닌 Aggregation(집약)관계로 표현을 해봤습니다. 이 부분이 적절하게 표현한 것인지 궁금합니다. 만약 잘못된 것이라면 어떤 부분을 기준으로 달리 표현해야하는지 궁금합니다.

https://www.youtube.com/watch?v=UKmD_Xi41UA 이 유튜브 35:16정도에 나오는 내용을 참고해서 작성했습니다.
![image](https://user-images.githubusercontent.com/39648822/124717204-dedea900-df3f-11eb-966d-f520dd68ca26.png)


4. Exposition이라는 메인화면을 표현하는데 필요한 json파일은 다른 모델 파일과 연관 관계가 없다고 판단해서 따로 선을 이어주지 않았는데 이렇게 하는게 맞는 건지 궁금합니다. 

5. json파일을 파싱하기 위한 용도의 사용자 정의 타입에도 접근제어자를 사용해주는게 좋은지 궁금합니다.

6. 저희는 간단한 기능명세서 및 제이슨 파일을 토대로 data타입을 만들어서 그에 쓰이는 이름, 이미지, 설명 등을 멤버로 만들어서 구조체를 짜보았습니다. 그런데 이것이 단순한 앱이기에 가능했지만 현업에서는 데이터의 종류가 훨씬 많고 다양할텐데 많은 변수들을 어떠한 방식으로 구조화 하는지 궁금합니다. 예를들어, 이번 작업에서 프로퍼티로 만들어준 것들을 개수가 수백개가 된다면 하나 하나 타입안에 프로퍼티로 작성을 해주는 것인지 궁금합니다. 