### PR TITLE
만국박람회 [STEP3] 조이 & 요한

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		602384442760D95D003C4325 /* JSONAssetNameList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602384432760D95D003C4325 /* JSONAssetNameList.swift */; };
 		6023844627631ED2003C4325 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023844527631ED2003C4325 /* Array+Extension.swift */; };
 		6036B54E276838C300011B06 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6036B54D276838C300011B06 /* NSMutableAttributedString+Extension.swift */; };
+		6036B551276868C500011B06 /* EntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6036B550276868C500011B06 /* EntryTableViewCell.swift */; };
 		606EA3D6275DDCD80061F495 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606EA3D5275DDCD80061F495 /* Entry.swift */; };
 		606EA3E4275DEE5C0061F495 /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606EA3E3275DEE5C0061F495 /* DecodingTests.swift */; };
 		606EA3EB275F55E70061F495 /* JSONDecoder+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606EA3EA275F55E70061F495 /* JSONDecoder+Extension.swift */; };
@@ -46,6 +47,7 @@
 		602384432760D95D003C4325 /* JSONAssetNameList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONAssetNameList.swift; sourceTree = "<group>"; };
 		6023844527631ED2003C4325 /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
 		6036B54D276838C300011B06 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
+		6036B550276868C500011B06 /* EntryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTableViewCell.swift; sourceTree = "<group>"; };
 		606EA3D5275DDCD80061F495 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		606EA3E1275DEE5C0061F495 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		606EA3E3275DEE5C0061F495 /* DecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingTests.swift; sourceTree = "<group>"; };
@@ -109,6 +111,14 @@
 			path = Error;
 			sourceTree = "<group>";
 		};
+		6036B54F276868AB00011B06 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				6036B550276868C500011B06 /* EntryTableViewCell.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		606EA3D4275DDCBC0061F495 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -150,6 +160,7 @@
 			children = (
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
+				6036B54F276868AB00011B06 /* View */,
 				3BCD686027632543007D2122 /* ViewController */,
 				606EA3D4275DDCBC0061F495 /* Model */,
 				3BCD686127632582007D2122 /* Extension */,
@@ -276,6 +287,7 @@
 				6023844627631ED2003C4325 /* Array+Extension.swift in Sources */,
 				6036B54E276838C300011B06 /* NSMutableAttributedString+Extension.swift in Sources */,
 				609C99E727604A97008FE6E7 /* EntryTableViewController.swift in Sources */,
+				6036B551276868C500011B06 /* EntryTableViewCell.swift in Sources */,
 				3B409D63275DE1E500159134 /* Exposition.swift in Sources */,
 				606EA3EB275F55E70061F495 /* JSONDecoder+Extension.swift in Sources */,
 				6023844227608573003C4325 /* Int+Extension.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6023844227608573003C4325 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023844127608573003C4325 /* Int+Extension.swift */; };
 		602384442760D95D003C4325 /* JSONAssetNameList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602384432760D95D003C4325 /* JSONAssetNameList.swift */; };
 		6023844627631ED2003C4325 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023844527631ED2003C4325 /* Array+Extension.swift */; };
+		6036B54E276838C300011B06 /* NSMutableAttributedString+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6036B54D276838C300011B06 /* NSMutableAttributedString+Extension.swift */; };
 		606EA3D6275DDCD80061F495 /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606EA3D5275DDCD80061F495 /* Entry.swift */; };
 		606EA3E4275DEE5C0061F495 /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606EA3E3275DEE5C0061F495 /* DecodingTests.swift */; };
 		606EA3EB275F55E70061F495 /* JSONDecoder+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606EA3EA275F55E70061F495 /* JSONDecoder+Extension.swift */; };
@@ -44,6 +45,7 @@
 		6023844127608573003C4325 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		602384432760D95D003C4325 /* JSONAssetNameList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONAssetNameList.swift; sourceTree = "<group>"; };
 		6023844527631ED2003C4325 /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
+		6036B54D276838C300011B06 /* NSMutableAttributedString+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+Extension.swift"; sourceTree = "<group>"; };
 		606EA3D5275DDCD80061F495 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		606EA3E1275DEE5C0061F495 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		606EA3E3275DEE5C0061F495 /* DecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingTests.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXGroup;
 			children = (
 				6023844127608573003C4325 /* Int+Extension.swift */,
+				6036B54D276838C300011B06 /* NSMutableAttributedString+Extension.swift */,
 				606EA3EA275F55E70061F495 /* JSONDecoder+Extension.swift */,
 				6023844527631ED2003C4325 /* Array+Extension.swift */,
 			);
@@ -271,6 +274,7 @@
 				606EA3D6275DDCD80061F495 /* Entry.swift in Sources */,
 				3B5EC63E275F7DBC008E51E1 /* Expo1900Error.swift in Sources */,
 				6023844627631ED2003C4325 /* Array+Extension.swift in Sources */,
+				6036B54E276838C300011B06 /* NSMutableAttributedString+Extension.swift in Sources */,
 				609C99E727604A97008FE6E7 /* EntryTableViewController.swift in Sources */,
 				3B409D63275DE1E500159134 /* Exposition.swift in Sources */,
 				606EA3EB275F55E70061F495 /* JSONDecoder+Extension.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3B409D63275DE1E500159134 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B409D62275DE1E500159134 /* Exposition.swift */; };
 		3B5EC63E275F7DBC008E51E1 /* Expo1900Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B5EC63D275F7DBC008E51E1 /* Expo1900Error.swift */; };
+		3B6AB28B276833B5007DCB4C /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B6AB28A276833B5007DCB4C /* NavigationController.swift */; };
 		3BE9FF782760575000A2E76F /* EntryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE9FF772760575000A2E76F /* EntryDetailViewController.swift */; };
 		6023844227608573003C4325 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6023844127608573003C4325 /* Int+Extension.swift */; };
 		602384442760D95D003C4325 /* JSONAssetNameList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602384432760D95D003C4325 /* JSONAssetNameList.swift */; };
