### PR TITLE
만국박람회 [STEP 3] 제리, 앨리, 허황

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		08A269332760DBDB001DF39C /* InformationStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A269322760DBDB001DF39C /* InformationStackView.swift */; };
+		08A269332760DBDB001DF39C /* ExpoInformationStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A269322760DBDB001DF39C /* ExpoInformationStackView.swift */; };
 		08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A269342760DEE8001DF39C /* CustomButtonStackView.swift */; };
 		08B1F6952762E14D0092D10A /* DecimalNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B1F6942762E14D0092D10A /* DecimalNumberFormatter.swift */; };
 		08B1F6972762FCF00092D10A /* EntryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B1F6962762FCF00092D10A /* EntryListViewController.swift */; };
@@ -39,7 +39,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		08A269322760DBDB001DF39C /* InformationStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationStackView.swift; sourceTree = "<group>"; };
+		08A269322760DBDB001DF39C /* ExpoInformationStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoInformationStackView.swift; sourceTree = "<group>"; };
 		08A269342760DEE8001DF39C /* CustomButtonStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButtonStackView.swift; sourceTree = "<group>"; };
 		08B1F6942762E14D0092D10A /* DecimalNumberFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalNumberFormatter.swift; sourceTree = "<group>"; };
 		08B1F6962762FCF00092D10A /* EntryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryListViewController.swift; sourceTree = "<group>"; };
@@ -96,7 +96,7 @@
 		08CB4FEA275DE49400784B89 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				08A269322760DBDB001DF39C /* InformationStackView.swift */,
+				08A269322760DBDB001DF39C /* ExpoInformationStackView.swift */,
 				08A269342760DEE8001DF39C /* CustomButtonStackView.swift */,
 				08B1F698276323710092D10A /* ExpoEntryCell.swift */,
 				F363702827633E160083D596 /* EntryDetailStackView.swift */,
@@ -275,7 +275,7 @@
 			files = (
 				08B1F699276323710092D10A /* ExpoEntryCell.swift in Sources */,
 				FBCC3F26275DF1520049EBCB /* Parser.swift in Sources */,
-				08A269332760DBDB001DF39C /* InformationStackView.swift in Sources */,
+				08A269332760DBDB001DF39C /* ExpoInformationStackView.swift in Sources */,
 				F3637031276729500083D596 /* ExpoEntries.swift in Sources */,
 				F363702927633E160083D596 /* EntryDetailStackView.swift in Sources */,
 				08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A269342760DEE8001DF39C /* CustomButtonStackView.swift */; };
 		08B1F6952762E14D0092D10A /* DecimalNumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B1F6942762E14D0092D10A /* DecimalNumberFormatter.swift */; };
 		08B1F6972762FCF00092D10A /* EntryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B1F6962762FCF00092D10A /* EntryListViewController.swift */; };
+		08B1F699276323710092D10A /* ExpoEntryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08B1F698276323710092D10A /* ExpoEntryCell.swift */; };
 		08CB4FED275DE63800784B89 /* ExpoInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB4FEC275DE63800784B89 /* ExpoInformation.swift */; };
 		08CB4FF5275DFDD800784B89 /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB4FF4275DFDD800784B89 /* ParserTests.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
@@ -39,6 +40,7 @@
 		08A269342760DEE8001DF39C /* CustomButtonStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomButtonStackView.swift; sourceTree = "<group>"; };
 		08B1F6942762E14D0092D10A /* DecimalNumberFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecimalNumberFormatter.swift; sourceTree = "<group>"; };
 		08B1F6962762FCF00092D10A /* EntryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryListViewController.swift; sourceTree = "<group>"; };
+		08B1F698276323710092D10A /* ExpoEntryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoEntryCell.swift; sourceTree = "<group>"; };
 		08CB4FEC275DE63800784B89 /* ExpoInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoInformation.swift; sourceTree = "<group>"; };
 		08CB4FF2275DFDD800784B89 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		08CB4FF4275DFDD800784B89 /* ParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTests.swift; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 			children = (
 				08A269322760DBDB001DF39C /* InformationStackView.swift */,
 				08A269342760DEE8001DF39C /* CustomButtonStackView.swift */,
+				08B1F698276323710092D10A /* ExpoEntryCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -261,6 +264,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				08B1F699276323710092D10A /* ExpoEntryCell.swift in Sources */,
 				FBCC3F26275DF1520049EBCB /* Parser.swift in Sources */,
 				08A269332760DBDB001DF39C /* InformationStackView.swift in Sources */,
 				08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
 		F3166076275DEDA6005468CB /* ExpoEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3166075275DEDA6005468CB /* ExpoEntry.swift */; };
 		F31660BA275EF2DD005468CB /* NSDataAssetName+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31660B9275EF2DD005468CB /* NSDataAssetName+extension.swift */; };
+		F363702727633BAA0083D596 /* EntryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363702627633BAA0083D596 /* EntryDetailViewController.swift */; };
+		F363702927633E160083D596 /* EntryDetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363702827633E160083D596 /* EntryDetailStackView.swift */; };
 		FBCC3F26275DF1520049EBCB /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCC3F25275DF1520049EBCB /* Parser.swift */; };
 /* End PBXBuildFile section */
 
@@ -54,6 +56,8 @@
 		C79FF4C22589F404005FB0FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F3166075275DEDA6005468CB /* ExpoEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoEntry.swift; sourceTree = "<group>"; };
 		F31660B9275EF2DD005468CB /* NSDataAssetName+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDataAssetName+extension.swift"; sourceTree = "<group>"; };
+		F363702627633BAA0083D596 /* EntryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailViewController.swift; sourceTree = "<group>"; };
+		F363702827633E160083D596 /* EntryDetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailStackView.swift; sourceTree = "<group>"; };
 		FBCC3F25275DF1520049EBCB /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -92,6 +96,7 @@
 				08A269322760DBDB001DF39C /* InformationStackView.swift */,
 				08A269342760DEE8001DF39C /* CustomButtonStackView.swift */,
 				08B1F698276323710092D10A /* ExpoEntryCell.swift */,
+				F363702827633E160083D596 /* EntryDetailStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -101,6 +106,7 @@
 			children = (
 				C79FF4B82589F401005FB0FD /* ViewController.swift */,
 				08B1F6962762FCF00092D10A /* EntryListViewController.swift */,
+				F363702627633BAA0083D596 /* EntryDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -267,8 +273,10 @@
 				08B1F699276323710092D10A /* ExpoEntryCell.swift in Sources */,
 				FBCC3F26275DF1520049EBCB /* Parser.swift in Sources */,
 				08A269332760DBDB001DF39C /* InformationStackView.swift in Sources */,
+				F363702927633E160083D596 /* EntryDetailStackView.swift in Sources */,
 				08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */,
 				08B1F6952762E14D0092D10A /* DecimalNumberFormatter.swift in Sources */,
+				F363702727633BAA0083D596 /* EntryDetailViewController.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				08CB4FED275DE63800784B89 /* ExpoInformation.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		F31660BA275EF2DD005468CB /* NSDataAssetName+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31660B9275EF2DD005468CB /* NSDataAssetName+extension.swift */; };
 		F363702727633BAA0083D596 /* EntryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363702627633BAA0083D596 /* EntryDetailViewController.swift */; };
 		F363702927633E160083D596 /* EntryDetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F363702827633E160083D596 /* EntryDetailStackView.swift */; };
+		F3637031276729500083D596 /* ExpoEntries.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3637030276729500083D596 /* ExpoEntries.swift */; };
 		FBCC3F26275DF1520049EBCB /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCC3F25275DF1520049EBCB /* Parser.swift */; };
 /* End PBXBuildFile section */
 
@@ -58,6 +59,7 @@
 		F31660B9275EF2DD005468CB /* NSDataAssetName+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDataAssetName+extension.swift"; sourceTree = "<group>"; };
 		F363702627633BAA0083D596 /* EntryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailViewController.swift; sourceTree = "<group>"; };
 		F363702827633E160083D596 /* EntryDetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailStackView.swift; sourceTree = "<group>"; };
+		F3637030276729500083D596 /* ExpoEntries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoEntries.swift; sourceTree = "<group>"; };
 		FBCC3F25275DF1520049EBCB /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -86,6 +88,7 @@
 				F3166075275DEDA6005468CB /* ExpoEntry.swift */,
 				FBCC3F25275DF1520049EBCB /* Parser.swift */,
 				08B1F6942762E14D0092D10A /* DecimalNumberFormatter.swift */,
+				F3637030276729500083D596 /* ExpoEntries.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -273,6 +276,7 @@
 				08B1F699276323710092D10A /* ExpoEntryCell.swift in Sources */,
 				FBCC3F26275DF1520049EBCB /* Parser.swift in Sources */,
 				08A269332760DBDB001DF39C /* InformationStackView.swift in Sources */,
+				F3637031276729500083D596 /* ExpoEntries.swift in Sources */,
 				F363702927633E160083D596 /* EntryDetailStackView.swift in Sources */,
 				08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */,
 				08B1F6952762E14D0092D10A /* DecimalNumberFormatter.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -16,7 +16,7 @@
 		08CB4FF5275DFDD800784B89 /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08CB4FF4275DFDD800784B89 /* ParserTests.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
-		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
+		C79FF4B92589F401005FB0FD /* ExpoInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpoInformationViewController.swift */; };
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
@@ -50,7 +50,7 @@
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C79FF4B82589F401005FB0FD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C79FF4B82589F401005FB0FD /* ExpoInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoInformationViewController.swift; sourceTree = "<group>"; };
 		C79FF4BB2589F401005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -107,7 +107,7 @@
 		08CB4FEB275DE49D00784B89 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C79FF4B82589F401005FB0FD /* ViewController.swift */,
+				C79FF4B82589F401005FB0FD /* ExpoInformationViewController.swift */,
 				08B1F6962762FCF00092D10A /* EntryListViewController.swift */,
 				F363702627633BAA0083D596 /* EntryDetailViewController.swift */,
 			);
@@ -281,7 +281,7 @@
 				08A269352760DEE8001DF39C /* CustomButtonStackView.swift in Sources */,
 				08B1F6952762E14D0092D10A /* DecimalNumberFormatter.swift in Sources */,
 				F363702727633BAA0083D596 /* EntryDetailViewController.swift in Sources */,
