### PR TITLE
만국박람회 [STEP 2] 고사리, 토니, 호랭이

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D85E87C2768E801008E9FA8 /* EntryDescriptionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D85E87B2768E801008E9FA8 /* EntryDescriptionViewController.swift */; };
 		0D923B092768354E008B7B02 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D923B082768354E008B7B02 /* TableViewController.swift */; };
 		0DED4B322760C60C0080E98B /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DED4B312760C60C0080E98B /* Exposition.swift */; };
 		48420267275DFDDC00422BFA /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48420266275DFDDC00422BFA /* Entry.swift */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0D85E87B2768E801008E9FA8 /* EntryDescriptionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDescriptionViewController.swift; sourceTree = "<group>"; };
 		0D923B082768354E008B7B02 /* TableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		0DED4B312760C60C0080E98B /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		48420266275DFDDC00422BFA /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 				48953AF22768904B00BF2022 /* EntryCustomTableViewCell.swift */,
+				0D85E87B2768E801008E9FA8 /* EntryDescriptionViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -189,6 +192,7 @@
 			files = (
 				48420267275DFDDC00422BFA /* Entry.swift in Sources */,
 				0D923B092768354E008B7B02 /* TableViewController.swift in Sources */,
+				0D85E87C2768E801008E9FA8 /* EntryDescriptionViewController.swift in Sources */,
 				0DED4B322760C60C0080E98B /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				53132DA227683964004D61DC /* ExpositionError.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0D923B092768354E008B7B02 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D923B082768354E008B7B02 /* TableViewController.swift */; };
 		0DED4B322760C60C0080E98B /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DED4B312760C60C0080E98B /* Exposition.swift */; };
 		48420267275DFDDC00422BFA /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48420266275DFDDC00422BFA /* Entry.swift */; };
+		48953AF32768904B00BF2022 /* EntryCustomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48953AF22768904B00BF2022 /* EntryCustomTableViewCell.swift */; };
 		53132D9F27676EEF004D61DC /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53132D9E27676EEF004D61DC /* Decoder.swift */; };
 		53132DA227683964004D61DC /* ExpositionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53132DA127683964004D61DC /* ExpositionError.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
@@ -24,6 +25,7 @@
 		0D923B082768354E008B7B02 /* TableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		0DED4B312760C60C0080E98B /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		48420266275DFDDC00422BFA /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
+		48953AF22768904B00BF2022 /* EntryCustomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryCustomTableViewCell.swift; sourceTree = "<group>"; };
 		53132D9E27676EEF004D61DC /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
 		53132DA127683964004D61DC /* ExpositionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionError.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,6 +66,7 @@
 				0D923B082768354E008B7B02 /* TableViewController.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
+				48953AF22768904B00BF2022 /* EntryCustomTableViewCell.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -192,6 +195,7 @@
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				53132D9F27676EEF004D61DC /* Decoder.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
+				48953AF32768904B00BF2022 /* EntryCustomTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,25 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D923B092768354E008B7B02 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D923B082768354E008B7B02 /* TableViewController.swift */; };
 		0DED4B322760C60C0080E98B /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DED4B312760C60C0080E98B /* Exposition.swift */; };
 		48420267275DFDDC00422BFA /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48420266275DFDDC00422BFA /* Entry.swift */; };
 		53132D9F27676EEF004D61DC /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53132D9E27676EEF004D61DC /* Decoder.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
-		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
+		C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* MainViewController.swift */; };
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0D923B082768354E008B7B02 /* TableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		0DED4B312760C60C0080E98B /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		48420266275DFDDC00422BFA /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		53132D9E27676EEF004D61DC /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C79FF4B82589F401005FB0FD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C79FF4B82589F401005FB0FD /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		C79FF4BB2589F401005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -56,7 +58,8 @@
 		48420264275DFDC400422BFA /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C79FF4B82589F401005FB0FD /* ViewController.swift */,
+				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
+				0D923B082768354E008B7B02 /* TableViewController.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 			);
@@ -171,8 +174,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				48420267275DFDDC00422BFA /* Entry.swift in Sources */,
+				0D923B092768354E008B7B02 /* TableViewController.swift in Sources */,
 				0DED4B322760C60C0080E98B /* Exposition.swift in Sources */,
-				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
+				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				53132D9F27676EEF004D61DC /* Decoder.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0DED4B322760C60C0080E98B /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DED4B312760C60C0080E98B /* Exposition.swift */; };
 		48420267275DFDDC00422BFA /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48420266275DFDDC00422BFA /* Entry.swift */; };
 		53132D9F27676EEF004D61DC /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53132D9E27676EEF004D61DC /* Decoder.swift */; };
+		53132DA227683964004D61DC /* ExpositionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53132DA127683964004D61DC /* ExpositionError.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* MainViewController.swift */; };
@@ -24,6 +25,7 @@
 		0DED4B312760C60C0080E98B /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		48420266275DFDDC00422BFA /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		53132D9E27676EEF004D61DC /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
+		53132DA127683964004D61DC /* ExpositionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionError.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -76,6 +78,14 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		53132DA02768390C004D61DC /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				53132DA127683964004D61DC /* ExpositionError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		C79FF4A82589F401005FB0FD = {
 			isa = PBXGroup;
 			children = (
@@ -96,6 +106,7 @@
 			isa = PBXGroup;
 			children = (
 				C79FF4C22589F404005FB0FD /* Info.plist */,
+				53132DA02768390C004D61DC /* Error */,
 				48420265275DFDCA00422BFA /* Model */,
 				48420264275DFDC400422BFA /* Controller */,
 				48420263275DFDBD00422BFA /* View */,
@@ -177,6 +188,7 @@
 				0D923B092768354E008B7B02 /* TableViewController.swift in Sources */,
 				0DED4B322760C60C0080E98B /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
+				53132DA227683964004D61DC /* ExpositionError.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				53132D9F27676EEF004D61DC /* Decoder.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0DED4B322760C60C0080E98B /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DED4B312760C60C0080E98B /* Exposition.swift */; };
 		48420267275DFDDC00422BFA /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48420266275DFDDC00422BFA /* Entry.swift */; };
+		53132D9F27676EEF004D61DC /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53132D9E27676EEF004D61DC /* Decoder.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
@@ -20,6 +21,7 @@
 /* Begin PBXFileReference section */
 		0DED4B312760C60C0080E98B /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		48420266275DFDDC00422BFA /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