@@ -38,6 +39,7 @@
 /* Begin PBXFileReference section */
 		3B409D62275DE1E500159134 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		3B5EC63D275F7DBC008E51E1 /* Expo1900Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expo1900Error.swift; sourceTree = "<group>"; };
+		3B6AB28A276833B5007DCB4C /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		3BE9FF772760575000A2E76F /* EntryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailViewController.swift; sourceTree = "<group>"; };
 		6023844127608573003C4325 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		602384432760D95D003C4325 /* JSONAssetNameList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONAssetNameList.swift; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 				C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */,
 				609C99E627604A97008FE6E7 /* EntryTableViewController.swift */,
 				3BE9FF772760575000A2E76F /* EntryDetailViewController.swift */,
+				3B6AB28A276833B5007DCB4C /* NavigationController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -272,6 +275,7 @@
 				3B409D63275DE1E500159134 /* Exposition.swift in Sources */,
 				606EA3EB275F55E70061F495 /* JSONDecoder+Extension.swift in Sources */,
 				6023844227608573003C4325 /* Int+Extension.swift in Sources */,
+				3B6AB28B276833B5007DCB4C /* NavigationController.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				3BE9FF782760575000A2E76F /* EntryDetailViewController.swift in Sources */,

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -144,9 +144,6 @@
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="dsS-hh-I9b">
                                                     <rect key="frame" x="0.0" y="1.5" width="77" height="77"/>
-                                                    <accessibility key="accessibilityConfiguration">
-                                                        <bool key="isElement" value="YES"/>
-                                                    </accessibility>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="dsS-hh-I9b" secondAttribute="height" multiplier="1:1" id="2sf-bK-CTz"/>
                                                     </constraints>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="12" y="0.0" width="390" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8j7-pV-HOV">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="418.5"/>
+                                        <rect key="frame" x="0.0" y="20" width="390" height="418.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LHA-Pd-lzj">
                                                 <rect key="frame" x="165.5" y="0.0" width="59" height="30"/>
@@ -95,7 +95,7 @@
                                     <constraint firstAttribute="bottom" secondItem="8j7-pV-HOV" secondAttribute="bottom" id="Y63-M0-74O"/>
                                     <constraint firstItem="8j7-pV-HOV" firstAttribute="leading" secondItem="QhU-cg-yQj" secondAttribute="leading" id="fuO-iU-6De"/>
                                     <constraint firstItem="8j7-pV-HOV" firstAttribute="width" secondItem="QhU-cg-yQj" secondAttribute="width" id="rRk-SA-Tnd"/>
-                                    <constraint firstItem="8j7-pV-HOV" firstAttribute="top" secondItem="QhU-cg-yQj" secondAttribute="top" id="yN2-yL-06i"/>
+                                    <constraint firstItem="8j7-pV-HOV" firstAttribute="top" secondItem="QhU-cg-yQj" secondAttribute="top" constant="20" id="yN2-yL-06i"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="BSV-gi-LvM"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="xeq-UR-Z5l"/>
@@ -132,24 +132,27 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCell" rowHeight="276" id="oD1-kW-pY0" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="276"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCell" rowHeight="100" id="oD1-kW-pY0" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="100"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oD1-kW-pY0" id="DFH-bg-O1q">
-                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="276"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="100"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="37P-MW-Pck">
-                                            <rect key="frame" x="10" y="10" width="374.5" height="256"/>
+                                            <rect key="frame" x="10" y="10" width="374.5" height="80"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="dsS-hh-I9b">
-                                                    <rect key="frame" x="0.0" y="89.5" width="77" height="77"/>
+                                                    <rect key="frame" x="0.0" y="1.5" width="77" height="77"/>
+                                                    <accessibility key="accessibilityConfiguration">
+                                                        <bool key="isElement" value="YES"/>
+                                                    </accessibility>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="dsS-hh-I9b" secondAttribute="height" multiplier="1:1" id="2sf-bK-CTz"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Sys-cp-deo">
-                                                    <rect key="frame" x="87" y="104.5" width="287.5" height="47"/>
+                                                    <rect key="frame" x="87" y="16.5" width="287.5" height="47"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LbM-TL-s5O">
                                                             <rect key="frame" x="0.0" y="0.0" width="287.5" height="30"/>
@@ -208,27 +211,31 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mf0-Bv-7o4">
                                 <rect key="frame" x="12" y="0.0" width="390" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="31" translatesAutoresizingMaskIntoConstraints="NO" id="YQ3-Cc-p3I">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="251.5"/>