-				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
+				C79FF4B92589F401005FB0FD /* ExpoInformationViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				08CB4FED275DE63800784B89 /* ExpoInformation.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -165,22 +165,61 @@
             </objects>
             <point key="canvasLocation" x="-816" y="-6"/>
         </scene>
-        <!--Table View Controller-->
+        <!--Entry List View Controller-->
         <scene sceneID="NB8-14-PUK">
             <objects>
-                <tableViewController id="NGF-kb-6xj" sceneMemberID="viewController">
+                <tableViewController id="NGF-kb-6xj" customClass="EntryListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="7kv-Dm-GpK">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="ZTC-Ff-zZV">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="expoEntryCell" rowHeight="142" id="ZTC-Ff-zZV" customClass="ExpoEntryCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="142"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZTC-Ff-zZV" id="QIe-Vp-kRT">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="142"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ocx-3f-ii9">
+                                            <rect key="frame" x="20" y="20" width="103.5" height="102"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" secondItem="ocx-3f-ii9" secondAttribute="height" multiplier="1:1" id="eaE-oF-5c4"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vIR-Ju-2SR">
+                                            <rect key="frame" x="138.5" y="10" width="42" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFY-oI-i1Y">
+                                            <rect key="frame" x="138.5" y="41" width="235.5" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="vIR-Ju-2SR" firstAttribute="leading" secondItem="ocx-3f-ii9" secondAttribute="trailing" constant="15" id="2eS-Hy-L6g"/>
+                                        <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="xFY-oI-i1Y" secondAttribute="bottom" id="6xA-Qq-fos"/>
+                                        <constraint firstItem="ocx-3f-ii9" firstAttribute="top" secondItem="QIe-Vp-kRT" secondAttribute="top" constant="20" id="9o4-hw-wUa"/>
+                                        <constraint firstItem="xFY-oI-i1Y" firstAttribute="top" secondItem="vIR-Ju-2SR" secondAttribute="bottom" constant="10" id="CSd-m2-Qgt"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="xFY-oI-i1Y" secondAttribute="trailing" constant="20" id="RH8-mh-qFZ"/>
+                                        <constraint firstItem="vIR-Ju-2SR" firstAttribute="top" secondItem="QIe-Vp-kRT" secondAttribute="top" constant="10" id="hOO-7W-TF0"/>
+                                        <constraint firstItem="xFY-oI-i1Y" firstAttribute="leading" secondItem="vIR-Ju-2SR" secondAttribute="leading" id="vbp-8A-Jrv"/>
+                                        <constraint firstItem="ocx-3f-ii9" firstAttribute="width" secondItem="QIe-Vp-kRT" secondAttribute="width" multiplier="0.25" id="wJm-9Y-1vB"/>
+                                        <constraint firstItem="ocx-3f-ii9" firstAttribute="leading" secondItem="QIe-Vp-kRT" secondAttribute="leading" constant="20" id="wV5-eU-hth"/>
+                                    </constraints>
                                 </tableViewCellContentView>
+                                <constraints>
+                                    <constraint firstItem="ocx-3f-ii9" firstAttribute="centerY" secondItem="ZTC-Ff-zZV" secondAttribute="centerY" id="edy-fU-JnS"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="entryDescription" destination="xFY-oI-i1Y" id="SQi-7n-tHg"/>
+                                    <outlet property="entryImage" destination="ocx-3f-ii9" id="PjU-UZ-NE6"/>
+                                    <outlet property="entryTitle" destination="vIR-Ju-2SR" id="1Ce-pE-8Ab"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -192,7 +231,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dBX-ic-TIG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="839" y="-6"/>
+            <point key="canvasLocation" x="837.68115942028987" y="-6.0267857142857144"/>
         </scene>
     </scenes>
     <resources>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -194,7 +194,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFY-oI-i1Y">
-                                            <rect key="frame" x="138.5" y="41" width="235.5" height="21"/>
+                                            <rect key="frame" x="138.5" y="36" width="250.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -204,8 +204,8 @@
                                         <constraint firstItem="vIR-Ju-2SR" firstAttribute="leading" secondItem="ocx-3f-ii9" secondAttribute="trailing" constant="15" id="2eS-Hy-L6g"/>
                                         <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="xFY-oI-i1Y" secondAttribute="bottom" id="6xA-Qq-fos"/>
                                         <constraint firstItem="ocx-3f-ii9" firstAttribute="top" secondItem="QIe-Vp-kRT" secondAttribute="top" constant="20" id="9o4-hw-wUa"/>
-                                        <constraint firstItem="xFY-oI-i1Y" firstAttribute="top" secondItem="vIR-Ju-2SR" secondAttribute="bottom" constant="10" id="CSd-m2-Qgt"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="xFY-oI-i1Y" secondAttribute="trailing" constant="20" id="RH8-mh-qFZ"/>
+                                        <constraint firstItem="xFY-oI-i1Y" firstAttribute="top" secondItem="vIR-Ju-2SR" secondAttribute="bottom" constant="5" id="CSd-m2-Qgt"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="xFY-oI-i1Y" secondAttribute="trailing" constant="5" id="RH8-mh-qFZ"/>
                                         <constraint firstItem="vIR-Ju-2SR" firstAttribute="top" secondItem="QIe-Vp-kRT" secondAttribute="top" constant="10" id="hOO-7W-TF0"/>
                                         <constraint firstItem="xFY-oI-i1Y" firstAttribute="leading" secondItem="vIR-Ju-2SR" secondAttribute="leading" id="vbp-8A-Jrv"/>
                                         <constraint firstItem="ocx-3f-ii9" firstAttribute="width" secondItem="QIe-Vp-kRT" secondAttribute="width" multiplier="0.25" id="wJm-9Y-1vB"/>
@@ -219,6 +219,7 @@
                                     <outlet property="entryDescription" destination="xFY-oI-i1Y" id="SQi-7n-tHg"/>
                                     <outlet property="entryImage" destination="ocx-3f-ii9" id="PjU-UZ-NE6"/>
                                     <outlet property="entryTitle" destination="vIR-Ju-2SR" id="1Ce-pE-8Ab"/>
+                                    <segue destination="5Yr-Uh-2w2" kind="show" id="uaW-xs-3zh"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -233,9 +234,82 @@
             </objects>
             <point key="canvasLocation" x="837.68115942028987" y="-6.0267857142857144"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="1F0-fj-pZP">
+            <objects>
+                <viewController id="5Yr-Uh-2w2" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ROR-mv-0c8">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ZU-LP-0NS">
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OI2-O8-Tsh" userLabel="Content View">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="220.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Veo-xA-eiJ" customClass="EntryDetailStackView" customModule="Expo1900" customModuleProvider="target">
+                                                <rect key="frame" x="10" y="10" width="394" height="200.5"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7UT-Ap-6HX">
+                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="180"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="180" id="hiA-Pv-Pl5"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kdv-sC-iRV">
+                                                        <rect key="frame" x="0.0" y="180" width="394" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="7UT-Ap-6HX" firstAttribute="width" secondItem="Veo-xA-eiJ" secondAttribute="width" id="7xg-Sl-Xqv"/>
+                                                </constraints>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                        <constraints>
+                                            <constraint firstItem="Veo-xA-eiJ" firstAttribute="top" secondItem="OI2-O8-Tsh" secondAttribute="top" constant="10" id="LEx-qa-4HS"/>
+                                            <constraint firstAttribute="trailing" secondItem="Veo-xA-eiJ" secondAttribute="trailing" constant="10" id="jch-Ua-KhX"/>
+                                            <constraint firstAttribute="bottom" secondItem="Veo-xA-eiJ" secondAttribute="bottom" constant="10" id="mPo-lQ-t45"/>
+                                            <constraint firstItem="Veo-xA-eiJ" firstAttribute="leading" secondItem="OI2-O8-Tsh" secondAttribute="leading" constant="10" id="zAn-ke-pWw"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="OI2-O8-Tsh" firstAttribute="bottom" secondItem="Ofl-Cr-xqZ" secondAttribute="bottom" id="5ZP-Pb-2xu"/>
+                                    <constraint firstItem="OI2-O8-Tsh" firstAttribute="width" secondItem="MjF-Ue-24w" secondAttribute="width" id="RJV-uQ-CVo"/>
+                                    <constraint firstItem="OI2-O8-Tsh" firstAttribute="trailing" secondItem="Ofl-Cr-xqZ" secondAttribute="trailing" id="RvO-DH-748"/>
+                                    <constraint firstItem="OI2-O8-Tsh" firstAttribute="top" secondItem="Ofl-Cr-xqZ" secondAttribute="top" id="pYC-Jc-d3g"/>
+                                    <constraint firstItem="OI2-O8-Tsh" firstAttribute="leading" secondItem="Ofl-Cr-xqZ" secondAttribute="leading" id="usR-Qd-j8h"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="Ofl-Cr-xqZ"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="MjF-Ue-24w"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="rWE-9p-alj"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="0ZU-LP-0NS" firstAttribute="top" secondItem="rWE-9p-alj" secondAttribute="top" id="FAL-Cc-mXW"/>
+                            <constraint firstItem="0ZU-LP-0NS" firstAttribute="leading" secondItem="rWE-9p-alj" secondAttribute="leading" id="NWc-dK-vUP"/>
+                            <constraint firstAttribute="bottom" secondItem="0ZU-LP-0NS" secondAttribute="bottom" id="aaL-l6-TGo"/>
+                            <constraint firstItem="rWE-9p-alj" firstAttribute="trailing" secondItem="0ZU-LP-0NS" secondAttribute="trailing" id="u5M-0D-UCI"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="7CK-XH-AFi"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bpT-bk-6Xt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1580" y="-6"/>
+        </scene>
     </scenes>
     <resources>
         <image name="flag" width="851" height="567"/>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
     <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -100,12 +100,12 @@
                                                     </stackView>
                                                 </subviews>
                                                 <connections>
-                                                    <outlet property="descriptionLabel" destination="Gh3-5i-q1d" id="Aiu-oM-d2h"/>
-                                                    <outlet property="durationLabel" destination="rgA-mT-8JZ" id="pXx-3J-G8R"/>
-                                                    <outlet property="locationLabel" destination="CR0-HW-0Vw" id="Kki-U9-WPM"/>
-                                                    <outlet property="posterImageView" destination="UlL-jm-ERX" id="AbR-R6-BqT"/>
-                                                    <outlet property="titleLabel" destination="EgD-pD-OlY" id="Tje-cu-zYn"/>
-                                                    <outlet property="visitorsLabel" destination="Qbx-Lx-bvQ" id="DuG-zm-rfh"/>
+                                                    <outlet property="descriptionLabel" destination="Gh3-5i-q1d" id="cJz-sb-8YP"/>
+                                                    <outlet property="durationLabel" destination="rgA-mT-8JZ" id="7ku-vF-cIr"/>
+                                                    <outlet property="locationLabel" destination="CR0-HW-0Vw" id="dQk-yB-dxh"/>
+                                                    <outlet property="posterImageView" destination="UlL-jm-ERX" id="AKJ-X7-HMB"/>
+                                                    <outlet property="titleLabel" destination="EgD-pD-OlY" id="Vlv-F5-ugP"/>
+                                                    <outlet property="visitorsLabel" destination="Qbx-Lx-bvQ" id="G64-pD-4r3"/>
                                                 </connections>
                                             </stackView>
                                         </subviews>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,67 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Expo Information View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ExpoInformationViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vnh-qj-nBR" customClass="ExpoInformationScrollView" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="600" height="556"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h8h-bQ-QY5">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="372.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="372.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QMh-vU-Sig" customClass="InformationStackView" customModule="Expo1900" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="10" width="580" height="352.5"/>
+                                                <rect key="frame" x="10" y="10" width="394" height="352.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EgD-pD-OlY">
-                                                        <rect key="frame" x="0.0" y="0.0" width="580" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UlL-jm-ERX">
-                                                        <rect key="frame" x="0.0" y="20.5" width="580" height="200"/>
+                                                        <rect key="frame" x="0.0" y="20.5" width="394" height="200"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="61R-Ht-o59"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qbx-Lx-bvQ">
-                                                        <rect key="frame" x="0.0" y="220.5" width="580" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="220.5" width="394" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CR0-HW-0Vw">
-                                                        <rect key="frame" x="0.0" y="241" width="580" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="241" width="394" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rgA-mT-8JZ">
-                                                        <rect key="frame" x="0.0" y="261.5" width="580" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="261.5" width="394" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gh3-5i-q1d">
-                                                        <rect key="frame" x="0.0" y="282" width="580" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="282" width="394" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bi4-Iz-xzf" customClass="CustomButtonStackView" customModule="Expo1900" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="302.5" width="580" height="50"/>
+                                                        <rect key="frame" x="0.0" y="302.5" width="394" height="50"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="i6o-AI-A6Q">
                                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -71,7 +73,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bDe-Lb-xjf">
-                                                                <rect key="frame" x="50" y="0.0" width="480" height="50"/>
+                                                                <rect key="frame" x="50" y="0.0" width="294" height="50"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="100" id="bID-fn-0GU"/>
                                                                 </constraints>
@@ -82,7 +84,7 @@
                                                                 </connections>
                                                             </button>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="ohh-U6-lZC">
-                                                                <rect key="frame" x="530" y="0.0" width="50" height="50"/>
+                                                                <rect key="frame" x="344" y="0.0" width="50" height="50"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="50" id="Yvl-su-eoN"/>
                                                                     <constraint firstAttribute="width" constant="50" id="bM5-Fq-l2F"/>
@@ -168,31 +170,31 @@
             <objects>
                 <tableViewController id="NGF-kb-6xj" customClass="EntryListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="7kv-Dm-GpK">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="expoEntryCell" rowHeight="142" id="ZTC-Ff-zZV" customClass="ExpoEntryCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="600" height="142"/>
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="142"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZTC-Ff-zZV" id="QIe-Vp-kRT">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="142"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="142"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ocx-3f-ii9">
-                                            <rect key="frame" x="20" y="20" width="150" height="102"/>
+                                            <rect key="frame" x="20" y="20" width="103.5" height="102"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="ocx-3f-ii9" secondAttribute="height" multiplier="1:1" id="eaE-oF-5c4"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vIR-Ju-2SR">
-                                            <rect key="frame" x="185" y="10" width="42" height="21"/>
+                                            <rect key="frame" x="138.5" y="10" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFY-oI-i1Y">
-                                            <rect key="frame" x="185" y="36" width="390" height="21"/>
+                                            <rect key="frame" x="138.5" y="36" width="250.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -237,26 +239,26 @@
             <objects>
                 <viewController id="5Yr-Uh-2w2" customClass="EntryDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ROR-mv-0c8">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ZU-LP-0NS">
-                                <rect key="frame" x="0.0" y="44" width="600" height="556"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OI2-O8-Tsh" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="220.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="220.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Veo-xA-eiJ" customClass="EntryDetailStackView" customModule="Expo1900" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="10" width="580" height="200.5"/>
+                                                <rect key="frame" x="10" y="10" width="394" height="200.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7UT-Ap-6HX">
-                                                        <rect key="frame" x="0.0" y="0.0" width="580" height="180"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="180"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="180" id="hiA-Pv-Pl5"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kdv-sC-iRV">
-                                                        <rect key="frame" x="0.0" y="180" width="580" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="180" width="394" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -23,7 +23,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h8h-bQ-QY5">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="372.5"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QMh-vU-Sig" customClass="InformationStackView" customModule="Expo1900" customModuleProvider="target">
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QMh-vU-Sig" customClass="ExpoInformationStackView" customModule="Expo1900" customModuleProvider="target">
                                                 <rect key="frame" x="10" y="10" width="394" height="352.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EgD-pD-OlY">
@@ -62,7 +62,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bi4-Iz-xzf" customClass="CustomButtonStackView" customModule="Expo1900" customModuleProvider="target">
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bi4-Iz-xzf" customClass="EntryListButtonStackView" customModule="Expo1900" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="302.5" width="394" height="50"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="i6o-AI-A6Q">
@@ -92,7 +92,7 @@
                                                             </imageView>
                                                         </subviews>
                                                         <connections>
-                                                            <outlet property="button" destination="bDe-Lb-xjf" id="LjQ-8O-hIv"/>
+                                                            <outlet property="entryListButton" destination="bDe-Lb-xjf" id="Zni-UY-LGd"/>
                                                             <outlet property="leftImageView" destination="i6o-AI-A6Q" id="cUA-if-iUG"/>
                                                             <outlet property="rightImageView" destination="ohh-U6-lZC" id="plo-aZ-4bj"/>
                                                         </connections>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -14,56 +12,56 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vnh-qj-nBR" customClass="ExpoInformationScrollView" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="44" width="600" height="556"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h8h-bQ-QY5">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="372.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="372.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QMh-vU-Sig" customClass="InformationStackView" customModule="Expo1900" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="10" width="394" height="352.5"/>
+                                                <rect key="frame" x="10" y="10" width="580" height="352.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EgD-pD-OlY">
-                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="580" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="UlL-jm-ERX">
-                                                        <rect key="frame" x="0.0" y="20.5" width="394" height="200"/>
+                                                        <rect key="frame" x="0.0" y="20.5" width="580" height="200"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="200" id="61R-Ht-o59"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qbx-Lx-bvQ">
-                                                        <rect key="frame" x="0.0" y="220.5" width="394" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="220.5" width="580" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CR0-HW-0Vw">
-                                                        <rect key="frame" x="0.0" y="241" width="394" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="241" width="580" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rgA-mT-8JZ">
-                                                        <rect key="frame" x="0.0" y="261.5" width="394" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="261.5" width="580" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gh3-5i-q1d">
-                                                        <rect key="frame" x="0.0" y="282" width="394" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="282" width="580" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bi4-Iz-xzf" customClass="CustomButtonStackView" customModule="Expo1900" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="302.5" width="394" height="50"/>
+                                                        <rect key="frame" x="0.0" y="302.5" width="580" height="50"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="i6o-AI-A6Q">
                                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -73,7 +71,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bDe-Lb-xjf">
-                                                                <rect key="frame" x="50" y="0.0" width="294" height="50"/>
+                                                                <rect key="frame" x="50" y="0.0" width="480" height="50"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="100" id="bID-fn-0GU"/>
                                                                 </constraints>
@@ -84,7 +82,7 @@
                                                                 </connections>
                                                             </button>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="ohh-U6-lZC">
-                                                                <rect key="frame" x="344" y="0.0" width="50" height="50"/>
+                                                                <rect key="frame" x="530" y="0.0" width="50" height="50"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="50" id="Yvl-su-eoN"/>
                                                                     <constraint firstAttribute="width" constant="50" id="bM5-Fq-l2F"/>
@@ -163,38 +161,38 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="V0b-Jc-9Ug" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-816" y="-6"/>
+            <point key="canvasLocation" x="-745" y="-6"/>
         </scene>
         <!--Entry List View Controller-->
         <scene sceneID="NB8-14-PUK">
             <objects>
                 <tableViewController id="NGF-kb-6xj" customClass="EntryListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="7kv-Dm-GpK">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="expoEntryCell" rowHeight="142" id="ZTC-Ff-zZV" customClass="ExpoEntryCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="142"/>
+                                <rect key="frame" x="0.0" y="44.5" width="600" height="142"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZTC-Ff-zZV" id="QIe-Vp-kRT">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="142"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="142"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ocx-3f-ii9">
-                                            <rect key="frame" x="20" y="20" width="103.5" height="102"/>
+                                            <rect key="frame" x="20" y="20" width="150" height="102"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="ocx-3f-ii9" secondAttribute="height" multiplier="1:1" id="eaE-oF-5c4"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vIR-Ju-2SR">
-                                            <rect key="frame" x="138.5" y="10" width="42" height="21"/>
+                                            <rect key="frame" x="185" y="10" width="42" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xFY-oI-i1Y">
-                                            <rect key="frame" x="138.5" y="36" width="250.5" height="21"/>
+                                            <rect key="frame" x="185" y="36" width="390" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -239,26 +237,26 @@
             <objects>
                 <viewController id="5Yr-Uh-2w2" customClass="EntryDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ROR-mv-0c8">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ZU-LP-0NS">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="44" width="600" height="556"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OI2-O8-Tsh" userLabel="Content View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="220.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="220.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Veo-xA-eiJ" customClass="EntryDetailStackView" customModule="Expo1900" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="10" width="394" height="200.5"/>
+                                                <rect key="frame" x="10" y="10" width="580" height="200.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7UT-Ap-6HX">
-                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="180"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="580" height="180"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="180" id="hiA-Pv-Pl5"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kdv-sC-iRV">
-                                                        <rect key="frame" x="0.0" y="180" width="394" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="180" width="580" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -303,7 +301,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="7CK-XH-AFi"/>
                     <connections>
-                        <outlet property="detailStackView" destination="Veo-xA-eiJ" id="Caj-j3-GBA"/>
+                        <outlet property="entryDetailStackView" destination="Veo-xA-eiJ" id="Caj-j3-GBA"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bpT-bk-6Xt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qw5-UT-2bA">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -219,7 +219,7 @@
                                     <outlet property="entryDescription" destination="xFY-oI-i1Y" id="SQi-7n-tHg"/>
                                     <outlet property="entryImage" destination="ocx-3f-ii9" id="PjU-UZ-NE6"/>
                                     <outlet property="entryTitle" destination="vIR-Ju-2SR" id="1Ce-pE-8Ab"/>
-                                    <segue destination="5Yr-Uh-2w2" kind="show" id="uaW-xs-3zh"/>
+                                    <segue destination="5Yr-Uh-2w2" kind="show" identifier="showDetailSegueIdentifier" id="uaW-xs-3zh"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -234,10 +234,10 @@
             </objects>
             <point key="canvasLocation" x="837.68115942028987" y="-6.0267857142857144"/>
         </scene>
-        <!--View Controller-->
+        <!--Entry Detail View Controller-->
         <scene sceneID="1F0-fj-pZP">
             <objects>
-                <viewController id="5Yr-Uh-2w2" sceneMemberID="viewController">
+                <viewController id="5Yr-Uh-2w2" customClass="EntryDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="ROR-mv-0c8">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -267,9 +267,12 @@
                                                 <constraints>
                                                     <constraint firstItem="7UT-Ap-6HX" firstAttribute="width" secondItem="Veo-xA-eiJ" secondAttribute="width" id="7xg-Sl-Xqv"/>
                                                 </constraints>
+                                                <connections>
+                                                    <outlet property="entryDescriptionLabel" destination="kdv-sC-iRV" id="sBc-bB-758"/>
+                                                    <outlet property="entryImageView" destination="7UT-Ap-6HX" id="hic-62-00q"/>
+                                                </connections>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                         <constraints>
                                             <constraint firstItem="Veo-xA-eiJ" firstAttribute="top" secondItem="OI2-O8-Tsh" secondAttribute="top" constant="10" id="LEx-qa-4HS"/>
                                             <constraint firstAttribute="trailing" secondItem="Veo-xA-eiJ" secondAttribute="trailing" constant="10" id="jch-Ua-KhX"/>
@@ -299,6 +302,9 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="7CK-XH-AFi"/>
+                    <connections>
+                        <outlet property="detailStackView" destination="Veo-xA-eiJ" id="Caj-j3-GBA"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="bpT-bk-6Xt" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -307,9 +313,6 @@
     </scenes>
     <resources>
         <image name="flag" width="851" height="567"/>
-        <systemColor name="opaqueSeparatorColor">
-            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -1,8 +1,19 @@
 import UIKit
 
 class EntryDetailViewController: UIViewController {
-
+    @IBOutlet weak var detailStackView: EntryDetailStackView!
+    
+    var expoEntry: ExpoEntry?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        setUpDetailView()
     }
+    
+    func setUpDetailView() {
+        if let data = expoEntry {
+            detailStackView.setUp(data: data)
+        }
+    }
+    
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class EntryDetailViewController: UIViewController {
-    @IBOutlet weak var detailStackView: EntryDetailStackView!
+    @IBOutlet private weak var detailStackView: EntryDetailStackView!
     
     var expoEntry: ExpoEntry?
     
@@ -10,7 +10,7 @@ class EntryDetailViewController: UIViewController {
         setUpDetailView()
     }
     
-    func setUpDetailView() {
+    private func setUpDetailView() {
         guard let data = expoEntry else {
             return
         }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+class EntryDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -12,19 +12,19 @@ class EntryDetailViewController: UIViewController {
     }
     
     private func setUpDetailView() {
-        guard let entryData = expoEntry else {
+        guard let model = expoEntry else {
             return
         }
         
-        entryDetailStackView.setUpView(from: entryData)
-        entryDetailStackView.setUpImageAccessibility(from: entryData)
+        entryDetailStackView.setUpView(from: model)
+        entryDetailStackView.setUpImageAccessibility(from: model)
     }
     
     private func setUpTitle() {
-        guard let entryData = expoEntry else {
+        guard let model = expoEntry else {
             return
         }
         
-        title = entryData.name
+        title = model.name
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class EntryDetailViewController: UIViewController {
-    @IBOutlet private weak var detailStackView: EntryDetailStackView!
+    @IBOutlet private weak var entryDetailStackView: EntryDetailStackView!
     
     var expoEntry: ExpoEntry?
     
@@ -15,7 +15,7 @@ class EntryDetailViewController: UIViewController {
             return
         }
         
-        detailStackView.setUp(data: data)
+        entryDetailStackView.setUpView(from: data)
         self.title = data.name
     }
     

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -18,5 +18,4 @@ class EntryDetailViewController: UIViewController {
         entryDetailStackView.setUpView(from: data)
         title = data.name
     }
-    
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -11,9 +11,12 @@ class EntryDetailViewController: UIViewController {
     }
     
     func setUpDetailView() {
-        if let data = expoEntry {
-            detailStackView.setUp(data: data)
+        guard let data = expoEntry else {
+            return
         }
+        
+        detailStackView.setUp(data: data)
+        self.title = data.name
     }
     
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -8,15 +8,23 @@ class EntryDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpDetailView()
+        setUpTitle()
     }
     
     private func setUpDetailView() {
-        guard let data = expoEntry else {
+        guard let entryData = expoEntry else {
             return
         }
         
-        entryDetailStackView.setUpView(from: data)
-        entryDetailStackView.setUpImageAccessibility(from: data)
-        title = data.name
+        entryDetailStackView.setUpView(from: entryData)
+        entryDetailStackView.setUpImageAccessibility(from: entryData)
+    }
+    
+    private func setUpTitle() {
+        guard let entryData = expoEntry else {
+            return
+        }
+        
+        title = entryData.name
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -16,7 +16,7 @@ class EntryDetailViewController: UIViewController {
         }
         
         entryDetailStackView.setUpView(from: data)
-        self.title = data.name
+        title = data.name
     }
     
 }

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -6,6 +6,8 @@ class EntryListViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setExpoEntryData()
+        self.title = "한국의 출품작"
+        self.navigationItem.backButtonTitle = "메인"
     }
     
     private func setExpoEntryData() {
@@ -30,8 +32,14 @@ extension EntryListViewController {
         return expoEntries.count
     }
     
-//    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-//        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
-//        return cell
-//    }
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "expoEntryCell", for: indexPath) as? ExpoEntryCell else {
+            fatalError("")
+        }
+        
+        let entry = expoEntries[indexPath.row]
+        cell.setUp(data: entry)
+        
+        return cell
+    }
 }

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -13,16 +13,6 @@ class EntryListViewController: UITableViewController {
     private func setExpoEntryData() {
         expoEntries = Parser<[ExpoEntry]>.decode(from: .items) ?? []
     }
-    
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 }
 
 // MARK: - Table view data source
@@ -41,5 +31,21 @@ extension EntryListViewController {
         cell.setUp(data: entry)
         
         return cell
+    }
+}
+
+// MARK: - Navigation
+
+extension EntryListViewController {
+    static let showDetailSegueIdentifier = "showDetailSegueIdentifier"
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        guard segue.identifier == Self.showDetailSegueIdentifier,
+              let destination = segue.destination as? EntryDetailViewController,
+              let indexPath = tableView.indexPathForSelectedRow else {
+                  return
+              }
+        
+        destination.expoEntry = expoEntries[indexPath.row]
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -1,16 +1,9 @@
 import UIKit
 
 class EntryListViewController: UITableViewController {
-    private var expoEntries: [ExpoEntry] = []
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-        setExpoEntryData()
         setTitle()
-    }
-    
-    private func setExpoEntryData() {
-        expoEntries = Parser<[ExpoEntry]>.decode(from: .items) ?? []
     }
 }
 
@@ -26,7 +19,7 @@ extension EntryListViewController {
 
 extension EntryListViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return expoEntries.count
+        return ExpoEntries.list.count
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -34,7 +27,7 @@ extension EntryListViewController {
             fatalError("")
         }
         
-        let entry = expoEntries[indexPath.row]
+        let entry = ExpoEntries.list[indexPath.row]
         cell.setUpView(from: entry)
         
         return cell
@@ -53,6 +46,6 @@ extension EntryListViewController {
                   return
               }
         
-        destination.expoEntry = expoEntries[indexPath.row]
+        destination.expoEntry = ExpoEntries.list[indexPath.row]
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -35,7 +35,7 @@ extension EntryListViewController {
         }
         
         let entry = expoEntries[indexPath.row]
-        cell.setUp(data: entry)
+        cell.setUpView(from: entry)
         
         return cell
     }

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -17,7 +17,7 @@ class EntryListViewController: UITableViewController {
 // MARK: - Method
 
 extension EntryListViewController {
-    func setTitle() {
+    private func setTitle() {
         self.title = "한국의 출품작"
     }
 }
@@ -44,7 +44,7 @@ extension EntryListViewController {
 // MARK: - Navigation
 
 extension EntryListViewController {
-    static let showDetailSegueIdentifier = "showDetailSegueIdentifier"
+    static private let showDetailSegueIdentifier = "showDetailSegueIdentifier"
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard segue.identifier == Self.showDetailSegueIdentifier,

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -18,7 +18,7 @@ class EntryListViewController: UITableViewController {
 
 extension EntryListViewController {
     private func setTitle() {
-        self.title = "한국의 출품작"
+        title = "한국의 출품작"
     }
 }
 

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -5,25 +5,23 @@ class EntryListViewController: UITableViewController {
         super.viewDidLoad()
         setTitle()
     }
-}
-
-// MARK: - Method
-
-extension EntryListViewController {
+    
+    // MARK: - Method
+    
     private func setTitle() {
         title = "한국의 출품작"
     }
-}
-
-// MARK: - Table view data source
-
-extension EntryListViewController {
+    
+    // MARK: - Table view data source
+    
+    private let customCellIdentifier = "expoEntryCell"
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return ExpoEntries.list.count
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "expoEntryCell", for: indexPath) as? ExpoEntryCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: customCellIdentifier, for: indexPath) as? ExpoEntryCell else {
             fatalError("")
         }
         
@@ -32,15 +30,13 @@ extension EntryListViewController {
         
         return cell
     }
-}
-
-// MARK: - Navigation
-
-extension EntryListViewController {
-    static private let showDetailSegueIdentifier = "showDetailSegueIdentifier"
+    
+    // MARK: - Navigation
+    
+    private let showDetailSegueIdentifier = "showDetailSegueIdentifier"
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        guard segue.identifier == Self.showDetailSegueIdentifier,
+        guard segue.identifier == showDetailSegueIdentifier,
               let destination = segue.destination as? EntryDetailViewController,
               let indexPath = tableView.indexPathForSelectedRow else {
                   return

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -1,74 +1,17 @@
 import UIKit
 
 class EntryListViewController: UITableViewController {
+    private var expoEntries: [ExpoEntry] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+        setExpoEntryData()
     }
     
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
+    private func setExpoEntryData() {
+        expoEntries = Parser<[ExpoEntry]>.decode(from: .items) ?? []
     }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return 0
-    }
-
-    /*
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
-
-        // Configure the cell...
-
-        return cell
-    }
-    */
-
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
+    
     /*
     // MARK: - Navigation
 
@@ -78,5 +21,17 @@ class EntryListViewController: UITableViewController {
         // Pass the selected object to the new view controller.
     }
     */
