### PR TITLE
왕국밥라멘 [STEP 3] 산체스, 승기

### DIFF
--- a/Expo1900/Expo1900/Controller/AppDelegate.swift
+++ b/Expo1900/Expo1900/Controller/AppDelegate.swift
@@ -9,7 +9,14 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
+    var shouldSupportAllOrientation = true
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+            if (shouldSupportAllOrientation == true){
+                return UIInterfaceOrientationMask.all
+            }
+            return UIInterfaceOrientationMask.portrait
+        }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/Expo1900/Expo1900/Controller/DetailHeritageViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailHeritageViewController.swift
@@ -11,7 +11,7 @@ class DetailHeritageViewController: UIViewController {
     
     //MARK: - IBOutlet
     @IBOutlet weak private var koreanHeritageImage: UIImageView!
-    @IBOutlet weak private var koreanHeritageDescription: UITextView!
+    @IBOutlet weak private var koreanHeritageDescription: UILabel!
     
     //MARK: - Property
     private var koreanHeritage: InformationOfKoreanHeritage?

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -49,9 +49,9 @@ class MainViewController: UIViewController {
     
     private func updateMainView(_ expo: InformationOfExpo) {
         mainTitleLabel.text = expo.title
-        mainVisitorLabel.text = "방문객 : " + expo.visitorsWithComma + "명"
-        mainLocationLabel.text = "개최지 : " + expo.location
-        mainDurationLabel.text = "개최 기간 : " + expo.duration
+        mainVisitorLabel.text = expo.visitorsWithComma + "명"
+        mainLocationLabel.text = expo.location
+        mainDurationLabel.text = expo.duration
         mainDescriptionLabel.text = expo.description
     }
     

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -18,6 +18,7 @@ class MainViewController: UIViewController {
     //MARK: - Property
     private var jsonDecoder = JsonDecoder()
     private let heritageTableViewControllerIdentifier = "SecondVC"
+    private let appDelegate = UIApplication.shared.delegate as! AppDelegate
     
     //MARK: - Life cycle
     override func viewDidLoad() {
@@ -30,12 +31,14 @@ class MainViewController: UIViewController {
         super.viewWillAppear(animated)
         
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        appDelegate.shouldSupportAllOrientation = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        appDelegate.shouldSupportAllOrientation = true
     }
     
     //MARK: - Method

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -48,8 +48,8 @@ class MainViewController: UIViewController {
     }
     
     private func updateMainView(_ expo: InformationOfExpo) {
-        mainTitleLabel.text = expo.title
-        mainVisitorLabel.text = expo.visitorsWithComma + "명"
+        mainTitleLabel.text = expo.title.replacingOccurrences(of: "(", with: "\n(")
+        mainVisitorLabel.text = expo.visitorsWithComma + " 명"
         mainLocationLabel.text = expo.location
         mainDurationLabel.text = expo.duration
         mainDescriptionLabel.text = expo.description

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -20,22 +20,22 @@
                                 <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="axN-nn-agy" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="426.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="419.33333333333331"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Y2r-Z8-QPW">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="426.33333333333331"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="419.33333333333331"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
-                                                        <rect key="frame" x="159" y="0.0" width="57.333333333333343" height="37"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
+                                                        <rect key="frame" x="164.33333333333334" y="0.0" width="46.333333333333343" height="30"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="I5Z-Hf-pd8">
-                                                        <rect key="frame" x="115.66666666666667" y="47" width="143.66666666666663" height="200"/>
+                                                        <rect key="frame" x="115.66666666666667" y="40" width="143.66666666666663" height="200"/>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="edd-g0-Fhe">
-                                                        <rect key="frame" x="122" y="257" width="131" height="23"/>
+                                                        <rect key="frame" x="122" y="250" width="131" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVh-oD-3cY" userLabel="Visitor">
                                                                 <rect key="frame" x="0.0" y="0.0" width="59.333333333333336" height="23"/>
@@ -52,7 +52,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="0ZJ-gT-gnw">
-                                                        <rect key="frame" x="120.33333333333333" y="290" width="134.66666666666669" height="23"/>
+                                                        <rect key="frame" x="120.33333333333333" y="283" width="134.66666666666669" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUH-Dn-tAT" userLabel="Location">
                                                                 <rect key="frame" x="0.0" y="0.0" width="59.333333333333336" height="23"/>
@@ -69,7 +69,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vvz-M3-CAH">
-                                                        <rect key="frame" x="109.66666666666667" y="323" width="155.66666666666663" height="23"/>
+                                                        <rect key="frame" x="109.66666666666667" y="316" width="155.66666666666663" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3P8-6s-tch" userLabel="Duration">
                                                                 <rect key="frame" x="0.0" y="0.0" width="80.333333333333329" height="23"/>
@@ -85,14 +85,14 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
-                                                        <rect key="frame" x="20" y="356" width="335" height="20.333333333333314"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
+                                                        <rect key="frame" x="20" y="349" width="335" height="20.333333333333314"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="ebA-xP-BwY">
-                                                        <rect key="frame" x="0.0" y="386.33333333333331" width="375" height="40"/>
+                                                        <rect key="frame" x="0.0" y="379.33333333333331" width="375" height="40"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YcZ-5c-l6h">
                                                                 <rect key="frame" x="0.0" y="0.0" width="118.66666666666667" height="40"/>
@@ -187,18 +187,18 @@
                                                         <constraint firstAttribute="height" constant="70" id="idE-BU-qPE"/>
                                                     </constraints>
                                                 </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="RqX-kQ-5Si">
-                                                    <rect key="frame" x="90" y="19.999999999999996" width="259.33333333333331" height="50.666666666666657"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="RqX-kQ-5Si">
+                                                    <rect key="frame" x="90" y="20" width="259.33333333333331" height="57"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K42-IC-7lv">
-                                                            <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K42-IC-7lv">
+                                                            <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g4N-HH-6gh">
-                                                            <rect key="frame" x="0.0" y="30.333333333333336" width="41.333333333333336" height="20.333333333333336"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g4N-HH-6gh">
+                                                            <rect key="frame" x="0.0" y="40" width="35.333333333333336" height="17"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
@@ -254,47 +254,66 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uW9-uh-lZo">
-                                <rect key="frame" x="74" y="191" width="201" height="128"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                <color key="textColor" systemColor="labelColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v85-SO-pbQ">
-                                <rect key="frame" x="74" y="95" width="240" height="118"/>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="TEXT" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ycm-AH-gEw">
-                                <rect key="frame" x="173" y="44" width="42" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="F3I-cR-ceI">
+                                <rect key="frame" x="16" y="44" width="343" height="734"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="05u-Sk-Epe" userLabel="Content View">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="202.66666666666666"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="eLG-9V-scv">
+                                                <rect key="frame" x="34.333333333333343" y="30" width="274.33333333333326" height="137.33333333333334"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="eLG-9V-scv" secondAttribute="height" multiplier="2:1" id="ma8-ay-zNe"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yt5-L0-8et">
+                                                <rect key="frame" x="0.0" y="182.33333333333334" width="343" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="yt5-L0-8et" firstAttribute="width" secondItem="05u-Sk-Epe" secondAttribute="width" id="0a1-gp-FIh"/>
+                                            <constraint firstItem="yt5-L0-8et" firstAttribute="top" secondItem="eLG-9V-scv" secondAttribute="bottom" constant="15" id="B25-Uy-dTM"/>
+                                            <constraint firstItem="eLG-9V-scv" firstAttribute="top" secondItem="05u-Sk-Epe" secondAttribute="top" constant="30" id="MNL-wv-1xF"/>
+                                            <constraint firstItem="yt5-L0-8et" firstAttribute="centerX" secondItem="05u-Sk-Epe" secondAttribute="centerX" id="dYx-3I-dB5"/>
+                                            <constraint firstItem="eLG-9V-scv" firstAttribute="centerX" secondItem="05u-Sk-Epe" secondAttribute="centerX" id="fUg-22-CdI"/>
+                                            <constraint firstItem="eLG-9V-scv" firstAttribute="width" secondItem="05u-Sk-Epe" secondAttribute="width" multiplier="0.8" id="nhB-p6-MQf"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="05u-Sk-Epe" firstAttribute="trailing" secondItem="qib-5Z-KTW" secondAttribute="trailing" id="Lrf-g7-JEP"/>
+                                    <constraint firstItem="05u-Sk-Epe" firstAttribute="width" secondItem="YpZ-vn-X7f" secondAttribute="width" id="NDm-Y0-dvL"/>
+                                    <constraint firstItem="05u-Sk-Epe" firstAttribute="bottom" secondItem="qib-5Z-KTW" secondAttribute="bottom" id="OUW-yp-aj1"/>
+                                    <constraint firstItem="05u-Sk-Epe" firstAttribute="leading" secondItem="qib-5Z-KTW" secondAttribute="leading" id="Q9Z-sU-BOW"/>
+                                    <constraint firstItem="05u-Sk-Epe" firstAttribute="top" secondItem="qib-5Z-KTW" secondAttribute="top" id="kbG-ax-maV"/>
+                                    <constraint firstItem="yt5-L0-8et" firstAttribute="bottom" secondItem="qib-5Z-KTW" secondAttribute="bottom" id="tpd-3a-03Q"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="qib-5Z-KTW"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="YpZ-vn-X7f"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="a8H-Be-tXJ"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="uW9-uh-lZo" firstAttribute="leading" secondItem="a8H-Be-tXJ" secondAttribute="leading" constant="74" id="AHe-9u-3U6"/>
-                            <constraint firstItem="a8H-Be-tXJ" firstAttribute="bottom" secondItem="v85-SO-pbQ" secondAttribute="bottom" constant="638" id="Gqt-Ld-mMo"/>
-                            <constraint firstItem="a8H-Be-tXJ" firstAttribute="trailing" secondItem="uW9-uh-lZo" secondAttribute="trailing" constant="100" id="QVS-4W-2wT"/>
-                            <constraint firstItem="v85-SO-pbQ" firstAttribute="top" secondItem="a8H-Be-tXJ" secondAttribute="top" constant="52" id="Vbt-mC-zAA"/>
-                            <constraint firstItem="a8H-Be-tXJ" firstAttribute="trailing" secondItem="v85-SO-pbQ" secondAttribute="trailing" constant="100" id="dsP-j6-LQU"/>
-                            <constraint firstItem="a8H-Be-tXJ" firstAttribute="bottom" secondItem="uW9-uh-lZo" secondAttribute="bottom" constant="459" id="p5E-UI-Zcp"/>
-                            <constraint firstItem="uW9-uh-lZo" firstAttribute="top" secondItem="v85-SO-pbQ" secondAttribute="bottom" constant="51" id="vsz-9F-7Gu"/>
-                            <constraint firstItem="v85-SO-pbQ" firstAttribute="leading" secondItem="a8H-Be-tXJ" secondAttribute="leading" constant="74" id="wDb-Uu-gOk"/>
+                            <constraint firstItem="F3I-cR-ceI" firstAttribute="top" secondItem="N2m-8a-g1f" secondAttribute="topMargin" id="Gv3-ru-RJc"/>
+                            <constraint firstItem="F3I-cR-ceI" firstAttribute="leading" secondItem="N2m-8a-g1f" secondAttribute="leadingMargin" id="NuW-iN-2nA"/>
+                            <constraint firstItem="F3I-cR-ceI" firstAttribute="bottom" secondItem="N2m-8a-g1f" secondAttribute="bottomMargin" id="eJr-uB-JuS"/>
+                            <constraint firstItem="F3I-cR-ceI" firstAttribute="trailing" secondItem="N2m-8a-g1f" secondAttribute="trailingMargin" id="oF9-MQ-bDp"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="cai-HZ-Vru"/>
                     <connections>
-                        <outlet property="koreanHeritageDescription" destination="uW9-uh-lZo" id="w69-7h-HTL"/>
-                        <outlet property="koreanHeritageImage" destination="v85-SO-pbQ" id="K5a-VF-8nM"/>
+                        <outlet property="koreanHeritageDescription" destination="yt5-L0-8et" id="bZa-22-QPU"/>
+                        <outlet property="koreanHeritageImage" destination="eLG-9V-scv" id="qId-On-WfD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="g9k-IK-09b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2587" y="75"/>
+            <point key="canvasLocation" x="2586.4000000000001" y="74.630541871921181"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="9zO-NC-h8Q">
@@ -318,9 +337,6 @@
     <resources>
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="143.66667175292969" height="200"/>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CiF-Mz-BPr">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,38 +13,38 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NkG-uV-DLp">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="88" width="375" height="690"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="axN-nn-agy" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="426.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="426.33333333333331"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Y2r-Z8-QPW">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="426.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="426.33333333333331"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
-                                                        <rect key="frame" x="178.5" y="0.0" width="57.5" height="37"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
+                                                        <rect key="frame" x="159" y="0.0" width="57.333333333333343" height="37"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="I5Z-Hf-pd8">
-                                                        <rect key="frame" x="135" y="47" width="144" height="200"/>
+                                                        <rect key="frame" x="115.66666666666667" y="47" width="143.66666666666663" height="200"/>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="edd-g0-Fhe">
-                                                        <rect key="frame" x="141.5" y="257" width="131" height="23"/>
+                                                        <rect key="frame" x="122" y="257" width="131" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVh-oD-3cY" userLabel="Visitor">
-                                                                <rect key="frame" x="0.0" y="0.0" width="59.5" height="23"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="59.333333333333336" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EeI-9y-Dxh">
-                                                                <rect key="frame" x="69.5" y="0.0" width="61.5" height="23"/>
+                                                                <rect key="frame" x="69.333333333333343" y="0.0" width="61.666666666666657" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -52,16 +52,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="0ZJ-gT-gnw">
-                                                        <rect key="frame" x="139.5" y="290" width="135" height="23"/>
+                                                        <rect key="frame" x="120.33333333333333" y="290" width="134.66666666666669" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUH-Dn-tAT" userLabel="Location">
-                                                                <rect key="frame" x="0.0" y="0.0" width="59.5" height="23"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="59.333333333333336" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ttb-T2-CM0">
-                                                                <rect key="frame" x="69.5" y="0.0" width="65.5" height="23"/>
+                                                                <rect key="frame" x="69.333333333333343" y="0.0" width="65.333333333333343" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -69,16 +69,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vvz-M3-CAH">
-                                                        <rect key="frame" x="129" y="323" width="156" height="23"/>
+                                                        <rect key="frame" x="109.66666666666667" y="323" width="155.66666666666663" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3P8-6s-tch" userLabel="Duration">
-                                                                <rect key="frame" x="0.0" y="0.0" width="80.5" height="23"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="80.333333333333329" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQ9-T5-Om8">
-                                                                <rect key="frame" x="90.5" y="0.0" width="65.5" height="23"/>
+                                                                <rect key="frame" x="90.333333333333343" y="0.0" width="65.333333333333343" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -86,26 +86,26 @@
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
-                                                        <rect key="frame" x="20" y="356" width="374" height="20.5"/>
+                                                        <rect key="frame" x="20" y="356" width="335" height="20.333333333333314"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="ebA-xP-BwY">
-                                                        <rect key="frame" x="0.0" y="386.5" width="414" height="40"/>
+                                                        <rect key="frame" x="0.0" y="386.33333333333331" width="375" height="40"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YcZ-5c-l6h">
-                                                                <rect key="frame" x="0.0" y="0.0" width="138" height="40"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="118.66666666666667" height="40"/>
                                                             </imageView>
                                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-aT-DdH">
-                                                                <rect key="frame" x="138" y="0.0" width="138" height="40"/>
+                                                                <rect key="frame" x="118.66666666666669" y="0.0" width="138" height="40"/>
                                                                 <state key="normal" title="한국의 출품작 보러가기"/>
                                                                 <connections>
                                                                     <action selector="moveHeritageTableVC:" destination="BYZ-38-t0r" eventType="touchUpInside" id="avh-fX-X5R"/>
                                                                 </connections>
                                                             </button>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="ysu-W6-xVg">
-                                                                <rect key="frame" x="276" y="0.0" width="138" height="40"/>
+                                                                <rect key="frame" x="256.66666666666669" y="0.0" width="118.33333333333331" height="40"/>
                                                             </imageView>
                                                         </subviews>
                                                         <constraints>
@@ -167,45 +167,52 @@
             <objects>
                 <viewController storyboardIdentifier="SecondVC" id="avq-eH-yMT" customClass="HeritageTableViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="YeK-B3-GTq">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="L50-h5-cos">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="customCell" rowHeight="161" id="jwg-Wa-K4c" customClass="HeritageTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="24.5" width="414" height="161"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="customCell" rowHeight="142.5" id="jwg-Wa-K4c" customClass="HeritageTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="24.333333969116211" width="375" height="142.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jwg-Wa-K4c" id="5Ki-RT-UcG">
-                                            <rect key="frame" x="0.0" y="0.0" width="384.5" height="161"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349.33333333333331" height="142.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WS1-rq-GUq">
-                                                    <rect key="frame" x="20" y="17" width="81.5" height="128"/>
+                                                    <rect key="frame" x="10" y="36.333333333333343" width="70" height="70"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="70" id="idE-BU-qPE"/>
+                                                    </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g4N-HH-6gh">
-                                                    <rect key="frame" x="168.5" y="105" width="42" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K42-IC-7lv">
-                                                    <rect key="frame" x="168.5" y="17" width="42" height="21"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="RqX-kQ-5Si">
+                                                    <rect key="frame" x="90" y="19.999999999999996" width="259.33333333333331" height="50.666666666666657"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K42-IC-7lv">
+                                                            <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g4N-HH-6gh">
+                                                            <rect key="frame" x="0.0" y="30.333333333333336" width="41.333333333333336" height="20.333333333333336"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="WS1-rq-GUq" firstAttribute="leading" secondItem="5Ki-RT-UcG" secondAttribute="leadingMargin" id="9AY-gZ-wDg"/>
-                                                <constraint firstItem="g4N-HH-6gh" firstAttribute="leading" secondItem="WS1-rq-GUq" secondAttribute="trailing" constant="67" id="EOJ-ru-vQV"/>
-                                                <constraint firstItem="WS1-rq-GUq" firstAttribute="top" secondItem="5Ki-RT-UcG" secondAttribute="topMargin" constant="6" id="QHL-vt-5og"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="WS1-rq-GUq" secondAttribute="bottom" constant="5" id="bOw-eW-pry"/>
-                                                <constraint firstItem="K42-IC-7lv" firstAttribute="leading" secondItem="WS1-rq-GUq" secondAttribute="trailing" constant="67" id="d1c-xU-OzI"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="K42-IC-7lv" secondAttribute="trailing" constant="166" id="dpk-hA-q3W"/>
-                                                <constraint firstItem="K42-IC-7lv" firstAttribute="top" secondItem="5Ki-RT-UcG" secondAttribute="topMargin" constant="6" id="oqk-2k-9ww"/>
-                                                <constraint firstItem="g4N-HH-6gh" firstAttribute="top" secondItem="K42-IC-7lv" secondAttribute="bottom" constant="67" id="vta-Eq-UaL"/>
+                                                <constraint firstItem="WS1-rq-GUq" firstAttribute="width" secondItem="5Ki-RT-UcG" secondAttribute="width" multiplier="0.2" id="2YG-8G-XCX"/>
+                                                <constraint firstAttribute="bottom" secondItem="RqX-kQ-5Si" secondAttribute="bottom" priority="250" constant="20" id="3yu-eL-xuD"/>
+                                                <constraint firstItem="RqX-kQ-5Si" firstAttribute="leading" secondItem="WS1-rq-GUq" secondAttribute="trailing" constant="10" id="4I7-Tv-5DB"/>
+                                                <constraint firstAttribute="trailing" secondItem="RqX-kQ-5Si" secondAttribute="trailing" id="Bwo-Mw-iVR"/>
+                                                <constraint firstItem="RqX-kQ-5Si" firstAttribute="top" secondItem="5Ki-RT-UcG" secondAttribute="top" constant="20" id="IgP-Xj-sQl"/>
+                                                <constraint firstItem="WS1-rq-GUq" firstAttribute="centerY" secondItem="5Ki-RT-UcG" secondAttribute="centerY" id="Up5-gF-Bls"/>
+                                                <constraint firstItem="WS1-rq-GUq" firstAttribute="leading" secondItem="5Ki-RT-UcG" secondAttribute="leading" constant="10" id="mrG-Xh-1xb"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -224,10 +231,10 @@
                         <viewLayoutGuide key="safeArea" id="vNZ-cW-VLM"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="L50-h5-cos" firstAttribute="top" secondItem="vNZ-cW-VLM" secondAttribute="top" id="7Fe-av-e6b"/>
-                            <constraint firstItem="vNZ-cW-VLM" firstAttribute="bottom" secondItem="L50-h5-cos" secondAttribute="bottom" id="DFN-iv-ZFF"/>
-                            <constraint firstItem="L50-h5-cos" firstAttribute="leading" secondItem="vNZ-cW-VLM" secondAttribute="leading" id="smM-LM-2rp"/>
-                            <constraint firstItem="vNZ-cW-VLM" firstAttribute="trailing" secondItem="L50-h5-cos" secondAttribute="trailing" id="xRT-TS-o6E"/>
+                            <constraint firstItem="vNZ-cW-VLM" firstAttribute="top" secondItem="L50-h5-cos" secondAttribute="top" id="EqY-bB-Y4l"/>
+                            <constraint firstItem="L50-h5-cos" firstAttribute="leading" secondItem="vNZ-cW-VLM" secondAttribute="leading" id="GVD-80-FMg"/>
+                            <constraint firstItem="L50-h5-cos" firstAttribute="bottom" secondItem="vNZ-cW-VLM" secondAttribute="bottom" id="I1b-FZ-JDu"/>
+                            <constraint firstItem="vNZ-cW-VLM" firstAttribute="trailing" secondItem="L50-h5-cos" secondAttribute="trailing" id="yJn-Fb-57o"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="한국의 출품작" id="Uen-JW-jSg"/>
@@ -244,11 +251,11 @@
             <objects>
                 <viewController storyboardIdentifier="ThirdVC" id="5Fc-Lc-dik" customClass="DetailHeritageViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="N2m-8a-g1f">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="uW9-uh-lZo">
-                                <rect key="frame" x="74" y="275" width="240" height="128"/>
+                                <rect key="frame" x="74" y="191" width="201" height="128"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -295,7 +302,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="CiF-Mz-BPr" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="cff-OG-CFS">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -310,7 +317,7 @@
     </scenes>
     <resources>
         <image name="flag" width="851" height="567"/>
-        <image name="poster" width="144" height="200"/>
+        <image name="poster" width="143.66667175292969" height="200"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -20,10 +20,10 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="axN-nn-agy" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="869.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="431"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Y2r-Z8-QPW">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="869.5"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Y2r-Z8-QPW">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="431"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
                                                         <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
@@ -32,49 +32,85 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="I5Z-Hf-pd8">
-                                                        <rect key="frame" x="135" y="20.5" width="144" height="200"/>
+                                                        <rect key="frame" x="135" y="30.5" width="144" height="200"/>
                                                     </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EeI-9y-Dxh">
-                                                        <rect key="frame" x="186.5" y="220.5" width="41.5" height="20.5"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="edd-g0-Fhe">
+                                                        <rect key="frame" x="133" y="240.5" width="148" height="30"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVh-oD-3cY" userLabel="Visitor">
+                                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EeI-9y-Dxh">
+                                                                <rect key="frame" x="86.5" y="0.0" width="61.5" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="0ZJ-gT-gnw">
+                                                        <rect key="frame" x="131" y="280.5" width="152" height="30"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUH-Dn-tAT" userLabel="Location">
+                                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ttb-T2-CM0">
+                                                                <rect key="frame" x="86.5" y="0.0" width="65.5" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vvz-M3-CAH">
+                                                        <rect key="frame" x="117.5" y="320.5" width="179" height="30"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3P8-6s-tch" userLabel="Duration">
+                                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQ9-T5-Om8">
+                                                                <rect key="frame" x="113.5" y="0.0" width="65.5" height="30"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
+                                                        <rect key="frame" x="0.0" y="360.5" width="414" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ttb-T2-CM0">
-                                                        <rect key="frame" x="186.5" y="241" width="41.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQ9-T5-Om8">
-                                                        <rect key="frame" x="186.5" y="261.5" width="41.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
-                                                        <rect key="frame" x="186.5" y="282" width="41.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ebA-xP-BwY">
-                                                        <rect key="frame" x="0.0" y="302.5" width="414" height="567"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="ebA-xP-BwY">
+                                                        <rect key="frame" x="0.0" y="391" width="414" height="40"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YcZ-5c-l6h">
-                                                                <rect key="frame" x="0.0" y="0.0" width="138" height="567"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="138" height="40"/>
                                                             </imageView>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-aT-DdH">
-                                                                <rect key="frame" x="138" y="0.0" width="138" height="567"/>
-                                                                <state key="normal" title="한국의 출품작"/>
+                                                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-aT-DdH">
+                                                                <rect key="frame" x="138" y="0.0" width="138" height="40"/>
+                                                                <state key="normal" title="한국의 출품작 보러가기"/>
                                                                 <connections>
                                                                     <action selector="moveHeritageTableVC:" destination="BYZ-38-t0r" eventType="touchUpInside" id="avh-fX-X5R"/>
                                                                 </connections>
                                                             </button>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="ysu-W6-xVg">
-                                                                <rect key="frame" x="276" y="0.0" width="138" height="567"/>
+                                                                <rect key="frame" x="276" y="0.0" width="138" height="40"/>
                                                             </imageView>
                                                         </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="40" id="z4K-W6-jsI"/>
+                                                        </constraints>
                                                     </stackView>
                                                 </subviews>
                                             </stackView>
@@ -82,6 +118,7 @@
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="Y2r-Z8-QPW" firstAttribute="leading" secondItem="axN-nn-agy" secondAttribute="leading" id="4SE-vU-x6W"/>
+                                            <constraint firstItem="3TX-ps-Dsr" firstAttribute="width" secondItem="axN-nn-agy" secondAttribute="width" id="Bcj-ly-sdW"/>
                                             <constraint firstItem="Y2r-Z8-QPW" firstAttribute="top" secondItem="axN-nn-agy" secondAttribute="top" id="FPu-DP-3Qr"/>
                                             <constraint firstAttribute="trailing" secondItem="Y2r-Z8-QPW" secondAttribute="trailing" id="TXZ-94-qTJ"/>
                                             <constraint firstAttribute="bottom" secondItem="Y2r-Z8-QPW" secondAttribute="bottom" id="eu8-fO-lmQ"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -20,31 +20,31 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="axN-nn-agy" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="431"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="426.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Y2r-Z8-QPW">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="431"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="426.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
-                                                        <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sAB-ZY-R0A">
+                                                        <rect key="frame" x="178.5" y="0.0" width="57.5" height="37"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="I5Z-Hf-pd8">
-                                                        <rect key="frame" x="135" y="30.5" width="144" height="200"/>
+                                                        <rect key="frame" x="135" y="47" width="144" height="200"/>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="edd-g0-Fhe">
-                                                        <rect key="frame" x="133" y="240.5" width="148" height="30"/>
+                                                        <rect key="frame" x="141.5" y="257" width="131" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVh-oD-3cY" userLabel="Visitor">
-                                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="30"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="59.5" height="23"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EeI-9y-Dxh">
-                                                                <rect key="frame" x="86.5" y="0.0" width="61.5" height="30"/>
+                                                                <rect key="frame" x="69.5" y="0.0" width="61.5" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -52,16 +52,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="0ZJ-gT-gnw">
-                                                        <rect key="frame" x="131" y="280.5" width="152" height="30"/>
+                                                        <rect key="frame" x="139.5" y="290" width="135" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LUH-Dn-tAT" userLabel="Location">
-                                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="30"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="59.5" height="23"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ttb-T2-CM0">
-                                                                <rect key="frame" x="86.5" y="0.0" width="65.5" height="30"/>
+                                                                <rect key="frame" x="69.5" y="0.0" width="65.5" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -69,30 +69,30 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vvz-M3-CAH">
-                                                        <rect key="frame" x="117.5" y="320.5" width="179" height="30"/>
+                                                        <rect key="frame" x="129" y="323" width="156" height="23"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3P8-6s-tch" userLabel="Duration">
-                                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="30"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="80.5" height="23"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wQ9-T5-Om8">
-                                                                <rect key="frame" x="113.5" y="0.0" width="65.5" height="30"/>
+                                                                <rect key="frame" x="90.5" y="0.0" width="65.5" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
-                                                        <rect key="frame" x="0.0" y="360.5" width="414" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Description" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3TX-ps-Dsr">
+                                                        <rect key="frame" x="20" y="356" width="374" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="ebA-xP-BwY">
-                                                        <rect key="frame" x="0.0" y="391" width="414" height="40"/>
+                                                        <rect key="frame" x="0.0" y="386.5" width="414" height="40"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YcZ-5c-l6h">
                                                                 <rect key="frame" x="0.0" y="0.0" width="138" height="40"/>
@@ -113,12 +113,15 @@
                                                         </constraints>
                                                     </stackView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="3TX-ps-Dsr" secondAttribute="trailing" constant="20" id="fvb-Zv-2Pv"/>
+                                                    <constraint firstItem="3TX-ps-Dsr" firstAttribute="leading" secondItem="Y2r-Z8-QPW" secondAttribute="leading" constant="20" id="pLn-6b-mvd"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="Y2r-Z8-QPW" firstAttribute="leading" secondItem="axN-nn-agy" secondAttribute="leading" id="4SE-vU-x6W"/>
-                                            <constraint firstItem="3TX-ps-Dsr" firstAttribute="width" secondItem="axN-nn-agy" secondAttribute="width" id="Bcj-ly-sdW"/>
                                             <constraint firstItem="Y2r-Z8-QPW" firstAttribute="top" secondItem="axN-nn-agy" secondAttribute="top" id="FPu-DP-3Qr"/>
                                             <constraint firstAttribute="trailing" secondItem="Y2r-Z8-QPW" secondAttribute="trailing" id="TXZ-94-qTJ"/>
                                             <constraint firstAttribute="bottom" secondItem="Y2r-Z8-QPW" secondAttribute="bottom" id="eu8-fO-lmQ"/>


### PR DESCRIPTION
@Limwin94 
부족한 점이 있겠지만 최선을 다했습니다!!!

1. 세번째 뷰에서 이미지의 width를 content View의 width의 비율과 1대1로 맞추어 주었는데 실행화면에서는 제가 원하던만큼 크기가 증가하지가 않았습니다. 원본 사진의 비율때문에 그런 것인지 다른이유가 잇는건지 궁금합니다.

2. 화면고정하는 부분에서 구글에서 코드를 복붙해왔는데 이 방법이 일반적인지 아니면 다른 방법이 있는지 궁금합니다.

3. 첫번째 화면에서 방문객,개최지,개최기간을 레이블을 두개를 사용해서 적용햇는데 line 수를 0으로 설정
했을 때 간격이 벌어지는 문제가 생겼습니다. 레이블을 하나로 사용해야 이 문제를 해결 할 수 있을까요?
<img width="306" alt="캡쳐" src="https://user-images.githubusercontent.com/65723901/125913723-9d36f07d-b084-4eb5-a349-5c23e6022d27.png">

4. 첫번째화면 title에서 현재 저희가 적용한 방식과 사진처럼 코드를 고민해보았습니다. 두가지 방식에 대한 린의 생각이 궁금합니다.
<img width="591" alt="캡쳐2" src="https://user-images.githubusercontent.com/65723901/125914013-ce5a2180-09bf-41ba-92f7-4e1d9077a82a.png">

@sanches37

마지막 리뷰도 잘 부탁드립니다!!