-                                        <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="yUB-yq-UXJ">
-                                                <rect key="frame" x="123" y="0.0" width="144" height="200"/>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="be5-Ng-agk">
-                                                <rect key="frame" x="174.5" y="231" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="god" translatesAutoresizingMaskIntoConstraints="NO" id="yUB-yq-UXJ">
+                                        <rect key="frame" x="49" y="20" width="292.5" height="219.5"/>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="yUB-yq-UXJ" secondAttribute="height" multiplier="4:3" id="G0N-TE-Tj8"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="be5-Ng-agk">
+                                        <rect key="frame" x="0.0" y="249.5" width="390" height="17"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="YQ3-Cc-p3I" firstAttribute="width" secondItem="Mf0-Bv-7o4" secondAttribute="width" id="1N3-P6-MQz"/>
-                                    <constraint firstAttribute="trailing" secondItem="YQ3-Cc-p3I" secondAttribute="trailing" id="C6J-2i-7o6"/>
-                                    <constraint firstItem="YQ3-Cc-p3I" firstAttribute="top" secondItem="Mf0-Bv-7o4" secondAttribute="top" id="RSb-sy-bXt"/>
-                                    <constraint firstAttribute="bottom" secondItem="YQ3-Cc-p3I" secondAttribute="bottom" id="nqW-UV-qEq"/>
-                                    <constraint firstItem="YQ3-Cc-p3I" firstAttribute="leading" secondItem="Mf0-Bv-7o4" secondAttribute="leading" id="qQy-nq-mXJ"/>
+                                    <constraint firstItem="be5-Ng-agk" firstAttribute="bottom" secondItem="UA1-8o-dHW" secondAttribute="bottom" id="8Hu-c9-4oC"/>
+                                    <constraint firstItem="yUB-yq-UXJ" firstAttribute="centerX" secondItem="Mf0-Bv-7o4" secondAttribute="centerX" id="EwO-gi-2BY"/>
+                                    <constraint firstAttribute="trailing" secondItem="be5-Ng-agk" secondAttribute="trailing" id="G0s-iu-DyW"/>
+                                    <constraint firstItem="be5-Ng-agk" firstAttribute="leading" secondItem="Mf0-Bv-7o4" secondAttribute="leading" id="dcD-yj-pXz"/>
+                                    <constraint firstItem="yUB-yq-UXJ" firstAttribute="top" secondItem="UA1-8o-dHW" secondAttribute="top" constant="20" id="dvK-5c-3ks"/>
+                                    <constraint firstItem="be5-Ng-agk" firstAttribute="width" secondItem="Mf0-Bv-7o4" secondAttribute="width" id="gSl-3d-PhZ"/>
+                                    <constraint firstItem="be5-Ng-agk" firstAttribute="top" secondItem="yUB-yq-UXJ" secondAttribute="bottom" constant="10" id="lqv-yd-xfu"/>
+                                    <constraint firstItem="yUB-yq-UXJ" firstAttribute="width" relation="lessThanOrEqual" secondItem="Mf0-Bv-7o4" secondAttribute="width" multiplier="0.75" id="yjN-Ck-2Bp"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="UA1-8o-dHW"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="RpS-VV-o3C"/>
@@ -238,8 +245,8 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="Mf0-Bv-7o4" secondAttribute="bottom" id="CAh-gD-Yg1"/>
-                            <constraint firstAttribute="trailing" secondItem="Mf0-Bv-7o4" secondAttribute="trailing" constant="12" id="OYX-0J-5hJ"/>
-                            <constraint firstItem="Mf0-Bv-7o4" firstAttribute="leading" secondItem="gBd-4W-A0c" secondAttribute="leading" constant="12" id="iAA-u4-yj0"/>
+                            <constraint firstItem="umO-d0-Zuo" firstAttribute="trailing" secondItem="Mf0-Bv-7o4" secondAttribute="trailing" constant="12" id="OYX-0J-5hJ"/>
+                            <constraint firstItem="Mf0-Bv-7o4" firstAttribute="leading" secondItem="umO-d0-Zuo" secondAttribute="leading" constant="12" id="iAA-u4-yj0"/>
                             <constraint firstItem="Mf0-Bv-7o4" firstAttribute="top" secondItem="gBd-4W-A0c" secondAttribute="top" id="kEy-b0-6vW"/>
                         </constraints>
                     </view>
@@ -275,6 +282,7 @@
     </scenes>
     <resources>
         <image name="flag" width="851" height="567"/>
+        <image name="god" width="293" height="194"/>
         <image name="poster" width="144" height="200"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -20,44 +20,44 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QhU-cg-yQj">
                                 <rect key="frame" x="12" y="0.0" width="390" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="31" translatesAutoresizingMaskIntoConstraints="NO" id="8j7-pV-HOV">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="538.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8j7-pV-HOV">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="418.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LHA-Pd-lzj">
-                                                <rect key="frame" x="174.5" y="0.0" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LHA-Pd-lzj">
+                                                <rect key="frame" x="165.5" y="0.0" width="59" height="30"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="aN6-vG-gBx">
-                                                <rect key="frame" x="123" y="51.5" width="144" height="200"/>
+                                                <rect key="frame" x="123" y="40" width="144" height="200"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ewM-wf-nTS">
-                                                <rect key="frame" x="174.5" y="282.5" width="41.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ewM-wf-nTS">
+                                                <rect key="frame" x="174.5" y="250" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="00g-vM-Qz4">
-                                                <rect key="frame" x="174.5" y="334" width="41.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="00g-vM-Qz4">
+                                                <rect key="frame" x="174.5" y="280.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iaO-XX-REJ">
-                                                <rect key="frame" x="174.5" y="385.5" width="41.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iaO-XX-REJ">
+                                                <rect key="frame" x="174.5" y="311" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uVu-2I-2rV">
-                                                <rect key="frame" x="174.5" y="437" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <rect key="frame" x="177.5" y="341.5" width="35.5" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wuu-gh-C93">
-                                                <rect key="frame" x="68.5" y="488.5" width="253" height="50"/>
+                                                <rect key="frame" x="68.5" y="368.5" width="253" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="BVb-yf-Hd5">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -59,17 +59,18 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wuu-gh-C93">
+                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="wuu-gh-C93">
                                                 <rect key="frame" x="68.5" y="368.5" width="253" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="BVb-yf-Hd5">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <constraints>
+                                                            <constraint firstAttribute="width" secondItem="BVb-yf-Hd5" secondAttribute="height" multiplier="1:1" id="b6l-bZ-MDc"/>
                                                             <constraint firstAttribute="width" constant="50" id="hks-rQ-Yuv"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N33-sf-bRi">
-                                                        <rect key="frame" x="50" y="0.0" width="153" height="50"/>
+                                                        <rect key="frame" x="50" y="9.5" width="153" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
@@ -80,12 +81,10 @@
                                                         <rect key="frame" x="203" y="0.0" width="50" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="50" id="e0j-Un-3Im"/>
+                                                            <constraint firstAttribute="width" secondItem="vSe-xm-3ax" secondAttribute="height" multiplier="1:1" id="mWz-jS-43q"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="50" id="Gc6-uT-M32"/>
-                                                </constraints>
                                             </stackView>
                                         </subviews>
                                     </stackView>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -132,29 +132,55 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCell" textLabel="yCY-pp-Bk3" detailTextLabel="jCK-Ls-2Ye" style="IBUITableViewCellStyleSubtitle" id="oD1-kW-pY0">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCell" rowHeight="276" id="oD1-kW-pY0" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="276"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oD1-kW-pY0" id="DFH-bg-O1q">