+}
 
+// MARK: - Table view data source
+
+extension EntryListViewController {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return expoEntries.count
+    }
+    
+//    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+//        return cell
+//    }
 }

--- a/Expo1900/Expo1900/Controller/EntryListViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryListViewController.swift
@@ -6,12 +6,19 @@ class EntryListViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setExpoEntryData()
-        self.title = "한국의 출품작"
-        self.navigationItem.backButtonTitle = "메인"
+        setTitle()
     }
     
     private func setExpoEntryData() {
         expoEntries = Parser<[ExpoEntry]>.decode(from: .items) ?? []
+    }
+}
+
+// MARK: - Method
+
+extension EntryListViewController {
+    func setTitle() {
+        self.title = "한국의 출품작"
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class ExpoInformationViewController: UIViewController {
     
-    @IBOutlet weak var informationStackView: ExpoInformationStackView!
+    @IBOutlet weak var informationStackView: InformationStackView!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ViewController: UIViewController {
+class ExpoInformationViewController: UIViewController {
     
     @IBOutlet weak var informationStackView: InformationStackView!
     
@@ -19,19 +19,15 @@ class ViewController: UIViewController {
         super.viewWillDisappear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
     }
-}
-
-// MARK: - Method
-
-extension ViewController {
-    func setTitle() {
+    
+    // MARK: - Private Method
+    
+    private func setTitle() {
         title = "메인"
     }
-}
-
-// MARK: - CustomView SetUp
-
-extension ViewController {
+    
+    // MARK: - CustomView SetUp
+    
     func informationStackViewSetUp() {
         guard let data = Parser<ExpoInformation>.decode(from: .expositionUniverselle1900) else {
             return

--- a/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class ExpoInformationViewController: UIViewController {
     
-    @IBOutlet weak var informationStackView: InformationStackView!
+    @IBOutlet weak var informationStackView: ExpoInformationStackView!
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
@@ -29,9 +29,9 @@ class ExpoInformationViewController: UIViewController {
     // MARK: - CustomView SetUp
     
     func informationStackViewSetUp() {
-        guard let data = Parser<ExpoInformation>.decode(from: .expositionUniverselle1900) else {
+        guard let informationData = Parser<ExpoInformation>.decode(from: .expositionUniverselle1900) else {
             return
         }
-        informationStackView.setUpView(from: data)
+        informationStackView.setUpView(from: informationData)
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoInformationViewController.swift
@@ -29,9 +29,9 @@ class ExpoInformationViewController: UIViewController {
     // MARK: - CustomView SetUp
     
     func informationStackViewSetUp() {
-        guard let informationData = Parser<ExpoInformation>.decode(from: .expositionUniverselle1900) else {
+        guard let model = Parser<ExpoInformation>.decode(from: .expositionUniverselle1900) else {
             return
         }
-        informationStackView.setUpView(from: informationData)
+        informationStackView.setUpView(from: model)
     }
 }

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -36,6 +36,6 @@ extension ViewController {
         guard let data = Parser<ExpoInformation>.decode(from: .expositionUniverselle1900) else {
             return
         }
-        informationStackView.setUp(data: data)
+        informationStackView.setUpView(from: data)
     }
 }

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -15,8 +15,8 @@ class ViewController: UIViewController {
         self.navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
     }
 }

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -7,7 +7,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         informationStackViewSetUp()
-        self.title = "메인"
+        setTitle()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -18,6 +18,14 @@ class ViewController: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         self.navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+}
+
+// MARK: - Method
+
+extension ViewController {
+    func setTitle() {
+        self.title = "메인"
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
 
 extension ViewController {
     func setTitle() {
-        self.title = "메인"
+        title = "메인"
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -18,7 +18,6 @@ class ViewController: UIViewController {
         super.viewDidDisappear(animated)
         self.navigationController?.isNavigationBarHidden = false
     }
-
 }
 
 // MARK: - CustomView SetUp

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -7,16 +7,17 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         informationStackViewSetUp()
+        self.title = "메인"
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.isNavigationBarHidden = true
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        self.navigationController?.isNavigationBarHidden = false
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
     }
 }
 

--- a/Expo1900/Expo1900/Model/DecimalNumberFormatter.swift
+++ b/Expo1900/Expo1900/Model/DecimalNumberFormatter.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 enum DecimalNumberFormatter {
-    static func string(for obj: Any?) -> String {
+    static func string(for obj: Any?) -> String? {
         let formatter = NumberFormatter()
         
         formatter.numberStyle = .decimal
         
-        return formatter.string(for: obj) ?? String()
+        return formatter.string(for: obj)
     }
 }

--- a/Expo1900/Expo1900/Model/ExpoEntries.swift
+++ b/Expo1900/Expo1900/Model/ExpoEntries.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ExpoEntries {
+    static var list: [ExpoEntry] {
+        return Parser<[ExpoEntry]>.decode(from: .items) ?? []
+    }
+}

--- a/Expo1900/Expo1900/View/CustomButtonStackView.swift
+++ b/Expo1900/Expo1900/View/CustomButtonStackView.swift
@@ -1,8 +1,8 @@
 import UIKit
 
-class CustomButtonStackView: UIStackView {
+class EntryListButtonStackView: UIStackView {
     @IBOutlet private weak var leftImageView: UIImageView!
-    @IBOutlet private weak var button: UIButton!
+    @IBOutlet private weak var entryListButton: UIButton!
     @IBOutlet private weak var rightImageView: UIImageView!
     
     required init(coder: NSCoder) {
@@ -17,6 +17,6 @@ class CustomButtonStackView: UIStackView {
     private func setUpView() {
         leftImageView.image = UIImage(named: "flag")
         rightImageView.image = UIImage(named: "flag")
-        button.setTitle("한국의 출품작 보러가기", for: .normal)
+        entryListButton.setTitle("한국의 출품작 보러가기", for: .normal)
     }
 }

--- a/Expo1900/Expo1900/View/CustomButtonStackView.swift
+++ b/Expo1900/Expo1900/View/CustomButtonStackView.swift
@@ -11,10 +11,10 @@ class CustomButtonStackView: UIStackView {
     
     override func awakeFromNib() {
         super.awakeFromNib()
-        setUp()
+        setUpView()
     }
     
-    private func setUp() {
+    private func setUpView() {
         leftImageView.image = UIImage(named: "flag")
         rightImageView.image = UIImage(named: "flag")
         button.setTitle("한국의 출품작 보러가기", for: .normal)

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -15,13 +15,13 @@ class EntryDetailStackView: UIStackView {
         setUpLabelTextLines()
     }
     
-    func setUpView(from data: ExpoEntry) {
-        entryImageView.image = UIImage(named: data.imageName)
-        entryDescriptionLabel.text = data.description
+    func setUpView(from entryData: ExpoEntry) {
+        entryImageView.image = UIImage(named: entryData.imageName)
+        entryDescriptionLabel.text = entryData.description
     }
     
-    func setUpImageAccessibility(from data: ExpoEntry) {
-        entryImageView.accessibilityLabel = data.name
+    func setUpImageAccessibility(from entryData: ExpoEntry) {
+        entryImageView.accessibilityLabel = entryData.name
         entryImageView.isAccessibilityElement = true
     }
     

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -15,13 +15,13 @@ class EntryDetailStackView: UIStackView {
         setUpLabelTextLines()
     }
     
-    func setUpView(from entryData: ExpoEntry) {
-        entryImageView.image = UIImage(named: entryData.imageName)
-        entryDescriptionLabel.text = entryData.description
+    func setUpView(from model: ExpoEntry) {
+        entryImageView.image = UIImage(named: model.imageName)
+        entryDescriptionLabel.text = model.description
     }
     
-    func setUpImageAccessibility(from entryData: ExpoEntry) {
-        entryImageView.accessibilityLabel = entryData.name
+    func setUpImageAccessibility(from model: ExpoEntry) {
+        entryImageView.accessibilityLabel = model.name
         entryImageView.isAccessibilityElement = true
     }
     

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class EntryDetailStackView: UIStackView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -1,13 +1,19 @@
 import UIKit
 
 class EntryDetailStackView: UIStackView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    @IBOutlet weak var entryImageView: UIImageView!
+    @IBOutlet weak var entryDescriptionLabel: UILabel!
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
     }
-    */
-
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+    
+    func setUp(data: ExpoEntry) {
+        entryImageView.image = UIImage(named: data.imageName)
+        entryDescriptionLabel.text = data.description
+    }
 }

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -18,7 +18,7 @@ class EntryDetailStackView: UIStackView {
         entryDescriptionLabel.text = data.description
     }
     
-    func setUpStyle() {
+    private func setUpStyle() {
         self.spacing = 10
         entryDescriptionLabel.numberOfLines = 0
     }

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -13,7 +13,7 @@ class EntryDetailStackView: UIStackView {
         setUpStyle()
     }
     
-    func setUp(data: ExpoEntry) {
+    func setUpView(from data: ExpoEntry) {
         entryImageView.image = UIImage(named: data.imageName)
         entryDescriptionLabel.text = data.description
     }

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -10,10 +10,16 @@ class EntryDetailStackView: UIStackView {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        setUpStyle()
     }
     
     func setUp(data: ExpoEntry) {
         entryImageView.image = UIImage(named: data.imageName)
         entryDescriptionLabel.text = data.description
+    }
+    
+    func setUpStyle() {
+        self.spacing = 10
+        entryDescriptionLabel.numberOfLines = 0
     }
 }

--- a/Expo1900/Expo1900/View/EntryDetailStackView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailStackView.swift
@@ -19,7 +19,8 @@ class EntryDetailStackView: UIStackView {
     }
     
     private func setUpStyle() {
-        self.spacing = 10
+        spacing = 10
+        
         entryDescriptionLabel.numberOfLines = 0
     }
 }

--- a/Expo1900/Expo1900/View/EntryListButtonStackView.swift
+++ b/Expo1900/Expo1900/View/EntryListButtonStackView.swift
@@ -12,13 +12,16 @@ class EntryListButtonStackView: UIStackView {
     override func awakeFromNib() {
         super.awakeFromNib()
         setUpView()
+        setUpButtonStyle()
     }
     
     private func setUpView() {
         leftImageView.image = UIImage(named: "flag")
         rightImageView.image = UIImage(named: "flag")
-        
         entryListButton.setTitle("한국의 출품작 보러가기", for: .normal)
+    }
+    
+    private func setUpButtonStyle() {
         entryListButton.titleLabel?.setUpDynamicFont(forTextStyle: .body)
         entryListButton.titleLabel?.numberOfLines = 1
     }

--- a/Expo1900/Expo1900/View/ExpoEntryCell.swift
+++ b/Expo1900/Expo1900/View/ExpoEntryCell.swift
@@ -1,0 +1,35 @@
+//
+//  ExpoEntryCell.swift
+//  Expo1900
+//
+//  Created by 황제하 on 2021/12/10.
+//
+
+import UIKit
+
+class ExpoEntryCell: UITableViewCell {
+    @IBOutlet weak var entryTitle: UILabel!
+    @IBOutlet weak var entryDescription: UILabel!
+    @IBOutlet weak var entryImage: UIImageView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setUpStyle()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+    }
+
+    func setUp(data: ExpoEntry) {
+        entryTitle.text = data.name
+        entryImage.image = UIImage(named: data.imageName)
+        entryDescription.text = data.shortDescription
+    }
+    
+    private func setUpStyle() {
+        entryTitle.font = .preferredFont(forTextStyle: .title1)
+        entryDescription.numberOfLines = 0
+        self.accessoryType = .disclosureIndicator
+    }
+}

--- a/Expo1900/Expo1900/View/ExpoEntryCell.swift
+++ b/Expo1900/Expo1900/View/ExpoEntryCell.swift
@@ -1,10 +1,3 @@
-//
-//  ExpoEntryCell.swift
-//  Expo1900
-//
-//  Created by 황제하 on 2021/12/10.
-//
-
 import UIKit
 
 class ExpoEntryCell: UITableViewCell {

--- a/Expo1900/Expo1900/View/ExpoEntryCell.swift
+++ b/Expo1900/Expo1900/View/ExpoEntryCell.swift
@@ -12,14 +12,14 @@ class ExpoEntryCell: UITableViewCell {
         setUpLabelFont()
     }
 
-    func setUpView(from entryData: ExpoEntry) {
-        entryTitle.text = entryData.name
-        entryImage.image = UIImage(named: entryData.imageName)
-        entryDescription.text = entryData.shortDescription
+    func setUpView(from model: ExpoEntry) {
+        entryTitle.text = model.name
+        entryImage.image = UIImage(named: model.imageName)
+        entryDescription.text = model.shortDescription
     }
     
-    func setUpImageAccessibility(from entryData: ExpoEntry) {
-        entryImage.accessibilityLabel = entryData.name
+    func setUpImageAccessibility(from model: ExpoEntry) {
+        entryImage.accessibilityLabel = model.name
         entryImage.isAccessibilityElement = true
     }
     

--- a/Expo1900/Expo1900/View/ExpoEntryCell.swift
+++ b/Expo1900/Expo1900/View/ExpoEntryCell.swift
@@ -14,7 +14,7 @@ class ExpoEntryCell: UITableViewCell {
         super.setSelected(selected, animated: animated)
     }
 
-    func setUp(data: ExpoEntry) {
+    func setUpView(from data: ExpoEntry) {
         entryTitle.text = data.name
         entryImage.image = UIImage(named: data.imageName)
         entryDescription.text = data.shortDescription

--- a/Expo1900/Expo1900/View/ExpoEntryCell.swift
+++ b/Expo1900/Expo1900/View/ExpoEntryCell.swift
@@ -23,6 +23,6 @@ class ExpoEntryCell: UITableViewCell {
     private func setUpStyle() {
         entryTitle.font = .preferredFont(forTextStyle: .title1)
         entryDescription.numberOfLines = 0
-        self.accessoryType = .disclosureIndicator
+        accessoryType = .disclosureIndicator
     }
 }

--- a/Expo1900/Expo1900/View/ExpoEntryCell.swift
+++ b/Expo1900/Expo1900/View/ExpoEntryCell.swift
@@ -12,14 +12,14 @@ class ExpoEntryCell: UITableViewCell {
         setUpLabelFont()
     }
 
-    func setUpView(from data: ExpoEntry) {
-        entryTitle.text = data.name
-        entryImage.image = UIImage(named: data.imageName)
-        entryDescription.text = data.shortDescription
+    func setUpView(from entryData: ExpoEntry) {
+        entryTitle.text = entryData.name
+        entryImage.image = UIImage(named: entryData.imageName)
+        entryDescription.text = entryData.shortDescription
     }
     
-    func setUpImageAccessibility(from data: ExpoEntry) {
-        entryImage.accessibilityLabel = data.name
+    func setUpImageAccessibility(from entryData: ExpoEntry) {
+        entryImage.accessibilityLabel = entryData.name
         entryImage.isAccessibilityElement = true
     }
     

--- a/Expo1900/Expo1900/View/ExpoInformationStackView.swift
+++ b/Expo1900/Expo1900/View/ExpoInformationStackView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class InformationStackView: UIStackView {
+class ExpoInformationStackView: UIStackView {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var posterImageView: UIImageView!
     @IBOutlet private weak var visitorsLabel: UILabel!

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ExpoInformationStackView: UIStackView {
+class InformationStackView: UIStackView {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var posterImageView: UIImageView!
     @IBOutlet private weak var visitorsLabel: UILabel!

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -8,6 +8,8 @@ class InformationStackView: UIStackView {
     @IBOutlet private weak var durationLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
     
+    private let stackViewSpacing: CGFloat = 10
+    
     required init(coder: NSCoder) {
         super.init(coder: coder)
     }
@@ -22,23 +24,29 @@ class InformationStackView: UIStackView {
     }
 
     func setUpView(from informationData: ExpoInformation) {
+        let colon = ":"
+        let visitor = "방문객"
+        let location = "개최지"
+        let duration = "개최 기간"
+        let peopleCountSymbol = "명"
+        
         titleLabel.text = informationData.title.replacingOccurrences(of: "(", with: "\n(")
         posterImageView.image = UIImage(named: "poster")
         if let visitors = DecimalNumberFormatter.string(for: informationData.visitors) {
             let visitorsAttributedText = NSMutableAttributedString()
-                                            .setTextSize(string: "방문객", fontSize: .title3)
-                                            .setTextSize(string: " : \(visitors) 명" , fontSize: .body)
+                .setTextSize(string: visitor, fontSize: .title3)
+                .setTextSize(string: " \(colon) \(visitors) \(peopleCountSymbol)" , fontSize: .body)
             visitorsLabel.attributedText = visitorsAttributedText
         }
         
         let locationAttributedText = NSMutableAttributedString()
-                                        .setTextSize(string: "개최지", fontSize: .title3)
-                                        .setTextSize(string: " : \(informationData.location)" , fontSize: .body)
+                                        .setTextSize(string: location, fontSize: .title3)
+                                        .setTextSize(string: " \(colon) \(informationData.location)" , fontSize: .body)
         locationLabel.attributedText = locationAttributedText
         
         let durationAttributedText = NSMutableAttributedString()
-                                        .setTextSize(string: "개최 기간", fontSize: .title3)
-                                        .setTextSize(string: " : \(informationData.duration)" , fontSize: .body)
+                                        .setTextSize(string: duration, fontSize: .title3)
+                                        .setTextSize(string: " \(colon) \(informationData.duration)" , fontSize: .body)
         durationLabel.attributedText = durationAttributedText
         
         descriptionLabel.text = informationData.description
@@ -50,7 +58,7 @@ class InformationStackView: UIStackView {
     }
     
     private func setUpStackViewSpacing() {
-        spacing = 10
+        spacing = stackViewSpacing
     }
     
     private func setUpLabelAlignment() {

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -27,7 +27,7 @@ class InformationStackView: UIStackView {
     }
     
     private func setUpStyle() {
-        self.spacing = 10
+        spacing = 10
         
         titleLabel.textAlignment = .center
         visitorsLabel.textAlignment = .center

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -20,7 +20,9 @@ class InformationStackView: UIStackView {
     func setUpView(from data: ExpoInformation) {
         titleLabel.text = data.title
         posterImageView.image = UIImage(named: "poster")
-        visitorsLabel.text = "방문객 : " + DecimalNumberFormatter.string(for: data.visitors) + " 명"
+        if let visitors = DecimalNumberFormatter.string(for: data.visitors) {
+            visitorsLabel.text = "방문객 : " + visitors + " 명"
+        }
         locationLabel.text = "개최지 : " + data.location
         durationLabel.text = "개최 기간 : " + data.duration
         descriptionLabel.text = data.description

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -24,29 +24,35 @@ class InformationStackView: UIStackView {
     }
 
     func setUpView(from informationData: ExpoInformation) {
-        let colon = ":"
-        let visitor = "방문객"
-        let location = "개최지"
-        let duration = "개최 기간"
-        let peopleCountSymbol = "명"
-        
+        enum InformationDataSet: String, CustomStringConvertible {
+            case colon = ":"
+            case visitor = "방문객"
+            case location = "개최지"
+            case duration = "개최 기간"
+            case peopleCountSymbol = "명"
+            
+            var description: String {
+                return self.rawValue
+            }
+        }
+    
         titleLabel.text = informationData.title.replacingOccurrences(of: "(", with: "\n(")
         posterImageView.image = UIImage(named: "poster")
         if let visitors = DecimalNumberFormatter.string(for: informationData.visitors) {
             let visitorsAttributedText = NSMutableAttributedString()
-                .setTextSize(string: visitor, fontSize: .title3)
-                .setTextSize(string: " \(colon) \(visitors) \(peopleCountSymbol)" , fontSize: .body)
+                .setTextSize(string: "\(InformationDataSet.visitor)", fontSize: .title3)
+                .setTextSize(string: " \(InformationDataSet.colon) \(visitors) \(InformationDataSet.peopleCountSymbol)" , fontSize: .body)
             visitorsLabel.attributedText = visitorsAttributedText
         }
         
         let locationAttributedText = NSMutableAttributedString()
-                                        .setTextSize(string: location, fontSize: .title3)
-                                        .setTextSize(string: " \(colon) \(informationData.location)" , fontSize: .body)
+            .setTextSize(string: "\(InformationDataSet.location)", fontSize: .title3)
+            .setTextSize(string: " \(InformationDataSet.colon) \(informationData.location)" , fontSize: .body)
         locationLabel.attributedText = locationAttributedText
         
         let durationAttributedText = NSMutableAttributedString()
-                                        .setTextSize(string: duration, fontSize: .title3)
-                                        .setTextSize(string: " \(colon) \(informationData.duration)" , fontSize: .body)
+            .setTextSize(string: "\(InformationDataSet.duration)", fontSize: .title3)
+                                        .setTextSize(string: " \(InformationDataSet.colon) \(informationData.duration)" , fontSize: .body)
         durationLabel.attributedText = durationAttributedText
         
         descriptionLabel.text = informationData.description

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -16,8 +16,8 @@ class InformationStackView: UIStackView {
         super.awakeFromNib()
         setUpStyle()
     }
-    
-    func setUp(data: ExpoInformation) {
+
+    func setUpView(from data: ExpoInformation) {
         titleLabel.text = data.title
         posterImageView.image = UIImage(named: "poster")
         visitorsLabel.text = "방문객 : " + DecimalNumberFormatter.string(for: data.visitors) + " 명"

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -23,7 +23,7 @@ class InformationStackView: UIStackView {
         setUpLabelFont()
     }
 
-    func setUpView(from informationData: ExpoInformation) {
+    func setUpView(from model: ExpoInformation) {
         enum InformationDataSet: String, CustomStringConvertible {
             case colon = ":"
             case visitor = "방문객"
@@ -36,9 +36,9 @@ class InformationStackView: UIStackView {
             }
         }
     
-        titleLabel.text = informationData.title.replacingOccurrences(of: "(", with: "\n(")
+        titleLabel.text = model.title.replacingOccurrences(of: "(", with: "\n(")
         posterImageView.image = UIImage(named: "poster")
-        if let visitors = DecimalNumberFormatter.string(for: informationData.visitors) {
+        if let visitors = DecimalNumberFormatter.string(for: model.visitors) {
             let visitorsAttributedText = NSMutableAttributedString()
                 .setTextSize(string: "\(InformationDataSet.visitor)", fontSize: .title3)
                 .setTextSize(string: " \(InformationDataSet.colon) \(visitors) \(InformationDataSet.peopleCountSymbol)" , fontSize: .body)
@@ -47,15 +47,15 @@ class InformationStackView: UIStackView {
         
         let locationAttributedText = NSMutableAttributedString()
             .setTextSize(string: "\(InformationDataSet.location)", fontSize: .title3)
-            .setTextSize(string: " \(InformationDataSet.colon) \(informationData.location)" , fontSize: .body)
+            .setTextSize(string: " \(InformationDataSet.colon) \(model.location)" , fontSize: .body)
         locationLabel.attributedText = locationAttributedText
         
         let durationAttributedText = NSMutableAttributedString()
             .setTextSize(string: "\(InformationDataSet.duration)", fontSize: .title3)
-                                        .setTextSize(string: " \(InformationDataSet.colon) \(informationData.duration)" , fontSize: .body)
+                                        .setTextSize(string: " \(InformationDataSet.colon) \(model.duration)" , fontSize: .body)
         durationLabel.attributedText = durationAttributedText
         
-        descriptionLabel.text = informationData.description
+        descriptionLabel.text = model.description
     }
     
     private func setUpAccessibilty() {

--- a/Expo1900/Expo1900/View/InformationStackView.swift
+++ b/Expo1900/Expo1900/View/InformationStackView.swift
@@ -21,10 +21,10 @@ class InformationStackView: UIStackView {
         setUpLabelFont()
     }
 
-    func setUpView(from data: ExpoInformation) {        
-        titleLabel.text = data.title.replacingOccurrences(of: "(", with: "\n(")
+    func setUpView(from informationData: ExpoInformation) {
+        titleLabel.text = informationData.title.replacingOccurrences(of: "(", with: "\n(")
         posterImageView.image = UIImage(named: "poster")
-        if let visitors = DecimalNumberFormatter.string(for: data.visitors) {
+        if let visitors = DecimalNumberFormatter.string(for: informationData.visitors) {
             let visitorsAttributedText = NSMutableAttributedString()
                                             .setTextSize(string: "방문객", fontSize: .title3)
                                             .setTextSize(string: " : \(visitors) 명" , fontSize: .body)
@@ -33,15 +33,15 @@ class InformationStackView: UIStackView {
         
         let locationAttributedText = NSMutableAttributedString()
                                         .setTextSize(string: "개최지", fontSize: .title3)
-                                        .setTextSize(string: " : \(data.location)" , fontSize: .body)
+                                        .setTextSize(string: " : \(informationData.location)" , fontSize: .body)
         locationLabel.attributedText = locationAttributedText
         
         let durationAttributedText = NSMutableAttributedString()
                                         .setTextSize(string: "개최 기간", fontSize: .title3)
-                                        .setTextSize(string: " : \(data.duration)" , fontSize: .body)
+                                        .setTextSize(string: " : \(informationData.duration)" , fontSize: .body)
         durationLabel.attributedText = durationAttributedText
         
-        descriptionLabel.text = data.description
+        descriptionLabel.text = informationData.description
     }
     
     private func setUpAccessibilty() {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,221 @@
-## iOS 커리어 스타터 캠프
 
-### 만국박람회 프로젝트 저장소
+## 🇰🇷 만국박람회
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+#### 🗓️ 프로젝트 기간: 2021.12.06 - 2021.12.17
 
+#### Contributor
+🐶 [Allie](https://github.com/wooyani77) 🦖 [허황](https://github.com/hwangjeha) 🐹 [제리](https://github.com/llghdud921)
+
+#### Reviewer
+🍎 [도미닉](https://github.com/AppleCEO)
+
+
+## ❐ UML
+
+![](https://i.imgur.com/sY2NLVO.jpg)
+
+
+## ✏️학습 키워드
+- JSON data Parsing
+- TableView
+- AutoLayout
+- Accessibilty
+- Custom View
+- 화면 회전
+
+
+## 프로젝트 설명
+
+### ✔️ 구현모습
+![](https://i.imgur.com/5OUVpro.gif)
+
+
+#### [**JSON Data를 이용한 테이블 뷰 앱**]
+✔️ 파리 만국박람회에 대한 정보와 출품작 보러가기 기능 
+
+✔️ 파리 박람회의 한국 출품작 리스트 TableView로 구현
+
+✔️ 리스트 출품작 클릭 시 상세 설명 화면 보여주는 기능
+
+✔️ 앱 내 모든 텍스트와 이미지에 VoiceOver 및 Dynamic Font 적용
+
+<br> 
+
+## Step 1. 모델 타입 구현
+
+### 💡 1-1. 구현 내용
+
+- JSON 포멧과 매칭할 모델 타입 구현
+- CodingKeys를 활용해 JSON Data Key와 프로퍼티 명 매칭 
+- JSONDecoder() 재사용성을 위해 제네릭 타입 메소드 `decode()` 구현
+- `decode()` Unit Test 
+
+
+
+
+<br>
+
+
+## Step 2. 화면 구현
+
+### 💡 2-1. 구현 내용
+
+- TableView를 활용한 리스트 화면 구현
+- CustomView로 구현하고 awakeFromNib를 이용하여 각 View의 초기설정 구현  
+- Navigation Controller를 활용한 화면 전환
+- NavigationBar 활성화/비활성화 구현
+
+### ❓ 2-2. 고민했던 점
+- `awakeFromNib()`
+    
+    StoryBoard에서 View를 구성하고 CustomView 클래스에 IBOutlet으로 View와 연결하는 방식을 사용했습니다.
+    
+    `awakeFromNib()`을 사용하기전 CustomView 내부 `init()`에서 `setUp()` 메소드를 사용하여 초기설정을 하려 했으나 
+    
+    오류가 발생해 원인을 찾아보니 뷰 컨트롤러 `loadView()`메소드가 호출되기 전 CustomView 내부 `init()`이 먼저 호출되어
+    
+    메모리 올라가지 않은 뷰에 접근하려 해서 생긴 문제였습니다.
+    
+    `awakeFromNib()` 메소드는 View가 인스턴스화 된 직후 호출되기 때문에
+    
+    커스텀 뷰 초기설정을 `awakeFromNib()`내부에서 호출해 줬습니다.
+    
+    ```swift
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setUp() // 커스텀 뷰 초기 설정하는 메소드
+    }
+    ```
+    
+- Navigation Controller 활성화/비활성화 호출 위치
+    
+    첫번째 main 화면에서는 navigation Bar Item을 나타내지 않기 위해서 ViewLifeCycle 메소드를 이용해 `isNavigationBarButton` 속성을 이용하였습니다.
+    
+    - ViewWillAppear : 화면이 나타나기 전에 navigationBarButton을 숨김
+    - viewWillDisappear : 화면이 사라지고 나서 navigationBarButton를 나타냄
+    
+    ```swift
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.isNavigationBarHidden = true
+    }
+        
+    override func viewWillDisappear(_ animated: Bool) {
+        viewWillDisappear(animated)
+        self.navigationController?.isNavigationBarHidden = false
+    }
+    ```
+
+
+- Custom Cell 구성 방법
+    1. `Xib 파일로 Cell View 구성`
+    2. `StoryBoard에 Cell View 구성`
+    
+    Cell View를 구성할 때 두 가지 방식 모두 적용해봤습니다.
+    
+    2번 방식 `StoryBoard에 Cell View 구성` 방법을 선택한 이유는 `만국박람회 앱`에는 하나의 TableView를 가지고 있어 `Xib 파일의 장점인 View 재사용성`의 이점을 가지지 못하다고 판단했습니다.
+    
+
+<br>
+
+## Step 3. 오토레이아웃 적용
+
+### 💡 3-1. 구현 내용
+- 첫 화면은 세로방향 고정
+- 모든 화면이 다른 아이폰 기기에서도 알맞은 크기로 보여지도록 구현
+- Dynamic Type 적용
+- 텍스트가 잘리거나 줄임표(…) 처리가 되지 않도록 구현
+
+### ❓ 3-2. 고민했던 점
+- 화면 방향 고정에 대한 고민
+    
+    각 `ViewController`에 `supportedInterfaceOrientations` 를 지정하기 보다 상위에 있는 `Controller`인  `navigationController` 에서 화면 방향을 컨트롤 하는 것이 override 측면에서 안전하고 
+    
+    각 `ViewController`에서 방향을 관리하는 것보다 용이하다고 생각했습니다.
+    
+    `navigationController`내부에 `topViewController` 즉, 현재 화면에 가장 상위에 위치한 `ViewController` 정보를 받아서 화면 방향을 조정해주었습니다.
+    
+    ```swift
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        if let _ = self.topViewController as? ExpoInformationViewController {
+            return .portrait
+        } else {
+            return .all
+        }
+    }
+    ```
+    
+
+- Label 내부 텍스트의 사이즈를 각각 다르게 지정해주기위해 `NSMutableAttributedString` 적용
+    
+    <img src="https://i.imgur.com/8pyXdyE.png" width="300" height="100">
+    
+    ```swift
+    // extension으로 메소드 구현
+    extension NSMutableAttributedString {
+        func setTextSize(string: String, fontSize: UIFont.TextStyle) -> Self {
+            let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.preferredFont(forTextStyle: fontSize)]
+            self.append(NSAttributedString(string: string, attributes: attributes))
+            return self
+        }
+    }
+    visitorsLabel.attributedText = NSMutableAttributedString().setTextSize(string: "방문객", fontSize: .title3).setTextSize(string: " : \(visitors) 명" , fontSize: .body)
+    ```
+
+    
+
+- 버튼 title 개행 관련 문제
+    
+    button에 dynamic font를 적용하고 일정 크기 이상은 커지면 버튼의 타이틀에 개행이 일어났습니다.  
+    `numberOfLines = 1` 로 설정하게 되면 개행이 되지 않을 줄 알았는데 개행이 되는 현상이 발생했습니다.
+    
+    <img src="https://i.imgur.com/74Opj4P.png)" width="200" height="150">
+
+    
+    ```swift
+    // 1. numberOfLines 설정 잘됨.
+    // 하지만 버튼을 눌렀을 때 title이 button으로 바뀜.
+    entryListButton.titleLabel?.text = "한국의 출품작 보러가기"
+    entryListButton.titleLabel?.numberOfLines = 1 
+    ```
+    
+    <img src="https://i.imgur.com/n2Yol6q.png" width="200" height="150">
+
+    
+    ```swift
+    // 2. numberOfLines 설정 안됨.
+    entryListButton.setTitle("한국의 출품작 보러가기", for: .normal)
+    entryListButton.titleLabel?.numberOfLines = 1 
+    ```
+    
+    고민해본 결과 버튼 스타일 문제였다는 것을 알게되었습니다
+    
+    스토리보드에서 버튼을 생성하게 되면 버튼 스타일이 기본적으로 `Plain`으로 생성되는데 `Default`로 설정을 바꿔서 테스트 해보니 정상적으로 `numberOfLines = 1` 동작하는 것을 확인했습니다.
+    
+    이를 통해 버튼 스타일 `Plain`, `Default` 등 스타일 별 차이를 알게되었습니다.
+
+<br>
+
+### 💢 3-3. Trouble Shooting
+
+- 디테일 뷰에서 이름이 긴 entry들은 `back button`이 "한국의 출품작"이 아닌 "Back"으로 나오는 것을 확인했습니다. 
+
+    해당 문제가 dynamic Font의 적용할 때 글자가 커지면 짤리는 문제를 발견하여 `navigationBar`의 `title`의 사이즈를 작게 고정시켰는데도 해결되지 않았습니다.
+
+    ![](https://i.imgur.com/Ga3fCUL.png)
+    
+    **문제 해결 시도**
+
+    아래 코드를 이용해서 title 텍스트를 동적으로 변환하는 것을 방지해보았지만
+    동일한 결과가 발생했습니다.
+    
+    ```swift
+    let label = UILabel()
+    label.text = entryData.name
+    label.adjustsFontForContentSizeCategory = false
+        
+    self.navigationItem.titleView = label
+    ```
+    ![](https://i.imgur.com/5kQ3P0q.png)
+
+    


### PR DESCRIPTION
안녕하세요 도미닉(@AppleCEO)

만국박람회 STEP 3 PR 요청 드립니다.

마지막 STEP까지 잘 부탁드립니다😊

## 고민했던 점

- 다이나믹 타입 numberOfLines
    
    다이나믹 타입을 적용하고 크기를 키웠을 때 글자가 생략`(...)`되는 현상이 발생해서
    
    Label의 프레임 크기에 폰트 사이즈를 맞춰주는 설정 `adjustsFontSizeToFitWidth = true`로 설정해 글자가 생략되는 문제는 해결했습니다.
    
    그러다 보니 글자 크기를 키워도 일정 크기 이상으로 커지지 않는 문제가 발생해 `numberOfLines = 0` 으로 설정해주고 개행이 일어나면서 글자도 커지도록 수정해 줬습니다.
    

- 화면 방향 고정에 대한 고민
    
    각 `ViewController`에 `supportedInterfaceOrientations` 를 지정하기 보다 상위에 있는 `Controller`인  `navigationController` 에서 화면 방향을 컨트롤 하는 것이 override 측면에서 안전하고 
    
    각 `ViewController`에서 방향을 관리하는 것보다 용이하다고 생각했습니다.
    
    `navigationController`내부에 `topViewController` 즉, 현재 화면에 가장 상위에 위치한 `ViewController` 정보를 받아서 화면 방향을 조정해주었습니다.
    
```swift
override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
    if let _ = self.topViewController as? ExpoInformationViewController {
        return .portrait
    } else {
        return .all
    }
}
```
    

- Label 내부 텍스트의 사이즈를 각각 다르게 지정해주는 문제
    
    아래와같이 두가지 방법이 있을 것 같은데 extension으로 빼서 작성해주는게 좀 더 깔끔한 것 같다는 생각이 들어서 적용해보았습니다!
    
```swift
// 방법 1. extension으로 빼서 작성해주는 방법
extension NSMutableAttributedString {
    func setTextSize(string: String, fontSize: UIFont.TextStyle) -> Self {
        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.preferredFont(forTextStyle: fontSize)]
        self.append(NSAttributedString(string: string, attributes: attributes))
        return self
    }
}
visitorsLabel.attributedText = NSMutableAttributedString().setTextSize(string: "방문객", fontSize: .title3).setTextSize(string: " : \(visitors) 명" , fontSize: .body)
    
// 방법 2
let visitorsFull = "방문객 : " + visitors + " 명"
let attributedString = NSMutableAttributedString(string: visitorsFull)
attributedString.addAttribute(.font, value: UIFont.preferredFont(forTextStyle: .title3), range: (visitorsFull as NSString).range(of: "방문객"))
visitorsLabel.attributedText = attributedString
```
    

- 버튼 title 개행 관련 문제
    
    button에 dynamic font를 적용하고 일정 크기 이상은 커지면 버튼의 타이틀에 개행이 일어났습니다.
    
    `numberOfLines = 1` 로 설정하게 되면 개행이 되지 않을 줄 알았는데 개행이 되는 현상이 발생했습니다.
    
<img width="242" alt="%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202021-12-16%20%EC%98%A4%ED%9B%84%203 06 30" src="https://user-images.githubusercontent.com/27428188/146348906-060d9a0d-14d5-4bef-b7af-c788169ea649.png">

    
```swift
// 1. numberOfLines 설정 잘됨.
// 하지만 버튼을 눌렀을 때 title이 button으로 바뀜.
entryListButton.titleLabel?.text = "한국의 출품작 보러가기"
entryListButton.titleLabel?.numberOfLines = 1 
```
   
    
<img width="249" alt="%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202021-12-16%20%EC%98%A4%ED%9B%84%203 09 29" src="https://user-images.githubusercontent.com/27428188/146349036-0c0be597-4e88-4e75-b4be-ced0ed3b924d.png">

    
```swift
// 2. numberOfLines 설정 안됨.
entryListButton.setTitle("한국의 출품작 보러가기", for: .normal)
entryListButton.titleLabel?.numberOfLines = 1 
```
    
이리저리 고민해보고 다른 캠퍼들과 의견을 나누다보니 버튼 스타일 문제였다는 것을 알게되었습니다😭
    
스토리보드에서 버튼을 생성하게 되면 버튼 스타일이 기본적으로 `Plain`으로 생성되는데 `Default`로 설정을 바꿔서 테스트 해보니 정상적으로 `numberOfLines = 1` 동작하는 것을 확인했습니다.
    
버튼 스타일 `Plain`, `Default` 등 스타일 별 차이점에 대해서 더 공부해 보겠습니다😊
    

## 해결이 되지 않은 점

- `EntryDetailStackView`에서 `Navigationbar` `backButton` `title`이 짤리는 문제
    
    디테일 뷰에서 이름이 긴 entry들은 `back button`이 "한국의 출품작"이 아닌 "Back"으로 나오는 것을 확인했습니다. 
    
    해당 문제가 dynamic Font의 적용할 때 글자가 커지면 짤리는 문제를 발견하여 `navigationBar`의 `title`의 사이즈를 작게 고정시켰는데도 해결되지 않았습니다.
    
    고민해 본 방법으로도 해결이 되지 않아서 어떤 방법으로 접근해야할지 도미닉의 조언이 필요합니다.. 😇
    
FontSize가 큰 경우
    
![Untitled](https://user-images.githubusercontent.com/27428188/146349127-9553b19e-25d8-4d80-8e40-ccaf3661e10f.png)
    

FontSize가 작은 경우

   
![%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%202021-12-16%20%EC%98%A4%ED%9B%84%205 49 23](https://user-images.githubusercontent.com/27428188/146349199-8c73a2e8-79bd-4a6c-9ea0-7b61426df722.png)
 