+		53132D9E27676EEF004D61DC /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -66,6 +68,7 @@
 			children = (
 				48420266275DFDDC00422BFA /* Entry.swift */,
 				0DED4B312760C60C0080E98B /* Exposition.swift */,
+				53132D9E27676EEF004D61DC /* Decoder.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -171,6 +174,7 @@
 				0DED4B322760C60C0080E98B /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
+				53132D9F27676EEF004D61DC /* Decoder.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900/Controller/EntryCustomTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/EntryCustomTableViewCell.swift
@@ -1,0 +1,25 @@
+//
+//  EntryCustomTableViewCell.swift
+//  Expo1900
+//
+//  Created by 서녕 on 2021/12/14.
+//
+
+import UIKit
+
+class EntryCustomTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var entryCustomCellUIImageView: UIImageView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Expo1900/Expo1900/Controller/EntryCustomTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/EntryCustomTableViewCell.swift
@@ -8,8 +8,9 @@
 import UIKit
 
 class EntryCustomTableViewCell: UITableViewCell {
-
-    @IBOutlet weak var entryCustomCellUIImageView: UIImageView!
+    @IBOutlet weak var entryImageView: UIImageView!
+    @IBOutlet weak var entryNameLabel: UILabel!
+    @IBOutlet weak var entryShortDescriptionLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Expo1900/Expo1900/Controller/EntryCustomTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/EntryCustomTableViewCell.swift
@@ -19,8 +19,6 @@ class EntryCustomTableViewCell: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
     }
 
 }

--- a/Expo1900/Expo1900/Controller/EntryDescriptionViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDescriptionViewController.swift
@@ -19,12 +19,10 @@ class EntryDescriptionViewController: UIViewController {
     }
     
     func loadEntryDescription() {
-        guard let entryImageLocation = entryData?.imageResourceLocator else {
-            return
+        if let entryImageLocation = entryData?.imageResourceLocator {
+            descriptionImage.image = UIImage(named: entryImageLocation)
+            descriptionText.text = entryData?.detailDescription
+            navigationItem.title = entryData?.name
         }
-        
-        descriptionImage.image = UIImage(named: entryImageLocation)
-        descriptionText.text = entryData?.detailDescription
-        navigationItem.title = entryData?.name
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryDescriptionViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDescriptionViewController.swift
@@ -15,5 +15,16 @@ class EntryDescriptionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        loadEntryDescription()
+    }
+    
+    func loadEntryDescription() {
+        guard let entryImageLocation = entryData?.imageResourceLocator else {
+            return
+        }
+        
+        descriptionImage.image = UIImage(named: entryImageLocation)
+        descriptionText.text = entryData?.detailDescription
+        navigationItem.title = entryData?.name
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryDescriptionViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDescriptionViewController.swift
@@ -1,0 +1,19 @@
+//
+//  EntryDescriptionViewController.swift
+//  Expo1900
+//
+//  Created by 고은 on 2021/12/14.
+//
+
+import UIKit
+
+class EntryDescriptionViewController: UIViewController {
+    @IBOutlet weak var descriptionImage: UIImageView!
+    @IBOutlet weak var descriptionText: UITextView!
+    
+    var entryData: Entry?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -49,7 +49,7 @@ class MainViewController: UIViewController {
             throw ExpositionError.failJSONParsing
         }
         
-        let visitorsCount = try insertComma(at: expositionData.visitorsCount)
+        let visitorsCount = try addComma(at: expositionData.visitorsCount)
         
         titleLabel.text = expositionData.title
         visitorsCountLabel.text = "방문객 : \(visitorsCount)"
@@ -58,7 +58,7 @@ class MainViewController: UIViewController {
         descriptionTextView.text = expositionData.description
     }
     
-    func insertComma(at value: Int) throws -> String {
+    func addComma(at value: Int) throws -> String {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -26,10 +26,25 @@ class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        try? loadExpositionInformation()
+        loadExpositionInformation()
     }
-    
-    func loadExpositionInformation() throws {
+
+    func loadExpositionInformation() {
+        do {
+            try insertDataToView()
+            
+        } catch ExpositionError.failJSONParsing {
+            print(ExpositionError.failJSONParsing)
+        } catch ExpositionError.failTypeCasting {
+            print(ExpositionError.failTypeCasting)
+        } catch ExpositionError.notExistData {
+            print(ExpositionError.notExistData)
+        } catch {
+            print(error)
+        }
+    }
+
+    func insertDataToView() throws {
         guard let expositionData = try parseExpositionJSON() else {
             throw ExpositionError.failJSONParsing
         }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -26,15 +26,15 @@ class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        loadExpositionInformation()
+        try? loadExpositionInformation()
     }
     
-    func loadExpositionInformation() {
-        guard let expositionData = parseExpositionJSON() else {
-            return
+    func loadExpositionInformation() throws {
+        guard let expositionData = try parseExpositionJSON() else {
+            throw ExpositionError.failJSONParsing
         }
         
-        let visitorsCount = insertComma(at: expositionData.visitorsCount)
+        let visitorsCount = try insertComma(at: expositionData.visitorsCount)
         
         titleLabel.text = expositionData.title
         visitorsCountLabel.text = "방문객 : \(visitorsCount)"
@@ -43,14 +43,14 @@ class MainViewController: UIViewController {
         descriptionTextView.text = expositionData.description
     }
     
-    func insertComma(at value: Int) -> String {
+    func insertComma(at value: Int) throws -> String {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         
         guard let insertedCommaValue = numberFormatter.string(from: NSNumber(value: value)) else {
-            fatalError()
+            throw ExpositionError.failTypeCasting
         }
-        
+    
         return insertedCommaValue
     }
 }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -45,10 +45,7 @@ class MainViewController: UIViewController {
     }
 
     func insertDataToView() throws {
-        guard let expositionData = try parseExpositionJSON() else {
-            throw ExpositionError.failJSONParsing
-        }
-        
+        let expositionData = try parseExpositionJSON()
         let visitorsCount = try addComma(at: expositionData.visitorsCount)
         
         titleLabel.text = expositionData.title

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class MainViewController: UIViewController {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var visitorsCountLabel: UILabel!
     @IBOutlet weak var locationLabel: UILabel!

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 class TableViewController: UITableViewController {
-
+    @IBOutlet weak var entryListTableView: UITableView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
@@ -15,6 +16,14 @@ extension TableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 10 // 임시 값
+    }
+
+    func decodedEntryData() throws -> Entry {
+        guard let entryData = try parseEntryJSON() else {
+            throw ExpositionError.failJSONParsing
+        }
+        
+        return entryData
     }
 }
 

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -1,89 +1,24 @@
-//
-//  TableViewController.swift
-//  Expo1900
-//
-//  Created by 고은 on 2021/12/14.
-//
-
 import UIKit
 
 class TableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
     }
+}
 
-    // MARK: - Table view data source
-
+// MARK: - Table view data source
+extension TableViewController {
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
+        return 1
     }
-
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return 0
+        return 10 // 임시 값
     }
+}
 
-    /*
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
-
-        // Configure the cell...
-
-        return cell
-    }
-    */
-
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
+// MARK: - Table view delegation
+extension TableViewController {
+    
 }

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -33,6 +33,7 @@ extension TableViewController {
     func decodedEntryData() {
         do {
             entryData = try parseEntryJSON()
+            
         } catch ExpositionError.notExistData {
             print(ExpositionError.notExistData)
         } catch ExpositionError.failJSONParsing {
@@ -50,7 +51,7 @@ extension TableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        performSegue(withIdentifier: "descriptionVeiwSegue", sender: indexPath.row)
+        performSegue(withIdentifier: "descriptionViewSegue", sender: indexPath.row)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -5,23 +5,27 @@ class TableViewController: UITableViewController {
     var entryData = [Entry]()
     
     override func viewDidLoad() {
+        decodedEntryData()
         super.viewDidLoad()
     }
 }
 
 // MARK: - Table view data source
 extension TableViewController {
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
-    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 10 // 임시 값
+        return entryData.count
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = entryListTableView.dequeueReusableCell(withIdentifier: "entryCustomCell", for: indexPath)
-        var content = cell.defaultContentConfiguration()
+        
+        if let customCell = cell as? EntryCustomTableViewCell {
+            customCell.entryNameLabel.text = entryData[indexPath.row].name
+            customCell.entryImageView.image = UIImage(named: entryData[indexPath.row].imageResourceLocator)
+            customCell.entryShortDescriptionLabel.text = entryData[indexPath.row].simpleDescription
+            
+            return customCell
+        }
         
         return cell
     }
@@ -29,7 +33,6 @@ extension TableViewController {
     func decodedEntryData() {
         do {
             entryData = try parseEntryJSON()
-            
         } catch ExpositionError.notExistData {
             print(ExpositionError.notExistData)
         } catch ExpositionError.failJSONParsing {
@@ -42,5 +45,7 @@ extension TableViewController {
 
 // MARK: - Table view delegation
 extension TableViewController {
-    
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return CGFloat(180)
+    }
 }

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -17,8 +17,15 @@ extension TableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 10 // 임시 값
     }
-
-    func decodedEntryData() throws -> Entry {
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = entryListTableView.dequeueReusableCell(withIdentifier: "entryCustomCell", for: indexPath)
+        var content = cell.defaultContentConfiguration()
+   
+        return cell
+    }
+    
+    func decodedEntryData() throws -> [Entry] {
         guard let entryData = try parseEntryJSON() else {
             throw ExpositionError.failJSONParsing
         }

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class TableViewController: UITableViewController {
     @IBOutlet weak var entryListTableView: UITableView!
+    var entryData = [Entry]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,16 +22,21 @@ extension TableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = entryListTableView.dequeueReusableCell(withIdentifier: "entryCustomCell", for: indexPath)
         var content = cell.defaultContentConfiguration()
-   
+        
         return cell
     }
     
-    func decodedEntryData() throws -> [Entry] {
-        guard let entryData = try parseEntryJSON() else {
-            throw ExpositionError.failJSONParsing
+    func decodedEntryData() {
+        do {
+            entryData = try parseEntryJSON()
+            
+        } catch ExpositionError.notExistData {
+            print(ExpositionError.notExistData)
+        } catch ExpositionError.failJSONParsing {
+            print(ExpositionError.failJSONParsing)
+        } catch {
+            print(error)
         }
-        
-        return entryData
     }
 }
 

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  TableViewController.swift
+//  Expo1900
+//
+//  Created by 고은 on 2021/12/14.
+//
+
+import UIKit
+
+class TableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Expo1900/Expo1900/Controller/TableViewController.swift
+++ b/Expo1900/Expo1900/Controller/TableViewController.swift
@@ -48,4 +48,16 @@ extension TableViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return CGFloat(180)
     }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        performSegue(withIdentifier: "descriptionVeiwSegue", sender: indexPath.row)
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if let descriptionView = segue.destination as? EntryDescriptionViewController {
+            if let index = sender as? Int {
+                descriptionView.entryData = entryData[index]
+            }
+        }
+    }
 }

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -14,6 +14,16 @@ class ViewController: UIViewController {
     @IBOutlet weak var viewKoreaEnrtyListButton: UIButton!
     @IBOutlet weak var descriptionTextView: UITextView!
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         loadExpositionInformation()

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -7,12 +7,16 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var visitorsCountLabel: UILabel!
+    @IBOutlet weak var locationLabel: UILabel!
+    @IBOutlet weak var durationLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
+    @IBOutlet weak var viewKoreaEnrtyListButton: UIButton!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
-
 }
 

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -16,7 +16,19 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+        loadExpositionInformation()
+    }
+    
+    func loadExpositionInformation() {
+        guard let expositionData = parseExpositionJSON() else {
+            return
+        }
+        
+        titleLabel.text = expositionData.title
+        visitorsCountLabel.text = "방문객 : \(expositionData.visitorsCount)"
+        locationLabel.text = "개최지 : \(expositionData.location)"
+        durationLabel.text = "개최기간 : \(expositionData.duration)"
+        descriptionLabel.text = expositionData.description
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -11,8 +11,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var visitorsCountLabel: UILabel!
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var durationLabel: UILabel!
-    @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var viewKoreaEnrtyListButton: UIButton!
+    @IBOutlet weak var descriptionTextView: UITextView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,7 +28,7 @@ class ViewController: UIViewController {
         visitorsCountLabel.text = "방문객 : \(expositionData.visitorsCount)"
         locationLabel.text = "개최지 : \(expositionData.location)"
         durationLabel.text = "개최기간 : \(expositionData.duration)"
-        descriptionLabel.text = expositionData.description
+        descriptionTextView.text = expositionData.description
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -24,11 +24,24 @@ class ViewController: UIViewController {
             return
         }
         
+        let visitorsCount = insertComma(at: expositionData.visitorsCount)
+        
         titleLabel.text = expositionData.title
-        visitorsCountLabel.text = "방문객 : \(expositionData.visitorsCount)"
+        visitorsCountLabel.text = "방문객 : \(visitorsCount)"
         locationLabel.text = "개최지 : \(expositionData.location)"
         durationLabel.text = "개최기간 : \(expositionData.duration)"
         descriptionTextView.text = expositionData.description
+    }
+    
+    func insertComma(at value: Int) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        guard let insertedCommaValue = numberFormatter.string(from: NSNumber(value: value)) else {
+            fatalError()
+        }
+        
+        return insertedCommaValue
     }
 }
 

--- a/Expo1900/Expo1900/Error/ExpositionError.swift
+++ b/Expo1900/Expo1900/Error/ExpositionError.swift
@@ -1,0 +1,14 @@
+//
+//  ExpositionError.swift
+//  Expo1900
+//
+//  Created by Sunwoo on 2021/12/14.
+//
+
+import Foundation
+
+enum ExpositionError: Error {
+    case notExistData
+    case failTypeCasting
+    case failJSONParsing
+}

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -1,0 +1,20 @@
+//
+//  Decoder.swift
+//  Expo1900
+//
+//  Created by Sunwoo on 2021/12/13.
+//
+
+import UIKit
+
+let decoder = JSONDecoder()
+
+func parseExpositionJSON() -> Exposition? {
+    guard let expositionJSON: NSDataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
+        fatalError()
+    }
+    
+    let decodedExpositionData = try? decoder.decode(Exposition.self, from: expositionJSON.data)
+    
+    return decodedExpositionData
+}

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -11,7 +11,7 @@ let decoder = JSONDecoder()
 
 func parseExpositionJSON() -> Exposition? {
     guard let expositionJSON: NSDataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
-        fatalError()
+        fatalError("^^")
     }
     
     let decodedExpositionData = try? decoder.decode(Exposition.self, from: expositionJSON.data)

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -9,9 +9,9 @@ import UIKit
 
 let decoder = JSONDecoder()
 
-func parseExpositionJSON() -> Exposition? {
+func parseExpositionJSON() throws -> Exposition? {
     guard let expositionJSON: NSDataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
-        fatalError("^^")
+        throw ExpositionError.notExistData
     }
     
     let decodedExpositionData = try? decoder.decode(Exposition.self, from: expositionJSON.data)

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -18,3 +18,13 @@ func parseExpositionJSON() throws -> Exposition? {
     
     return decodedExpositionData
 }
+
+func parseEntryJSON() throws -> Entry? {
+    guard let entryJSON: NSDataAsset = NSDataAsset(name: "items") else {
+        throw ExpositionError.notExistData
+    }
+    
+    let decodedEntryData = try? decoder.decode(Entry.self, from: entryJSON.data)
+    
+    return decodedEntryData
+}

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -19,12 +19,14 @@ func parseExpositionJSON() throws -> Exposition? {
     return decodedExpositionData
 }
 
-func parseEntryJSON() throws -> [Entry]? {
+func parseEntryJSON() throws -> [Entry] {
     guard let entryJSON: NSDataAsset = NSDataAsset(name: "items") else {
         throw ExpositionError.notExistData
     }
     
-    let decodedEntryData = try? decoder.decode([Entry].self, from: entryJSON.data)
+    guard let decodedEntryData = try decoder.decode([Entry]?.self, from: entryJSON.data) else {
+        throw ExpositionError.failJSONParsing
+    }
     
     return decodedEntryData
 }

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -19,12 +19,12 @@ func parseExpositionJSON() throws -> Exposition? {
     return decodedExpositionData
 }
 
-func parseEntryJSON() throws -> Entry? {
+func parseEntryJSON() throws -> [Entry]? {
     guard let entryJSON: NSDataAsset = NSDataAsset(name: "items") else {
         throw ExpositionError.notExistData
     }
     
-    let decodedEntryData = try? decoder.decode(Entry.self, from: entryJSON.data)
+    let decodedEntryData = try? decoder.decode([Entry].self, from: entryJSON.data)
     
     return decodedEntryData
 }

--- a/Expo1900/Expo1900/Model/Decoder.swift
+++ b/Expo1900/Expo1900/Model/Decoder.swift
@@ -9,12 +9,14 @@ import UIKit
 
 let decoder = JSONDecoder()
 
-func parseExpositionJSON() throws -> Exposition? {
+func parseExpositionJSON() throws -> Exposition {
     guard let expositionJSON: NSDataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
         throw ExpositionError.notExistData
     }
     
-    let decodedExpositionData = try? decoder.decode(Exposition.self, from: expositionJSON.data)
+   guard let decodedExpositionData = try decoder.decode(Exposition?.self, from: expositionJSON.data) else {
+        throw ExpositionError.failJSONParsing
+    }
     
     return decodedExpositionData
 }

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct Exposition: Decodable {
     let title: String
-    let visitors: Int
+    let visitorsCount: Int
     let location: String
     let duration: String
     let description: String

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -7,7 +7,3 @@ struct Exposition: Decodable {
     let duration: String
     let description: String
 }
-
-struct ExpositionPoster {
-    let imageResourceLocator: String
-}

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -6,4 +6,12 @@ struct Exposition: Decodable {
     let location: String
     let duration: String
     let description: String
+    
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case visitorsCount = "visitors"
+        case location
+        case duration
+        case description
+    }
 }

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -134,7 +133,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="entryCustomCell" id="qps-oe-uoT" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qps-oe-uoT" id="Js7-BY-8fz">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -144,10 +143,26 @@
                                             <rect key="frame" x="0.0" y="-16" width="77" height="75"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Kp-kU-Nrj">
+                                            <rect key="frame" x="101" y="0.0" width="42" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6dl-m0-YEz">
+                                            <rect key="frame" x="101" y="22" width="42" height="21"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                     </subviews>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <outlet property="entryCustomCellUIImageView" destination="XKE-KE-a67" id="jWV-gM-RLr"/>
+                                    <outlet property="entryImageView" destination="XKE-KE-a67" id="jWV-gM-RLr"/>
+                                    <outlet property="entryNameLabel" destination="2Kp-kU-Nrj" id="uaZ-Sj-UjG"/>
+                                    <outlet property="entryShortDescriptionLabel" destination="6dl-m0-YEz" id="Luo-1i-bzn"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--메인-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="메인" id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r16-BT-Zwx">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9Jy-Cd-kN3" userLabel="Expo Information Stack View">
-                                        <rect key="frame" x="0.0" y="30" width="414" height="577"/>
+                                        <rect key="frame" x="0.0" y="90" width="414" height="577"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hz-e5-pqd" userLabel="Title">
                                                 <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
@@ -71,6 +71,9 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6OD-rx-X5r">
                                                         <rect key="frame" x="65" y="0.0" width="46" height="68.5"/>
                                                         <state key="normal" title="Button"/>
+                                                        <connections>
+                                                            <segue destination="80Q-2V-TUU" kind="push" id="CIc-5i-tJo"/>
+                                                        </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="vO1-he-brr">
                                                         <rect key="frame" x="131" y="0.0" width="45" height="68.5"/>
@@ -89,7 +92,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="9Jy-Cd-kN3" firstAttribute="leading" secondItem="xsP-Os-Xz1" secondAttribute="leading" id="6it-rd-f4L"/>
-                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="top" secondItem="xsP-Os-Xz1" secondAttribute="top" constant="30" id="JVc-Ro-N39"/>
+                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="top" secondItem="xsP-Os-Xz1" secondAttribute="top" constant="90" id="JVc-Ro-N39"/>
                                     <constraint firstItem="9Jy-Cd-kN3" firstAttribute="bottom" secondItem="xsP-Os-Xz1" secondAttribute="bottom" id="JfJ-1q-JBj"/>
                                     <constraint firstItem="9Jy-Cd-kN3" firstAttribute="trailing" secondItem="xsP-Os-Xz1" secondAttribute="trailing" id="SSu-tQ-4qg"/>
                                     <constraint firstItem="9Jy-Cd-kN3" firstAttribute="width" secondItem="JJj-Kk-8GZ" secondAttribute="width" id="pOo-VR-QDM"/>
@@ -101,12 +104,13 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="r16-BT-Zwx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="F7v-LA-dKL"/>
+                            <constraint firstItem="r16-BT-Zwx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="-88" id="F7v-LA-dKL"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="r16-BT-Zwx" secondAttribute="bottom" id="ngT-Z7-2ij"/>
                             <constraint firstItem="r16-BT-Zwx" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="oyU-El-vLj"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="r16-BT-Zwx" secondAttribute="trailing" id="tsr-rt-HG9"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" title="메인" largeTitleDisplayMode="never" id="YSf-Gu-YFu"/>
                     <connections>
                         <outlet property="descriptionTextView" destination="nB6-xq-ecW" id="5aJ-GP-Fjt"/>
                         <outlet property="durationLabel" destination="zsJ-gj-BKz" id="ujH-Xf-9oE"/>
@@ -118,7 +122,54 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="8.6956521739130448" y="137.94642857142856"/>
+            <point key="canvasLocation" x="1828.985507246377" y="137.94642857142856"/>
+        </scene>
+        <!--한국의 출품작-->
+        <scene sceneID="4fE-Nw-xK7">
+            <objects>
+                <tableViewController id="80Q-2V-TUU" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="Q1a-B4-OBK">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="qps-oe-uoT">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qps-oe-uoT" id="Js7-BY-8fz">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="80Q-2V-TUU" id="4Kq-cd-vOT"/>
+                            <outlet property="delegate" destination="80Q-2V-TUU" id="CsS-Yy-Qkv"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="한국의 출품작" id="tXC-Rv-m3Z"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2735" y="194"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="a5a-xG-Ufa">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ow8-TM-m3B" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="KRT-N1-X6U">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="adG-hw-PQp"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Iy9-cW-Zih" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="918.84057971014499" y="137.94642857142856"/>
         </scene>
     </scenes>
     <resources>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,7 +12,7 @@
         <!--메인-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController title="메인" id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="메인" id="BYZ-38-t0r" customClass="MainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -127,7 +127,7 @@
         <!--한국의 출품작-->
         <scene sceneID="4fE-Nw-xK7">
             <objects>
-                <tableViewController id="80Q-2V-TUU" sceneMemberID="viewController">
+                <tableViewController id="80Q-2V-TUU" customClass="TableViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="Q1a-B4-OBK">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -151,7 +151,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2735" y="194"/>
+            <point key="canvasLocation" x="2690" y="138"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="a5a-xG-Ufa">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -50,7 +50,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AUQ-EO-4u0" userLabel="description">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AUQ-EO-4u0" userLabel="description">
                                                 <rect key="frame" x="186.5" y="332" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -106,6 +106,16 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="r16-BT-Zwx" secondAttribute="trailing" id="tsr-rt-HG9"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="descriptionLabel" destination="AUQ-EO-4u0" id="8Ic-Ku-qLO"/>
+                        <outlet property="durationLabel" destination="zsJ-gj-BKz" id="ujH-Xf-9oE"/>
+                        <outlet property="locationLabel" destination="rFG-ZG-U2a" id="RkL-C7-c7O"/>
+                        <outlet property="title" destination="4hz-e5-pqd" id="SGb-kH-Emz"/>
+                        <outlet property="titleLabel" destination="4hz-e5-pqd" id="Zfn-oy-O0C"/>
+                        <outlet property="viewKoreaEnrtyListButton" destination="6OD-rx-X5r" id="Pyx-PS-eaw"/>
+                        <outlet property="visitorsCount" destination="cYr-sf-9F8" id="9Iv-ST-19L"/>
+                        <outlet property="visitorsCountLabel" destination="cYr-sf-9F8" id="oS0-tW-TIM"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,24 +1,122 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r16-BT-Zwx">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9Jy-Cd-kN3" userLabel="Expo Information Stack View">
+                                        <rect key="frame" x="0.0" y="30" width="414" height="431"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hz-e5-pqd" userLabel="Title">
+                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="A85-OA-Odx">
+                                                <rect key="frame" x="135" y="30.5" width="144" height="200"/>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cYr-sf-9F8" userLabel="VisitorsCount">
+                                                <rect key="frame" x="186.5" y="240.5" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rFG-ZG-U2a" userLabel="Location">
+                                                <rect key="frame" x="186.5" y="271" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zsJ-gj-BKz" userLabel="duration">
+                                                <rect key="frame" x="186.5" y="301.5" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AUQ-EO-4u0" userLabel="description">
+                                                <rect key="frame" x="186.5" y="332" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="3QV-qD-gUm" userLabel="Next View Stack View">
+                                                <rect key="frame" x="65.5" y="362.5" width="283" height="68.5"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="VKv-X6-o7F">
+                                                        <rect key="frame" x="0.0" y="0.0" width="45" height="68.5"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="VKv-X6-o7F" secondAttribute="height" multiplier="124:189" id="c65-kZ-ZLB"/>
+                                                            <constraint firstAttribute="width" constant="45" id="j1B-xm-XFx"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6OD-rx-X5r">
+                                                        <rect key="frame" x="65" y="0.0" width="153" height="68.5"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
+                                                    </button>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="vO1-he-brr">
+                                                        <rect key="frame" x="238" y="0.0" width="45" height="68.5"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="45" id="2bl-re-5k6"/>
+                                                            <constraint firstAttribute="width" secondItem="vO1-he-brr" secondAttribute="height" multiplier="124:189" id="h9J-pV-kRN"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="vO1-he-brr" firstAttribute="width" secondItem="vO1-he-brr" secondAttribute="height" multiplier="124:189" id="sor-tk-vb6"/>
+                                                </constraints>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="leading" secondItem="xsP-Os-Xz1" secondAttribute="leading" id="6it-rd-f4L"/>
+                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="top" secondItem="xsP-Os-Xz1" secondAttribute="top" constant="30" id="JVc-Ro-N39"/>
+                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="bottom" secondItem="xsP-Os-Xz1" secondAttribute="bottom" id="JfJ-1q-JBj"/>
+                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="trailing" secondItem="xsP-Os-Xz1" secondAttribute="trailing" id="SSu-tQ-4qg"/>
+                                    <constraint firstItem="9Jy-Cd-kN3" firstAttribute="width" secondItem="JJj-Kk-8GZ" secondAttribute="width" id="pOo-VR-QDM"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="xsP-Os-Xz1"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="JJj-Kk-8GZ"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="r16-BT-Zwx" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="F7v-LA-dKL"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="r16-BT-Zwx" secondAttribute="bottom" id="ngT-Z7-2ij"/>
+                            <constraint firstItem="r16-BT-Zwx" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="oyU-El-vLj"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="r16-BT-Zwx" secondAttribute="trailing" id="tsr-rt-HG9"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="8.6956521739130448" y="137.94642857142856"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="flag" width="851" height="567"/>
+        <image name="poster" width="144" height="200"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -57,7 +56,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="3QV-qD-gUm" userLabel="Next View Stack View">
-                                                <rect key="frame" x="65.5" y="362.5" width="283" height="68.5"/>
+                                                <rect key="frame" x="119" y="362.5" width="176" height="68.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="VKv-X6-o7F">
                                                         <rect key="frame" x="0.0" y="0.0" width="45" height="68.5"/>
@@ -67,12 +66,11 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6OD-rx-X5r">
-                                                        <rect key="frame" x="65" y="0.0" width="153" height="68.5"/>
+                                                        <rect key="frame" x="65" y="0.0" width="46" height="68.5"/>
                                                         <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="vO1-he-brr">
-                                                        <rect key="frame" x="238" y="0.0" width="45" height="68.5"/>
+                                                        <rect key="frame" x="131" y="0.0" width="45" height="68.5"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="45" id="2bl-re-5k6"/>
                                                             <constraint firstAttribute="width" secondItem="vO1-he-brr" secondAttribute="height" multiplier="124:189" id="h9J-pV-kRN"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -108,10 +109,8 @@
                         <outlet property="descriptionLabel" destination="AUQ-EO-4u0" id="8Ic-Ku-qLO"/>
                         <outlet property="durationLabel" destination="zsJ-gj-BKz" id="ujH-Xf-9oE"/>
                         <outlet property="locationLabel" destination="rFG-ZG-U2a" id="RkL-C7-c7O"/>
-                        <outlet property="title" destination="4hz-e5-pqd" id="SGb-kH-Emz"/>
                         <outlet property="titleLabel" destination="4hz-e5-pqd" id="Zfn-oy-O0C"/>
                         <outlet property="viewKoreaEnrtyListButton" destination="6OD-rx-X5r" id="Pyx-PS-eaw"/>
-                        <outlet property="visitorsCount" destination="cYr-sf-9F8" id="9Iv-ST-19L"/>
                         <outlet property="visitorsCountLabel" destination="cYr-sf-9F8" id="oS0-tW-TIM"/>
                     </connections>
                 </viewController>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -132,13 +133,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="qps-oe-uoT">
-                                <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="entryCustomCell" id="qps-oe-uoT" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qps-oe-uoT" id="Js7-BY-8fz">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XKE-KE-a67">
+                                            <rect key="frame" x="0.0" y="-16" width="77" height="75"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        </imageView>
+                                    </subviews>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="entryCustomCellUIImageView" destination="XKE-KE-a67" id="jWV-gM-RLr"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -153,7 +163,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2690" y="138"/>
+            <point key="canvasLocation" x="2689.8550724637685" y="137.94642857142856"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="a5a-xG-Ufa">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -132,26 +132,26 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="entryCustomCell" id="qps-oe-uoT" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="entryCustomCell" rowHeight="187" id="qps-oe-uoT" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="24.5" width="414" height="187"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qps-oe-uoT" id="Js7-BY-8fz">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="187"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XKE-KE-a67">
-                                            <rect key="frame" x="0.0" y="-16" width="77" height="75"/>
+                                            <rect key="frame" x="11" y="28" width="125" height="131"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Kp-kU-Nrj">
-                                            <rect key="frame" x="101" y="0.0" width="42" height="21"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6dl-m0-YEz">
+                                            <rect key="frame" x="158" y="129" width="236" height="21"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6dl-m0-YEz">
-                                            <rect key="frame" x="101" y="22" width="42" height="21"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Kp-kU-Nrj">
+                                            <rect key="frame" x="158" y="28" width="207" height="67"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -59,7 +59,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="3QV-qD-gUm" userLabel="Next View Stack View">
-                                                <rect key="frame" x="119" y="508.5" width="176" height="68.5"/>
+                                                <rect key="frame" x="73" y="508.5" width="268" height="68.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="VKv-X6-o7F">
                                                         <rect key="frame" x="0.0" y="0.0" width="45" height="68.5"/>
@@ -69,14 +69,14 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6OD-rx-X5r">
-                                                        <rect key="frame" x="65" y="0.0" width="46" height="68.5"/>
-                                                        <state key="normal" title="Button"/>
+                                                        <rect key="frame" x="65" y="0.0" width="138" height="68.5"/>
+                                                        <state key="normal" title="한국의 출품작 보러가기"/>
                                                         <connections>
                                                             <segue destination="80Q-2V-TUU" kind="push" id="CIc-5i-tJo"/>
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="vO1-he-brr">
-                                                        <rect key="frame" x="131" y="0.0" width="45" height="68.5"/>
+                                                        <rect key="frame" x="223" y="0.0" width="45" height="68.5"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="45" id="2bl-re-5k6"/>
                                                             <constraint firstAttribute="width" secondItem="vO1-he-brr" secondAttribute="height" multiplier="124:189" id="h9J-pV-kRN"/>
@@ -175,7 +175,7 @@
                     <navigationItem key="navigationItem" title="한국의 출품작" id="tXC-Rv-m3Z"/>
                     <connections>
                         <outlet property="entryListTableView" destination="Q1a-B4-OBK" id="fFd-ML-1v3"/>
-                        <segue destination="rbt-wT-fvP" kind="show" identifier="descriptionVeiwSegue" id="O9V-5D-IIK"/>
+                        <segue destination="rbt-wT-fvP" kind="show" identifier="descriptionViewSegue" id="O9V-5D-IIK"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9Jy-Cd-kN3" userLabel="Expo Information Stack View">
-                                        <rect key="frame" x="0.0" y="30" width="414" height="431"/>
+                                        <rect key="frame" x="0.0" y="30" width="414" height="577"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4hz-e5-pqd" userLabel="Title">
                                                 <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
@@ -50,14 +50,16 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="100" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AUQ-EO-4u0" userLabel="description">
-                                                <rect key="frame" x="186.5" y="332" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nB6-xq-ecW">
+                                                <rect key="frame" x="2" y="332" width="410.5" height="166.5"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="3QV-qD-gUm" userLabel="Next View Stack View">
-                                                <rect key="frame" x="119" y="362.5" width="176" height="68.5"/>
+                                                <rect key="frame" x="119" y="508.5" width="176" height="68.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="VKv-X6-o7F">
                                                         <rect key="frame" x="0.0" y="0.0" width="45" height="68.5"/>
@@ -106,7 +108,7 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="descriptionLabel" destination="AUQ-EO-4u0" id="8Ic-Ku-qLO"/>
+                        <outlet property="descriptionTextView" destination="nB6-xq-ecW" id="5aJ-GP-Fjt"/>
                         <outlet property="durationLabel" destination="zsJ-gj-BKz" id="ujH-Xf-9oE"/>
                         <outlet property="locationLabel" destination="rFG-ZG-U2a" id="RkL-C7-c7O"/>
                         <outlet property="titleLabel" destination="4hz-e5-pqd" id="Zfn-oy-O0C"/>
@@ -122,6 +124,9 @@
     <resources>
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="144" height="200"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -132,11 +133,11 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="entryCustomCell" rowHeight="187" id="qps-oe-uoT" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="24.5" width="414" height="187"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCustomCell" rowHeight="187" id="qps-oe-uoT" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="187"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qps-oe-uoT" id="Js7-BY-8fz">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="187"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="187"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XKE-KE-a67">
@@ -163,6 +164,7 @@
                                     <outlet property="entryImageView" destination="XKE-KE-a67" id="jWV-gM-RLr"/>
                                     <outlet property="entryNameLabel" destination="2Kp-kU-Nrj" id="uaZ-Sj-UjG"/>
                                     <outlet property="entryShortDescriptionLabel" destination="6dl-m0-YEz" id="Luo-1i-bzn"/>
+                                    <segue destination="rbt-wT-fvP" kind="show" id="K0S-Um-St9"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -179,6 +181,59 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2689.8550724637685" y="137.94642857142856"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="UUG-uy-SsS">
+            <objects>
+                <viewController id="rbt-wT-fvP" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="CCh-Jy-Qv3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cfx-Lr-BmC">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="MAx-lJ-bI8">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="289"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="RKZ-d8-BlG">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="256"/>
+                                            </imageView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="dd" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1cV-RB-DI9">
+                                                <rect key="frame" x="0.0" y="256" width="414" height="33"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="MAx-lJ-bI8" firstAttribute="bottom" secondItem="MIV-wC-WLD" secondAttribute="bottom" id="3zc-Zq-RpD"/>
+                                    <constraint firstItem="MAx-lJ-bI8" firstAttribute="leading" secondItem="MIV-wC-WLD" secondAttribute="leading" id="ZsH-AQ-tle"/>
+                                    <constraint firstItem="MAx-lJ-bI8" firstAttribute="top" secondItem="MIV-wC-WLD" secondAttribute="top" id="m9V-8R-SkZ"/>
+                                    <constraint firstItem="MAx-lJ-bI8" firstAttribute="width" secondItem="8wA-Mg-RVX" secondAttribute="width" id="toR-U7-3T5"/>
+                                    <constraint firstItem="MAx-lJ-bI8" firstAttribute="trailing" secondItem="MIV-wC-WLD" secondAttribute="trailing" id="u0Y-Zl-fB2"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="MIV-wC-WLD"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="8wA-Mg-RVX"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ipw-wk-rUI"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ipw-wk-rUI" firstAttribute="top" secondItem="Cfx-Lr-BmC" secondAttribute="top" constant="44" id="Aoq-x2-vu6"/>
+                            <constraint firstItem="Cfx-Lr-BmC" firstAttribute="bottom" secondItem="ipw-wk-rUI" secondAttribute="bottom" id="cDJ-4n-Taq"/>
+                            <constraint firstItem="ipw-wk-rUI" firstAttribute="trailing" secondItem="Cfx-Lr-BmC" secondAttribute="trailing" id="mZS-do-m4X"/>
+                            <constraint firstItem="Cfx-Lr-BmC" firstAttribute="leading" secondItem="ipw-wk-rUI" secondAttribute="leading" id="tIm-kh-zC4"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="cpC-yr-Znd"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vzz-6N-6ut" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3408.6956521739135" y="115.84821428571428"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="a5a-xG-Ufa">
@@ -200,6 +255,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="bangjja" width="341.5" height="256"/>
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="144" height="200"/>
         <systemColor name="labelColor">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -134,7 +133,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="qps-oe-uoT">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qps-oe-uoT" id="Js7-BY-8fz">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -148,6 +147,9 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="한국의 출품작" id="tXC-Rv-m3Z"/>
+                    <connections>
+                        <outlet property="entryListTableView" destination="Q1a-B4-OBK" id="fFd-ML-1v3"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ow8-TM-m3B">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -164,7 +164,6 @@
                                     <outlet property="entryImageView" destination="XKE-KE-a67" id="jWV-gM-RLr"/>
                                     <outlet property="entryNameLabel" destination="2Kp-kU-Nrj" id="uaZ-Sj-UjG"/>
                                     <outlet property="entryShortDescriptionLabel" destination="6dl-m0-YEz" id="Luo-1i-bzn"/>
-                                    <segue destination="rbt-wT-fvP" kind="show" id="K0S-Um-St9"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -176,17 +175,18 @@
                     <navigationItem key="navigationItem" title="한국의 출품작" id="tXC-Rv-m3Z"/>
                     <connections>
                         <outlet property="entryListTableView" destination="Q1a-B4-OBK" id="fFd-ML-1v3"/>
+                        <segue destination="rbt-wT-fvP" kind="show" identifier="descriptionVeiwSegue" id="O9V-5D-IIK"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pxY-ZN-UvA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2689.8550724637685" y="137.94642857142856"/>
+            <point key="canvasLocation" x="2614" y="138"/>
         </scene>
-        <!--View Controller-->
+        <!--Entry Description View Controller-->
         <scene sceneID="UUG-uy-SsS">
             <objects>
-                <viewController id="rbt-wT-fvP" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="CCh-Jy-Qv3">
+                <viewController storyboardIdentifier="descriptionView" id="rbt-wT-fvP" customClass="EntryDescriptionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="CCh-Jy-Qv3" customClass="EntryCustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -199,7 +199,7 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="RKZ-d8-BlG">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="256"/>
                                             </imageView>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="dd" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1cV-RB-DI9">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Text" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="1cV-RB-DI9">
                                                 <rect key="frame" x="0.0" y="256" width="414" height="33"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -230,10 +230,14 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="cpC-yr-Znd"/>
+                    <connections>
+                        <outlet property="descriptionImage" destination="RKZ-d8-BlG" id="QGS-S8-THS"/>
+                        <outlet property="descriptionText" destination="1cV-RB-DI9" id="7Op-82-sgy"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vzz-6N-6ut" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3408.6956521739135" y="115.84821428571428"/>
+            <point key="canvasLocation" x="3368" y="138"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="a5a-xG-Ufa">


### PR DESCRIPTION
안녕하세요, @lina0322
STEP2 PR 제출합니다!
늦은 진도를 따라잡기 위해 이번 step은 부지런히 달려봤습니다 😇
여러가지 시도와 시행착오를 많이 겪어서 여쭤볼게 좀 많네요..!!
이번 리뷰도 잘부탁드립니다! 감사합니다 🥰

---

## 1. 고민했던 점

1-1. 스택뷰 사용의 장점은?

→ 스택뷰를 사용하면 각각 따로 배치하는 것보다 편하게 배치하고 관리할 수 있습니다.

1-2. 네비게이션과 모달 중 전자를 선택했습니다.

- 네비게이션은 정보의 깊이와 흐름을 가지는 구조에서 사용됩니다. 반면, 모달은 화면자가 특정 선택을 해야만 할 경우 등 사용자가 액션을 취해야 하는 뷰를 보여줄 때 사용됩니다.
- 해당 앱은 뷰가 계층적으로 이동하는 방식이기 때문에 네비게이션이 적합하다고 판단하였습니다.

1-3. TextView vs Label ?

- 처음에 박람회의 설명을 하는 부분에 Label로 텍스트를 넣어주었었습니다. 저희끼리 textView와 Label 중 무엇이 더 좋을지 고민을 해본 끝에, 현재는 TextView로 설명을 나타냈습니다. editable과 scoll을 불가능하게 하는 조건으로 변경을 하였는데, 저희가 느끼기로는 text의 길이를 알아서 나타내는 TextView의 효용성이 더 좋은 것 같다고 판단을 했었습니다. 이렇게 했을 때 textView와 Label의 차이가 길이정보를 자동으로 나타내는 것 이외에는 없다고 생각이 들었는데 혹시 저희가 생각한 것이 맞을까요? 그리고, 글을 받아서 화면에 나타내야 하는 경우에는 현업에서 어떻게 처리하는 지 궁금합니다 🧐

1-4. 테이블뷰컨트롤러와 뷰컨트롤러에 테이블뷰를 올려쓰는 것과의 차이?

- 화면을 마음대로 커스텀하려면(하나의 뷰 안에 테이블뷰 외 다른 요소들을 넣는 경우 등등…) 뷰컨트롤러를 쓰는 것이 적합하지만, 현재 프로젝트의 경우 화면에 테이블뷰 외의 요소가 들어가지 않기 때문에 테이블뷰컨트롤러를 사용했습니다.

## 2. 해결이 되지 않은 점

2-1. Decoder 파일 내 decoder를 두 개로 나누었는데, 합치는 방법이 있을까요?

2-2. NSDataAsset

- NSNumber, NSInteger등 NS가 붙어있는 타입들에 대해서 찾아보다가 스칼라, 번들 등 아무리 읽어봐도 이해가 가지 않는 개념들이 있었습니다. 🥲 캠퍼들에게 물어봐도 정확히 아는 분이 없어서 도움을 요청합니다...!! 혹시 이 개념들을 쉽게 이해할 수 있는 방법이 있을까요?

## 3. 조언을 얻고 싶은 부분

3-1. numberFormatter에서 NSNumber를 사용하는 이유는 무엇일까요?

- NS는 objective C의 흔적으로 검색되었습니다. numberFormatter가 정의된 Foundation 프레임워크가 해당 시기의 것이기 때문에 NS 또한 여전히 사용되고 있는 것으로 생각해보았습니다.
    - String은 NSString과 연결되어 있기 때문에 그대로 사용됩니다. 참고한 공식문서는 아래와 같습니다.
    
    > Swift’s `String` type is bridged with Foundation’s `NSString` class. Foundation also extends `String` to expose methods defined by `NSString`. This means, if you import Foundation, you can access those `NSString` methods on `String` without casting.
    > 
    

3-2. 메서드내에서 do catch까지 일괄처리를 해주는 것 vs do catch만을 위한 메서드를 만들어주는 것

```swift
func loadExpositionInformation() {
        do {
            try insertDataToView()
            
        } catch ExpositionError.failJSONParsing {
            print(ExpositionError.failJSONParsing)
        } catch ExpositionError.failTypeCasting {
            print(ExpositionError.failTypeCasting)
        } catch ExpositionError.notExistData {
            print(ExpositionError.notExistData)
        } catch {
            print(error)
        }
    }
```

1. 메서드내에 일괄처리를 해주는 경우: 옵셔널 바인딩 등 때문에 코드가 중첩이 되고, 다중 책임이 의심되었습니다. 여러 책임을 가진 결과, 가독성 또한 떨어진다고 생각했습니다. 
2. do catch만을 위한 메서드를 만드는 경우: 가독성이 좋지만, do-catch 기능만 수행하는 메서드를 따로 만드는 것이 적절한 것인지에 대한 의문이 들었습니다. (메서드명을 지을때  해당 메서드의 기능(에러처리만을 위한)을 잘 나타내지 못하는 것 같은 의문이였습니다.)

3-3. TableViewController의 `entryListTableView`가 선언될 때, 자동으로 `strong` 참조를 하던데, weak 참조가 아닌 이유가 무엇인가요?

- view가 해제되었을 때에도 남겨둘 이유가 없기 때문에 `weak`로 진행하였습니다.

3-4. `Content Configuration` after iOS 14 vs `Configuring a cell` before iOS 14

1️⃣  cell을 customCell 타입으로 형변환하여 직접 접근해서 데이터를 입력해주는 것

2️⃣  content를 생성해서 모든 데이터를 담아준 뒤, cell에 content에 담긴 값을 입력해주는 것

위와 같이 두가지 방법으로 데이터에 접근해서 셀에 넣어줄 수 있는 것으로 이해하면서 의문점이 생겼는데요,

content에서 접근 가능한 항목이 image, text, attributedText, secondaryText, secondaryAttributedText 다섯개밖에 없는 것 같은데, 만약에 커스텀셀을 만들어서 이미지를 2개 이상 넣고 싶은 경우에는 content를 못쓰는 건가? 하는 궁금증이 생겨서 질문 드려요. 커스텀셀을 사용할 경우 content를 사용할 수는 없는 걸까요? 그리고 Text나 Image의 위치를 지정하는 것 또한 불가능한 것일까요?

3-5. 뷰를 이동할 때, `sender(cell)`의 `indexPath`정보를 도착하는 뷰에 전달해주는 방법을 고민했습니다.

```swift
override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
        performSegue(withIdentifier: "descriptionVeiwSegue", sender: indexPath.row)
    }
    
override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
     let tableView = sender as! UITableView
     tableView.indexPathsForSelectedRows
        
     if let descriptionView = segue.destination as? EntryDescriptionViewController {
         if let index = sender as? Int {
             descriptionView.entryData = entryData[index]
         }
     }
 }
```

현재는 sender에 index 정보를 담아서 데이터를 전달하는 방식으로 구현을 했습니다. 헌데, 이게 올바른 방법인지는 잘 모르겠습니다..😓

이렇게 사용해도 되는지, 만약 다른 더 좋은방법이 있다면 힌트 조금만 주시면 refactor 해보도록 하겠습니다

### 4. 트러블 슈팅

4-1. 문제 상황: JSON 데이터를 파싱하는 과정에서 트러블이 발생하였습니다.

- 해결 방법: 파싱할 데이터 타입의 일부 데이터 리네이밍을 진행한 후 CodingKeys 추가를 하지 않아 발생한 문제임을 확인, 해당 내용을 추가하여 해결하였습니다.

![](https://i.imgur.com/Nw52vW8.png)
![](https://i.imgur.com/xE8jJWX.png)


4-2. 문제 상황: 출품작 목록뷰→출품작 상세뷰 이동을 설정할 때, performSegue를 이용하면서 segue의 identifier 설정을 위해 스토리보드에서도 연결을 해주었는데 이 경우 출품작 상세뷰가 2개 겹쳐서 나타나는 문제가 있었습니다.

- 해결 방법: performSegue와 스토리보드에서 각각 1번씩 뷰 이동을 하기 때문에 나타나는 현상이라고 생각해서 스토리보드 상의 segue 연결을 (기존: 출품작 목록뷰 셀-출품작 상세뷰 → 변경: 출품작 목록뷰 전체-출품작 상세뷰)와 같이 변경했습니다.