-                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="276"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yCY-pp-Bk3">
-                                            <rect key="frame" x="20" y="6" width="25" height="14.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jCK-Ls-2Ye">
-                                            <rect key="frame" x="20" y="22.5" width="40.5" height="13.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="37P-MW-Pck">
+                                            <rect key="frame" x="10" y="10" width="374.5" height="256"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="dsS-hh-I9b">
+                                                    <rect key="frame" x="0.0" y="89.5" width="77" height="77"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="dsS-hh-I9b" secondAttribute="height" multiplier="1:1" id="2sf-bK-CTz"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Sys-cp-deo">
+                                                    <rect key="frame" x="87" y="104.5" width="287.5" height="47"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LbM-TL-s5O">
+                                                            <rect key="frame" x="0.0" y="0.0" width="287.5" height="30"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iUm-pD-0ea">
+                                                            <rect key="frame" x="0.0" y="30" width="287.5" height="17"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                        </stackView>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="37P-MW-Pck" firstAttribute="leading" secondItem="DFH-bg-O1q" secondAttribute="leading" constant="10" id="3wS-XT-QIZ"/>
+                                        <constraint firstItem="dsS-hh-I9b" firstAttribute="width" secondItem="DFH-bg-O1q" secondAttribute="width" multiplier="0.2" id="KuU-O9-M8K"/>
+                                        <constraint firstItem="37P-MW-Pck" firstAttribute="top" secondItem="DFH-bg-O1q" secondAttribute="top" constant="10" id="bug-lt-eiO"/>
+                                        <constraint firstAttribute="bottom" secondItem="37P-MW-Pck" secondAttribute="bottom" constant="10" id="ozb-Ku-CmR"/>
+                                        <constraint firstAttribute="trailing" secondItem="37P-MW-Pck" secondAttribute="trailing" id="pfB-uk-k10"/>
+                                    </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="entryImageView" destination="dsS-hh-I9b" id="AzQ-QM-RoN"/>
+                                    <outlet property="entryNameLabel" destination="LbM-TL-s5O" id="ymD-ab-vN4"/>
+                                    <outlet property="entryShortDescriptionLabel" destination="iUm-pD-0ea" id="F6X-9d-Pzg"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -23,7 +23,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="8j7-pV-HOV">
                                         <rect key="frame" x="0.0" y="0.0" width="390" height="418.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LHA-Pd-lzj">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LHA-Pd-lzj">
                                                 <rect key="frame" x="165.5" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
@@ -31,26 +31,29 @@
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="aN6-vG-gBx">
                                                 <rect key="frame" x="123" y="40" width="144" height="200"/>
+                                                <accessibility key="accessibilityConfiguration" label="만국박람회 포스터">
+                                                    <bool key="isElement" value="YES"/>
+                                                </accessibility>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ewM-wf-nTS">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ewM-wf-nTS">
                                                 <rect key="frame" x="174.5" y="250" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="00g-vM-Qz4">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="00g-vM-Qz4">
                                                 <rect key="frame" x="174.5" y="280.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iaO-XX-REJ">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iaO-XX-REJ">
                                                 <rect key="frame" x="174.5" y="311" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uVu-2I-2rV">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uVu-2I-2rV">
                                                 <rect key="frame" x="177.5" y="341.5" width="35.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -227,7 +227,7 @@
         <!--Navigation Controller-->
         <scene sceneID="d97-FU-lgz">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="eZa-Zb-zxU" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="eZa-Zb-zxU" customClass="NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="z00-Gh-42u">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>

--- a/Expo1900/Expo1900/Extension/NSMutableAttributedString+Extension.swift
+++ b/Expo1900/Expo1900/Extension/NSMutableAttributedString+Extension.swift
@@ -1,19 +1,11 @@
 import UIKit
 
 extension NSMutableAttributedString {
-    func title3(text: String) -> NSMutableAttributedString {
-        let font = UIFont.preferredFont(forTextStyle: .title3)
-        let attributes: [NSAttributedString.Key: Any] = [.font: font]
-        
-        append(NSAttributedString(string: text, attributes: attributes))
-        return self
-    }
     
-    func body(text: String) -> NSMutableAttributedString {
-        let font = UIFont.preferredFont(forTextStyle: .body)
+    func append(_ text: String, forTextStyle: UIFont.TextStyle) {
+        let font = UIFont.preferredFont(forTextStyle: forTextStyle)
         let attributes: [NSAttributedString.Key: Any] = [.font: font]
         
         append(NSAttributedString(string: text, attributes: attributes))
-        return self
     }
 }

--- a/Expo1900/Expo1900/Extension/NSMutableAttributedString+Extension.swift
+++ b/Expo1900/Expo1900/Extension/NSMutableAttributedString+Extension.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+extension NSMutableAttributedString {
+    func title3(text: String) -> NSMutableAttributedString {
+        let font = UIFont.preferredFont(forTextStyle: .title3)
+        let attributes: [NSAttributedString.Key: Any] = [.font: font]
+        
+        append(NSAttributedString(string: text, attributes: attributes))
+        return self
+    }
+    
+    func body(text: String) -> NSMutableAttributedString {
+        let font = UIFont.preferredFont(forTextStyle: .body)
+        let attributes: [NSAttributedString.Key: Any] = [.font: font]
+        
+        append(NSAttributedString(string: text, attributes: attributes))
+        return self
+    }
+}

--- a/Expo1900/Expo1900/Extension/NSMutableAttributedString+Extension.swift
+++ b/Expo1900/Expo1900/Extension/NSMutableAttributedString+Extension.swift
@@ -2,10 +2,10 @@ import UIKit
 
 extension NSMutableAttributedString {
     
-    func append(_ text: String, forTextStyle: UIFont.TextStyle) {
+    func append(string: String, forTextStyle: UIFont.TextStyle) {
         let font = UIFont.preferredFont(forTextStyle: forTextStyle)
         let attributes: [NSAttributedString.Key: Any] = [.font: font]
         
-        append(NSAttributedString(string: text, attributes: attributes))
+        append(NSAttributedString(string: string, attributes: attributes))
     }
 }

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -7,14 +7,20 @@ struct Exposition: Decodable {
     let duration: String
     let description: String
     
-    var visitorsDescription: String {
-        return "방문객 : \(visitors.decimalString) 명"
+    var visitorsDescription: NSMutableAttributedString {
+        return NSMutableAttributedString()
+            .title3(text: "방문객")
+            .body(text: " : \(visitors.decimalString) 명")
     }
-    var locationDescription: String {
-        return "개최지 : \(location)"
+    var locationDescription: NSMutableAttributedString {
+        return NSMutableAttributedString()
+            .title3(text: "개최지")
+            .body(text: " : \(location)")
     }
-    var durationDescription: String {
-        return "개최 기간 : \(duration)"
+    var durationDescription: NSMutableAttributedString {
+        return NSMutableAttributedString()
+            .title3(text: "개최 기간")
+            .body(text: " : \(duration)")
     }
     
     init() throws {

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -9,22 +9,22 @@ struct Exposition: Decodable {
     
     var visitorsDescription: NSMutableAttributedString {
         let description = NSMutableAttributedString()
-        description.append("방문객", forTextStyle: .title3)
-        description.append(" : \(visitors.decimalString) 명", forTextStyle: .body)
+        description.append(string: "방문객", forTextStyle: .title3)
+        description.append(string: " : \(visitors.decimalString) 명", forTextStyle: .body)
         
         return description
     }
     var locationDescription: NSMutableAttributedString {
         let description = NSMutableAttributedString()
-        description.append("개최지", forTextStyle: .title3)
-        description.append(" : \(location)", forTextStyle: .body)
+        description.append(string: "개최지", forTextStyle: .title3)
+        description.append(string: " : \(location)", forTextStyle: .body)
         
         return description
     }
     var durationDescription: NSMutableAttributedString {
         let description = NSMutableAttributedString()
-        description.append("개최 기간", forTextStyle: .title3)
-        description.append(" : \(duration)", forTextStyle: .body)
+        description.append(string: "개최 기간", forTextStyle: .title3)
+        description.append(string: " : \(duration)", forTextStyle: .body)
         
         return description
     }

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -8,19 +8,25 @@ struct Exposition: Decodable {
     let description: String
     
     var visitorsDescription: NSMutableAttributedString {
-        return NSMutableAttributedString()
-            .title3(text: "방문객")
-            .body(text: " : \(visitors.decimalString) 명")
+        let description = NSMutableAttributedString()
+        description.append("방문객", forTextStyle: .title3)
+        description.append(" : \(visitors.decimalString) 명", forTextStyle: .body)
+        
+        return description
     }
     var locationDescription: NSMutableAttributedString {
-        return NSMutableAttributedString()
-            .title3(text: "개최지")
-            .body(text: " : \(location)")
+        let description = NSMutableAttributedString()
+        description.append("개최지", forTextStyle: .title3)
+        description.append(" : \(location)", forTextStyle: .body)
+        
+        return description
     }
     var durationDescription: NSMutableAttributedString {
-        return NSMutableAttributedString()
-            .title3(text: "개최 기간")
-            .body(text: " : \(duration)")
+        let description = NSMutableAttributedString()
+        description.append("개최 기간", forTextStyle: .title3)
+        description.append(" : \(duration)", forTextStyle: .body)
+        
+        return description
     }
     
     init() throws {

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+class EntryTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var entryImageView: UIImageView!
+    @IBOutlet weak var entryNameLabel: UILabel!
+    @IBOutlet weak var entryShortDescriptionLabel: UILabel!
+    
+    func configureContent(from entry: Entry) {
+        entryImageView.image = UIImage(named: entry.imageName)
+        entryNameLabel.text = entry.name
+        entryShortDescriptionLabel.text = entry.shortDescription
+    }
+}

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -13,6 +13,6 @@ class EntryTableViewCell: UITableViewCell {
     }
     
     func configureAccessibility(from entry: Entry) {
-        self.accessibilityHint = "누르면 \(entry.name) 상세정보 화면으로 이동합니다"
+        accessibilityHint = "누르면 \(entry.name) 상세정보 화면으로 이동합니다"
     }
 }

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -13,6 +13,13 @@ class EntryTableViewCell: UITableViewCell {
     }
     
     func configureAccessibility(from entry: Entry) {
-        accessibilityHint = "누르면 \(entry.name) 상세정보 화면으로 이동합니다"
+        guard let entryNameLabel = entryNameLabel,
+              let entryShortDescriptionLabel = entryShortDescriptionLabel else {
+                  return
+              }
+        accessibilityElements = [entryNameLabel, entryShortDescriptionLabel]
+        
+        entryNameLabel.accessibilityHint = "누르면 \(entry.name) 상세정보 화면으로 이동합니다"
+        entryShortDescriptionLabel.accessibilityHint = "누르면 \(entry.name) 상세정보 화면으로 이동합니다"
     }
 }

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -2,9 +2,9 @@ import UIKit
 
 class EntryTableViewCell: UITableViewCell {
 
-    @IBOutlet weak var entryImageView: UIImageView!
-    @IBOutlet weak var entryNameLabel: UILabel!
-    @IBOutlet weak var entryShortDescriptionLabel: UILabel!
+    @IBOutlet private weak var entryImageView: UIImageView!
+    @IBOutlet private weak var entryNameLabel: UILabel!
+    @IBOutlet private weak var entryShortDescriptionLabel: UILabel!
     
     func configureContent(from entry: Entry) {
         entryImageView.image = UIImage(named: entry.imageName)

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -11,4 +11,8 @@ class EntryTableViewCell: UITableViewCell {
         entryNameLabel.text = entry.name
         entryShortDescriptionLabel.text = entry.shortDescription
     }
+    
+    func configureAccessibility(from entry: Entry) {
+        self.accessibilityHint = "누르면 \(entry.name) 상세정보 화면으로 이동합니다"
+    }
 }

--- a/Expo1900/Expo1900/ViewController/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/ViewController/EntryDetailViewController.swift
@@ -16,16 +16,17 @@ class EntryDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setViewsFromEntry()
+        configureContent()
         setNavigationTitle()
-        setAccessiblity()
+        configureEntryImageAccessiblity()
     }
 }
 
 //MARK: - Private Methods
 
 extension EntryDetailViewController {
-    private func setViewsFromEntry() {
+    
+    private func configureContent() {
         guard let entry = entry else {
             return
         }
@@ -37,7 +38,7 @@ extension EntryDetailViewController {
         navigationItem.title = entry?.name
     }
     
-    private func setAccessiblity() {
+    private func configureEntryImageAccessiblity() {
         guard let entry = entry else {
             return
         }

--- a/Expo1900/Expo1900/ViewController/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/ViewController/EntryDetailViewController.swift
@@ -18,6 +18,7 @@ class EntryDetailViewController: UIViewController {
         
         setViewsFromEntry()
         setNavigationTitle()
+        setAccessiblity()
     }
 }
 
@@ -25,12 +26,21 @@ class EntryDetailViewController: UIViewController {
 
 extension EntryDetailViewController {
     private func setViewsFromEntry() {
-        guard let entry = entry else { return }
+        guard let entry = entry else {
+            return
+        }
         entryImageView.image = UIImage(named: entry.imageName)
         entryDescriptionLabel.text = entry.description
     }
     
     private func setNavigationTitle() {
         navigationItem.title = entry?.name
+    }
+    
+    private func setAccessiblity() {
+        guard let entry = entry else {
+            return
+        }
+        entryImageView.image?.accessibilityLabel = entry.name
     }
 }

--- a/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
@@ -14,6 +14,7 @@ class EntryTableViewController: UITableViewController {
         super.viewDidLoad()
         
         parseEntriesFromAsset()
+        UINavigationController.attemptRotationToDeviceOrientation()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
@@ -57,17 +57,15 @@ extension EntryTableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-        var content = cell.defaultContentConfiguration()
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? EntryTableViewCell else {
+            return UITableViewCell()
+        }
         
         guard let entry = entries[index: indexPath.row] else {
             return cell
         }
         
-        content.text = entry.name
-        content.secondaryText = entry.shortDescription
-        content.image = UIImage(named: entry.imageName)
-        cell.contentConfiguration = content
+        cell.configureContent(from: entry)
         
         return cell
     }

--- a/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
@@ -66,6 +66,7 @@ extension EntryTableViewController {
         }
         
         cell.configureContent(from: entry)
+        cell.configureAccessibility(from: entry)
         
         return cell
     }

--- a/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/ViewController/EntryTableViewController.swift
@@ -26,7 +26,9 @@ class EntryTableViewController: UITableViewController {
         super.prepare(for: segue, sender: sender)
         
         guard let entryDetailViewController = segue.destination as? EntryDetailViewController,
-              let entry = sender as? Entry else { return }
+              let entry = sender as? Entry else {
+                  return
+              }
         
         entryDetailViewController.entry = entry
     }
@@ -35,6 +37,7 @@ class EntryTableViewController: UITableViewController {
 //MARK: - Private Methods
 
 extension EntryTableViewController {
+    
     private func parseEntriesFromAsset() {
         do {
             guard let entryJSON = NSDataAsset(name: JSONAssetNameList.entry.rawValue) else {
@@ -52,6 +55,7 @@ extension EntryTableViewController {
 //MARK: - TableView Methods
 
 extension EntryTableViewController {
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return entries.count
     }

--- a/Expo1900/Expo1900/ViewController/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpositionViewController.swift
@@ -21,8 +21,10 @@ class ExpositionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let exposition = parseExpositionFromAsset() else { return }
-        setLabels(from: exposition)
+        guard let exposition = parseExpositionFromAsset() else {
+            return
+        }
+        configureContent(from: exposition)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -39,6 +41,7 @@ class ExpositionViewController: UIViewController {
 //MARK: - Private Methods
 
 extension ExpositionViewController {
+    
     private func parseExpositionFromAsset() -> Exposition? {
         do {
             return try Exposition()
@@ -51,7 +54,7 @@ extension ExpositionViewController {
         }
     }
     
-    private func setLabels(from exposition: Exposition) {
+    private func configureContent(from exposition: Exposition) {
         titleLabel.text = exposition.title
         visitorsLabel.attributedText = exposition.visitorsDescription
         locationLabel.attributedText = exposition.locationDescription

--- a/Expo1900/Expo1900/ViewController/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpositionViewController.swift
@@ -30,6 +30,10 @@ class ExpositionViewController: UIViewController {
         
         navigationController?.setNavigationBarHidden(true, animated: true)
     }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
 }
 
 //MARK: - Private Methods

--- a/Expo1900/Expo1900/ViewController/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpositionViewController.swift
@@ -53,9 +53,9 @@ extension ExpositionViewController {
     
     private func setLabels(from exposition: Exposition) {
         titleLabel.text = exposition.title
-        visitorsLabel.text = exposition.visitorsDescription
-        locationLabel.text = exposition.locationDescription
-        durationLabel.text = exposition.durationDescription
+        visitorsLabel.attributedText = exposition.visitorsDescription
+        locationLabel.attributedText = exposition.locationDescription
+        durationLabel.attributedText = exposition.durationDescription
         descriptionLabel.text = exposition.description
     }
 }

--- a/Expo1900/Expo1900/ViewController/NavigationController.swift
+++ b/Expo1900/Expo1900/ViewController/NavigationController.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+class NavigationController: UINavigationController {
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        topViewController?.supportedInterfaceOrientations ?? .all
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,124 @@
-## iOS 커리어 스타터 캠프
 
-### 만국박람회 프로젝트 저장소
+## ⚙️ 프로젝트 정보
+- 🤖 프로젝트명: 만국박람회
+- 🗓️ 프로젝트 기간: [2주] 2021.12.6 - 2021.12.17
+- 👵🧓 팀원: [yohan](https://github.com/YohanBlessYou) & [zoe](https://github.com/na-young-kwon)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+<br>
 
+### ✏️ 학습키워드
+#### 1. Foundation
+- JSON / JSONDecoder
+
+#### 2. UI 관련
+- Autolayout
+- Scroll View
+- TableView
+- Navigation Controller
+- 화면 세로고정 하기
+
+#### 3. Accessibility
+- Dynamic Type
+- Voice Over
+- Accessibility Inspector
+
+#### 4. 소프트웨어
+- Coding Convention/Style
+
+<br>
+
+### 🤖 App 소개
+<img src="https://user-images.githubusercontent.com/39155090/146541650-6ae22eeb-a4eb-44bd-8f47-6c4d09134b30.gif" width="30%" height="30%">
+
+<br>
+
+## 🤔 고민했던 점 + 해결방법
+
+### 1. Scroll View 오토레이아웃
+✔️ 문제
+첫 화면을 스크롤할 때 네비게이션바 뒤로 사진이 비치도록 구현하고 싶었으나 어째서인지 사진이 비치지 않는 문제가 있었습니다.
+
+✔️ 해결
+네비게이션 바의 투명도 문제가 아닌, 애초에 스크롤뷰의 크기를 화면에 꽉차게 구성하지 않았던 점이 문제였습니다.
+구체적으로는 제약을 걸 때 constraint to margins 이 항목을 체크해서 스크롤뷰의 top attribute를 superview에 맞추더라도 margin이 생겨버렸기 때문이었습니다.
+constraint to margins 항목을 체크해제 해서 문제를 해결했습니다.
+
+<br>
+
+### 2. 버튼과 레이블이 겹쳐 보이는 문제
+**✔️ 문제상황**
+!<img src="https://i.imgur.com/YAFqkFE.png" width="20%" height="30%">
+
+**✔️ 문제**
+첫번째 화면에서 글씨크기를 키우면 버튼과 레이블이 겹쳐서 보이는 문제가 있었습니다. 원인은 `태극기 + 버튼 + 태극기` 스택뷰의 Alignment가 fill 이었습니다
+
+**✔️ 해결**
+스택뷰의 Alignment를 `center`로 바꾸고, 임의의 숫자로 고정해 놓았던 스택뷰의 높이 제약을 제거해서 해결했습니다
+
+<br>
+
+### 3. 가로보기 모드에서 두번째 화면 진입 시 자동회전이 안되는 문제
+
+**✔️ 문제**
+(세로보기로 orientation이 고정된) 첫번째 화면에서 device를 눕힌 채로, (가로/세로 모두를 지원하는) 두번째 화면으로 전환하면 자동으로 가로보기가 되지 않는 문제가 있었습니다
+
+**✔️ 해결**
+`EntryTableViewController` 에서 아래 메서드를 호출해서 해결했습니다.
+
+```swift
+UINavigationController.attemptRotationToDeviceOrientation()
+```
+기능: 뷰 컨트롤러 별로 인터페이스 방향이 다를 때 이 메서드를 호출하면 시스템이 즉시 새 방향으로 회전을 시도한다
+
+
+<br>
+
+
+## 📝 피드백 반영
+
+### 1. 코드 컨벤션 관련
+- 코드의 작성 순서를 `IBOutlet - 프로퍼티 - 라이프사이클 메서드` 순으로 배치했습니다.
+- 테이블 뷰 관련 메서드들은 extension으로 빼서 구분해주었습니다.
+- 필요하다면 주석으로 메서드들을 구분하여 가독성을 높이려고 노력했습니다.
+
+<br>
+
+### 2. viewWillAppear 에서 super 메서드가 왜 필요한지 생각해보았습니다.
+super는 부모클래스를 의미합니다. 따라서 오버라이딩 할 때 부모의 작업을 실행하지말지 선택하는 것이기에 코드가 없어도 컴파일 에러를 유발하진 않습니다.
+
+다만, 현재는 `super.viewWillAppear`가 빈 메서드 이더라도 애플이 나중에 뷰에 필요한 코드를 추가할 수도 있으므로 일단 적어주는게 좋습니다. 또 공식문서를 보면 반드시 호출하라고 적혀있기도 합니다.
+
+<br>
+
+### 3. file 이름을 고민했습니다.
+처음에는 `Extension_Int` 이런식으로 파일명을 정했습니다.
+피드백을 받고 `extension` 파일을 만들 때 `타입명 + Extension` 형식으로 통일하기로 했습니다.
+
+<br>
+
+### 4. 생략할 수 있는 `self`는 생략하기
+```swift
+private func setNavigationTitle() {
+        self.navigationItem.title = entry?.name
+}
+```
+- self를 반드시 써주어야 하는 부분과 구분이 되도록 하기 위해서
+- 모든 곳에 self를 붙혀주는건 비효율적이기 때문에
+
+굳이 써야할 이유가 없다면 `self`를 생략하는 방향으로 코드에 통일성을 주었습니다.
+
+<br>
+
+### 5. 배열 안전하게 조회하기
+배열의 요소를 subscript로 추출할 때, range를 벗어난 곳을 참조하면 런타임 에러가 발생합니다
+
+이를 방지하고자 여러 방법 중 별도의 subscript를 추가하는 방법을 택하였습니다 
+index를 포함하는지 확인한 후 요소를 옵셔널 타입으로 리턴하도록 구현했습니다
+
+```swift
+extension Array {
+    subscript(index index: Int) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}
+```


### PR DESCRIPTION
## 인사말

안녕하세요 쿠마~ @leejun6694 
벌써 STEP3네요! 이번 PR도 잘 부탁드려요🙏🙏

---

## 📌 STEP3 주요 요구사항
이전까지 구현했던 3개 화면에 대해 오토레이아웃과 Accessibility를 적용하는 것이 목표입니다

### 1. Orientation
1. 첫 화면은 세로 방향만 지원
2. 나머지 두 화면은 모든 방향 회전 지원

### 2. Dynamic Type
1. 모든 화면에서 Dynamic Type 지원
2. 아이패드를 제외한 모든 기기의 크기에 맞도록 구현
3. 텍스트가 잘리거나 줄임표(...) 처리가 되지 않도록

---


## 🤔 신경쓴 점 & 고민한 점

### 1. cellForRowAt 메서드 개선
스텝2에서는 cell의 레이블이나 이미지를 주는 작업을 cellForRowAt에서 했습니다

스텝3에서 커스텀 셀을 만들면서 해당 작업들을 cell 클래스 안으로 옮기고


```swift
override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? EntryTableViewCell else {
            return UITableViewCell()
        }
        guard let entry = entries[index: indexPath.row] else {
            return cell
        }
        cell.configureContent(from: entry)
        cell.configureAccessibility(from: entry)
        
        return cell
    }
```
cellForRowAt 안에서는 cell 에서 정의한 메서드를 호출하는 식으로 변경했습니다
스텝2보다 가독성이 높아졌고 뷰와 뷰컨의 역할을 분리했다는 점에서 의의가 있는 것 같습니다

<br>

### 2. 버튼과 레이블이 겹쳐서 보이는 문제
**✔️ 문제상황**
!<img src="https://i.imgur.com/YAFqkFE.png" width="20%" height="30%">

**✔️ 문제**
첫번째 화면에서 글씨크기를 키우면 버튼과 레이블이 겹쳐서 보이는 문제가 있었습니다. 원인은 `태극기 + 버튼 + 태극기` 스택뷰의 Alignment가 fill 이었습니다

**✔️ 해결**
스택뷰의 Alignment를 `center`로 바꾸고, 임의의 숫자로 고정해 놓았던 스택뷰의 높이 제약을 제거해서 해결했습니다

<br>

### 3. 가로보기 모드에서 두번째 화면 진입 시 자동회전이 안되는 문제

**✔️ 문제**
(세로보기로 orientation이 고정된) 첫번째 화면에서 device를 눕힌 채로, (가로/세로 모두를 지원하는) 두번째 화면으로 전환하면 자동으로 가로보기가 되지 않는 문제가 있었습니다

**✔️ 해결**
`EntryTableViewController` 에서 아래 메서드를 호출해서 해결했습니다.

```swift
UINavigationController.attemptRotationToDeviceOrientation()
```
기능: 뷰 컨트롤러 별로 인터페이스 방향이 다를 때 이 메서드를 호출하면 시스템이 즉시 새 방향으로 회전을 시도한다

<br>

### 4. ImageView에 대한 Voice Over를 고민했습니다
VoiceOver 사용자에게 이미지 정보는 그다지 유효하지 않은 경우가 많다고 합니다. 그렇기 때문에 이미지에 대한 VoiceOver를 지원하지 않는 경우도 꽤 흔하게 볼 수 있습니다. 비록 이미지에 대해서 꼭 보이스 오버를 지원할 필요는 없지만, 어떻게 지원할 수 있을지 고민해봤고 최대한 정보를 전달할 수 있도록 노력했습니다.

---

## 🔍 궁금한 점 🔎

### Q1. Label 텍스트 가공을 Model에 구현하는게 맞을까요?
첫 화면에서 박람회에 대한 정보를 제공하는 Label에는 font size가 다른 텍스트가 혼합되어 있습니다

이를 표현하기 위해 `NSMutableAttributedString` 타입을 활용하고는, 이 가공 작업을 Model에 줄지 ViewController에 줄지 고민되었습니다

JSON에서 추출한 `Exposition` Model 데이터는, 이렇게 가공된 형태로만 사용되므로 뷰컨의 규모를 덜고자 `Exposition`의 computed 프로퍼티에 가공 작업을 구현하였습니다

> 질문: 하지만, 결국은 텍스트 가공이라는게 데이터를 '어떻게 보여줄 것인가'에 대한 것이라는 관점에서 View 혹은 ViewController에 구현했어야 했을까 하는 궁금증이 남아 쿠마의 의견을 묻습니다!

<br>

### Q2. device가 굉장히 많은데 UI 테스트를 일일히 시뮬레이터 돌려봐야 하나요?

모든 device에서 UI가 문제가 없는지 테스트가 필요했습니다 

효율적인 방법이 떠오르지 않아서 device 한 두개씩 device를 바꿔가며 시뮬레이터를 실행하고 모든 화면을 체크하였는데 하면서 이게 맞나? 싶더라구요😂

> 질문1: UI 테스트를 모든 device에 대해 해야 하는지 궁금합니다!
(디스플레이 크기 별로 하나씩만 하면 된다던지..)

> 질문2: 테스트해야 할 device가 많은데 시뮬레이터 레벨에서 한꺼번에 테스트 할 방법이 있을까요? (혹은 테스트 자동화?)

> 질문3: 현업에서는 어떻게 많은 device들을 테스트하시는지 궁금합니다!

<br>

### Q3. Cell 내부의 UI 요소에 대한 VoiceOver가 Accessibility Inspector에서 확인이 안되는 문제가 있었습니다

TableView에 VoiceOver Label을 지정해보았습니다
대상은 Cell 전체와 Cell 내부의 UI 요소였습니다

문제가 발생한 점은, Accessibility Inspector에서 title Label에 대해서는 VoiceOver를 테스트해볼 수 없었다는 점입니다
(Cell 전체에 대해선 테스트가 가능하나 Cell 내부의 title Label은 테스트 타겟으로 선택 자체가 되지 않았습니다)



> 질문: Cell 전체가 아닌 Cell 내부의 UI 요소들에 대해서 별도의 VoiceOver를 지정하는건 불가능한지 궁금합니다!

코드로 Label에 `accessibilityLabel`을 적용하는것은 가능한데 이를 테스트하거나 device에서 VoiceOver를 발동시키는게 가능한지 궁금합니다

*p.s. 상용 App인 카카오톡에서 대화내용 목록의 VoiceOver를 확인해봤을 때는, Cell 전체에 대해서만 걸려있었습니다*