### PR TITLE
만국박람회 [STEP3] 릴리, 니콜라스, 아카페라커피

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3A0EB497275F190900C6C9A8 /* ExpositionInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0EB496275F190900C6C9A8 /* ExpositionInformation.swift */; };
 		3AD80167276332BD005DB2B9 /* EntryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD80166276332BD005DB2B9 /* EntryDetailViewController.swift */; };
 		63B18B0C275F1CDA004524FB /* ExpositionEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B18B0B275F1CDA004524FB /* ExpositionEntry.swift */; };
+		63FDD2CA276C74E3009DC373 /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63FDD2C9276C74E2009DC373 /* ContainerViewController.swift */; };
 		89264B372767517D00D4203F /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89264B362767517D00D4203F /* Identifier.swift */; };
 		894199152762E9C200D6015E /* EntriesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 894199142762E9C200D6015E /* EntriesTableViewController.swift */; };
 		89847EB62768370500B9923A /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89847EB52768370500B9923A /* JSONParser.swift */; };
@@ -36,6 +37,7 @@
 		3A0EB496275F190900C6C9A8 /* ExpositionInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionInformation.swift; sourceTree = "<group>"; };
 		3AD80166276332BD005DB2B9 /* EntryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailViewController.swift; sourceTree = "<group>"; };
 		63B18B0B275F1CDA004524FB /* ExpositionEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionEntry.swift; sourceTree = "<group>"; };
+		63FDD2C9276C74E2009DC373 /* ContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
 		89264B362767517D00D4203F /* Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
 		894199142762E9C200D6015E /* EntriesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntriesTableViewController.swift; sourceTree = "<group>"; };
 		89847EB52768370500B9923A /* JSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 				C79FF4B82589F401005FB0FD /* ExpositionInformationViewController.swift */,
 				894199142762E9C200D6015E /* EntriesTableViewController.swift */,
 				3AD80166276332BD005DB2B9 /* EntryDetailViewController.swift */,
+				63FDD2C9276C74E2009DC373 /* ContainerViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -241,6 +244,7 @@
 			files = (
 				C79FF4B92589F401005FB0FD /* ExpositionInformationViewController.swift in Sources */,
 				894199152762E9C200D6015E /* EntriesTableViewController.swift in Sources */,
+				63FDD2CA276C74E3009DC373 /* ContainerViewController.swift in Sources */,
 				89847EB62768370500B9923A /* JSONParser.swift in Sources */,
 				63B18B0C275F1CDA004524FB /* ExpositionEntry.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -237,10 +237,10 @@
             </objects>
             <point key="canvasLocation" x="2337.68115942029" y="114.50892857142857"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Container View Controller-->
         <scene sceneID="waf-wp-EXk">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="fu9-go-kJ5" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="fu9-go-kJ5" customClass="ContainerViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="AaW-BG-zN0">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -17,54 +17,49 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oXG-o2-dfY">
-                                <rect key="frame" x="0.0" y="58" width="414" height="781"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oXG-o2-dfY">
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="J4m-6O-7JJ">
-                                        <rect key="frame" x="0.0" y="-30" width="414" height="781"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="61" translatesAutoresizingMaskIntoConstraints="NO" id="J4m-6O-7JJ">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="694.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UR3-YH-q7t">
-                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="147.5"/>
+                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jb4-nT-GE7">
-                                                <rect key="frame" x="87" y="166.5" width="240" height="128"/>
+                                                <rect key="frame" x="87" y="81.5" width="240" height="50"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8m-PR-AyC">
-                                                <rect key="frame" x="186.5" y="313.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="192.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smh-uU-2We">
-                                                <rect key="frame" x="186.5" y="353" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="274" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8y-JF-8sK">
-                                                <rect key="frame" x="186.5" y="392.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="355.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FZp-L8-DmO">
-                                                <rect key="frame" x="52.5" y="432" width="309" height="300"/>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" editable="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FZp-L8-DmO">
+                                                <rect key="frame" x="2" y="437" width="410.5" height="166.5"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="309" id="GAS-8c-XvZ"/>
-                                                    <constraint firstAttribute="height" constant="300" id="cXr-da-d0x"/>
-                                                </constraints>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="51" translatesAutoresizingMaskIntoConstraints="NO" id="nS9-LG-u8q">
-                                                <rect key="frame" x="92.5" y="751" width="229" height="30"/>
+                                                <rect key="frame" x="92.5" y="664.5" width="229" height="30"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="VdE-NF-wj9">
                                                         <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
@@ -90,13 +85,17 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" priority="250" constant="694.5" id="BOa-h1-r5r"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="bottom" secondItem="FVa-Mm-CYx" secondAttribute="bottom" id="JjI-AK-6EF"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="leading" secondItem="FVa-Mm-CYx" secondAttribute="leading" id="K2b-jl-dqv"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="trailing" secondItem="FVa-Mm-CYx" secondAttribute="trailing" id="ada-7R-Ple"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="top" secondItem="FVa-Mm-CYx" secondAttribute="top" id="gmM-af-g1x"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="leading" secondItem="PfU-uJ-V93" secondAttribute="leading" id="IQq-MG-Vmq"/>
+                                    <constraint firstItem="PfU-uJ-V93" firstAttribute="top" secondItem="J4m-6O-7JJ" secondAttribute="top" id="b9L-SQ-K6h"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="trailing" secondItem="PfU-uJ-V93" secondAttribute="trailing" id="ewN-fE-AHb"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="bottom" secondItem="PfU-uJ-V93" secondAttribute="bottom" id="lFn-bo-7tb"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="width" secondItem="FVa-Mm-CYx" secondAttribute="width" id="pms-gh-3tU"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="PfU-uJ-V93"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="FVa-Mm-CYx"/>
@@ -104,6 +103,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="12c-l9-S2E"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="npK-re-SUe"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="s50-Ka-rcf"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="xa6-e0-he2"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title=" " id="8pj-bl-5uA"/>
                     <connections>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -210,7 +210,7 @@
                                 <constraints>
                                     <constraint firstItem="XhO-RK-4hn" firstAttribute="leading" secondItem="vfG-Nm-z9q" secondAttribute="leading" constant="20" id="Ff1-dF-V3A"/>
                                     <constraint firstItem="XhO-RK-4hn" firstAttribute="width" secondItem="wjM-xb-1Cu" secondAttribute="width" constant="-40" id="P5f-Ri-aOo"/>
-                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="trailing" secondItem="vfG-Nm-z9q" secondAttribute="trailing" id="Yp1-ey-k8H"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="trailing" secondItem="vfG-Nm-z9q" secondAttribute="trailing" constant="-20" id="Yp1-ey-k8H"/>
                                     <constraint firstItem="XhO-RK-4hn" firstAttribute="bottom" secondItem="vfG-Nm-z9q" secondAttribute="bottom" id="anN-6W-vMD"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="vfG-Nm-z9q"/>
@@ -222,8 +222,8 @@
                         <constraints>
                             <constraint firstItem="vfG-Nm-z9q" firstAttribute="top" secondItem="XhO-RK-4hn" secondAttribute="top" constant="-40" id="1XS-LU-K7P"/>
                             <constraint firstItem="PsG-Ew-M3b" firstAttribute="top" secondItem="IHf-QC-6uu" secondAttribute="top" id="5Rg-px-B9t"/>
-                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="leading" secondItem="IHf-QC-6uu" secondAttribute="leading" id="6X0-Li-YSX"/>
-                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="trailing" secondItem="IHf-QC-6uu" secondAttribute="trailing" id="AIZ-Sw-gIv"/>
+                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="leading" secondItem="cjq-Lx-ysY" secondAttribute="leading" id="6X0-Li-YSX"/>
+                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="trailing" secondItem="cjq-Lx-ysY" secondAttribute="trailing" id="AIZ-Sw-gIv"/>
                             <constraint firstItem="PsG-Ew-M3b" firstAttribute="bottom" secondItem="IHf-QC-6uu" secondAttribute="bottom" id="Z2Y-ks-ba4"/>
                         </constraints>
                     </view>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -23,34 +23,34 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="J4m-6O-7JJ">
                                         <rect key="frame" x="20" y="20" width="374" height="694.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UR3-YH-q7t">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UR3-YH-q7t">
                                                 <rect key="frame" x="157.5" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jb4-nT-GE7">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jb4-nT-GE7">
                                                 <rect key="frame" x="67" y="40" width="240" height="50"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8m-PR-AyC">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8m-PR-AyC">
                                                 <rect key="frame" x="166.5" y="100" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8y-JF-8sK">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8y-JF-8sK">
                                                 <rect key="frame" x="166.5" y="130.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smh-uU-2We">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smh-uU-2We">
                                                 <rect key="frame" x="166.5" y="161" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" editable="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FZp-L8-DmO">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" editable="NO" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FZp-L8-DmO">
                                                 <rect key="frame" x="1" y="191.5" width="372.5" height="443"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -18,57 +18,57 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oXG-o2-dfY">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="61" translatesAutoresizingMaskIntoConstraints="NO" id="J4m-6O-7JJ">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="694.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="J4m-6O-7JJ">
+                                        <rect key="frame" x="20" y="20" width="374" height="694.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UR3-YH-q7t">
-                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UR3-YH-q7t">
+                                                <rect key="frame" x="157.5" y="0.0" width="59" height="30"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jb4-nT-GE7">
-                                                <rect key="frame" x="87" y="81.5" width="240" height="50"/>
+                                                <rect key="frame" x="67" y="40" width="240" height="50"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8m-PR-AyC">
-                                                <rect key="frame" x="186.5" y="192.5" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8m-PR-AyC">
+                                                <rect key="frame" x="166.5" y="100" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smh-uU-2We">
-                                                <rect key="frame" x="186.5" y="274" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8y-JF-8sK">
+                                                <rect key="frame" x="166.5" y="130.5" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8y-JF-8sK">
-                                                <rect key="frame" x="186.5" y="355.5" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smh-uU-2We">
+                                                <rect key="frame" x="166.5" y="161" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" editable="NO" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FZp-L8-DmO">
-                                                <rect key="frame" x="2" y="437" width="410.5" height="166.5"/>
+                                                <rect key="frame" x="1" y="191.5" width="372.5" height="443"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="51" translatesAutoresizingMaskIntoConstraints="NO" id="nS9-LG-u8q">
-                                                <rect key="frame" x="92.5" y="664.5" width="229" height="30"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="nS9-LG-u8q">
+                                                <rect key="frame" x="83.5" y="644.5" width="207" height="50"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="VdE-NF-wj9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="VdE-NF-wj9">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="30" id="9py-vu-MUZ"/>
+                                                            <constraint firstAttribute="width" constant="50" id="9py-vu-MUZ"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wpt-6h-ubY">
-                                                        <rect key="frame" x="81" y="0.0" width="67" height="30"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wpt-6h-ubY">
+                                                        <rect key="frame" x="70" y="0.0" width="67" height="50"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                                         <connections>
@@ -76,13 +76,16 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="o1z-bZ-HDR">
-                                                        <rect key="frame" x="199" y="0.0" width="30" height="30"/>
+                                                        <rect key="frame" x="157" y="0.0" width="50" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="o1z-bZ-HDR" secondAttribute="height" multiplier="1:1" id="QUX-sN-fPG"/>
-                                                            <constraint firstAttribute="width" constant="30" id="cZs-NH-i7c"/>
+                                                            <constraint firstAttribute="width" constant="50" id="cZs-NH-i7c"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="VdE-NF-wj9" firstAttribute="height" secondItem="Wpt-6h-ubY" secondAttribute="height" id="9UZ-wa-olP"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <constraints>
@@ -91,11 +94,11 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="leading" secondItem="PfU-uJ-V93" secondAttribute="leading" id="IQq-MG-Vmq"/>
-                                    <constraint firstItem="PfU-uJ-V93" firstAttribute="top" secondItem="J4m-6O-7JJ" secondAttribute="top" id="b9L-SQ-K6h"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="trailing" secondItem="PfU-uJ-V93" secondAttribute="trailing" id="ewN-fE-AHb"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="leading" secondItem="PfU-uJ-V93" secondAttribute="leading" constant="20" id="IQq-MG-Vmq"/>
+                                    <constraint firstItem="PfU-uJ-V93" firstAttribute="top" secondItem="J4m-6O-7JJ" secondAttribute="top" constant="-20" id="b9L-SQ-K6h"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="trailing" secondItem="PfU-uJ-V93" secondAttribute="trailing" constant="-20" id="ewN-fE-AHb"/>
                                     <constraint firstItem="J4m-6O-7JJ" firstAttribute="bottom" secondItem="PfU-uJ-V93" secondAttribute="bottom" id="lFn-bo-7tb"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="width" secondItem="FVa-Mm-CYx" secondAttribute="width" id="pms-gh-3tU"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="width" secondItem="FVa-Mm-CYx" secondAttribute="width" constant="-40" id="pms-gh-3tU"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="PfU-uJ-V93"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="FVa-Mm-CYx"/>
@@ -104,10 +107,10 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="oXG-o2-dfY" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="12c-l9-S2E"/>
-                            <constraint firstItem="oXG-o2-dfY" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="npK-re-SUe"/>
-                            <constraint firstItem="oXG-o2-dfY" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="s50-Ka-rcf"/>
-                            <constraint firstItem="oXG-o2-dfY" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="xa6-e0-he2"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailing" id="12c-l9-S2E"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="bottom" secondItem="8bC-Xf-vdC" secondAttribute="bottom" id="npK-re-SUe"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="s50-Ka-rcf"/>
+                            <constraint firstItem="oXG-o2-dfY" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="xa6-e0-he2"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title=" " id="8pj-bl-5uA"/>
@@ -117,7 +120,7 @@
                         <outlet property="locationLabel" destination="Y8y-JF-8sK" id="qNf-7F-njl"/>
                         <outlet property="nationalFlagLeftImage" destination="VdE-NF-wj9" id="eMk-Bj-n0T"/>
                         <outlet property="nationalFlagRightImage" destination="o1z-bZ-HDR" id="gdI-tx-rCb"/>
-                        <outlet property="numberOfVisitorsLabel" destination="i8m-PR-AyC" id="iOW-SI-drY"/>
+                        <outlet property="numberOfVisitorsLabel" destination="i8m-PR-AyC" id="1Yk-Sm-eYv"/>
                         <outlet property="posterImageView" destination="jb4-nT-GE7" id="8w2-ox-2MN"/>
                         <outlet property="titleLabel" destination="UR3-YH-q7t" id="5s8-DD-MQF"/>
                         <outlet property="transitionToEntriesListButton" destination="Wpt-6h-ubY" id="JIv-TU-gbh"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -21,37 +21,37 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="J4m-6O-7JJ">
-                                        <rect key="frame" x="20" y="20" width="374" height="694.5"/>
+                                        <rect key="frame" x="10" y="20" width="394" height="694.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="clip" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UR3-YH-q7t">
-                                                <rect key="frame" x="157.5" y="0.0" width="59" height="30"/>
+                                                <rect key="frame" x="167.5" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jb4-nT-GE7">
-                                                <rect key="frame" x="67" y="40" width="240" height="50"/>
+                                                <rect key="frame" x="77" y="40" width="240" height="50"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i8m-PR-AyC">
-                                                <rect key="frame" x="166.5" y="100" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="176.5" y="100" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y8y-JF-8sK">
-                                                <rect key="frame" x="166.5" y="130.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="176.5" y="130.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smh-uU-2We">
-                                                <rect key="frame" x="166.5" y="161" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="176.5" y="161" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" scrollEnabled="NO" editable="NO" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FZp-L8-DmO">
-                                                <rect key="frame" x="1" y="191.5" width="372.5" height="443"/>
+                                                <rect key="frame" x="1" y="191.5" width="392" height="443"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -59,7 +59,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="nS9-LG-u8q">
-                                                <rect key="frame" x="83.5" y="644.5" width="207" height="50"/>
+                                                <rect key="frame" x="93.5" y="644.5" width="207" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="VdE-NF-wj9">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -94,11 +94,11 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="leading" secondItem="PfU-uJ-V93" secondAttribute="leading" constant="20" id="IQq-MG-Vmq"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="leading" secondItem="PfU-uJ-V93" secondAttribute="leading" constant="10" id="IQq-MG-Vmq"/>
                                     <constraint firstItem="PfU-uJ-V93" firstAttribute="top" secondItem="J4m-6O-7JJ" secondAttribute="top" constant="-20" id="b9L-SQ-K6h"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="trailing" secondItem="PfU-uJ-V93" secondAttribute="trailing" constant="-20" id="ewN-fE-AHb"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="trailing" secondItem="PfU-uJ-V93" secondAttribute="trailing" constant="-10" id="ewN-fE-AHb"/>
                                     <constraint firstItem="J4m-6O-7JJ" firstAttribute="bottom" secondItem="PfU-uJ-V93" secondAttribute="bottom" id="lFn-bo-7tb"/>
-                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="width" secondItem="FVa-Mm-CYx" secondAttribute="width" constant="-40" id="pms-gh-3tU"/>
+                                    <constraint firstItem="J4m-6O-7JJ" firstAttribute="width" secondItem="FVa-Mm-CYx" secondAttribute="width" constant="-20" id="pms-gh-3tU"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="PfU-uJ-V93"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="FVa-Mm-CYx"/>
@@ -188,16 +188,16 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="XhO-RK-4hn">
-                                        <rect key="frame" x="20" y="40" width="374" height="380"/>
+                                        <rect key="frame" x="10" y="40" width="394" height="380"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jq5-4w-dYJ">
-                                                <rect key="frame" x="104" y="0.0" width="166" height="166"/>
+                                                <rect key="frame" x="114" y="0.0" width="166" height="166"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="jq5-4w-dYJ" secondAttribute="height" multiplier="1:1" id="1nP-Q7-beh"/>
                                                 </constraints>
                                             </imageView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFa-NB-giR">
-                                                <rect key="frame" x="1" y="174" width="372.5" height="206"/>
+                                                <rect key="frame" x="1" y="174" width="392" height="206"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -208,9 +208,9 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="leading" secondItem="vfG-Nm-z9q" secondAttribute="leading" constant="20" id="Ff1-dF-V3A"/>
-                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="width" secondItem="wjM-xb-1Cu" secondAttribute="width" constant="-40" id="P5f-Ri-aOo"/>
-                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="trailing" secondItem="vfG-Nm-z9q" secondAttribute="trailing" constant="-20" id="Yp1-ey-k8H"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="leading" secondItem="vfG-Nm-z9q" secondAttribute="leading" constant="10" id="Ff1-dF-V3A"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="width" secondItem="wjM-xb-1Cu" secondAttribute="width" constant="-20" id="P5f-Ri-aOo"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="trailing" secondItem="vfG-Nm-z9q" secondAttribute="trailing" constant="-10" id="Yp1-ey-k8H"/>
                                     <constraint firstItem="XhO-RK-4hn" firstAttribute="bottom" secondItem="vfG-Nm-z9q" secondAttribute="bottom" id="anN-6W-vMD"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="vfG-Nm-z9q"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -184,29 +184,48 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="XhO-RK-4hn">
-                                <rect key="frame" x="20" y="122" width="337" height="536"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PsG-Ew-M3b">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jq5-4w-dYJ">
-                                        <rect key="frame" x="48.5" y="0.0" width="240" height="128"/>
-                                    </imageView>
-                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="NFa-NB-giR">
-                                        <rect key="frame" x="0.0" y="136" width="337" height="400"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="400" id="3QR-fq-U9A"/>
-                                            <constraint firstAttribute="width" constant="337" id="Q5s-Dd-Rdw"/>
-                                        </constraints>
-                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                        <color key="textColor" systemColor="labelColor"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                    </textView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="XhO-RK-4hn">
+                                        <rect key="frame" x="20" y="40" width="374" height="380"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jq5-4w-dYJ">
+                                                <rect key="frame" x="104" y="0.0" width="166" height="166"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="jq5-4w-dYJ" secondAttribute="height" multiplier="1:1" id="1nP-Q7-beh"/>
+                                                </constraints>
+                                            </imageView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFa-NB-giR">
+                                                <rect key="frame" x="1" y="174" width="372.5" height="206"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="leading" secondItem="vfG-Nm-z9q" secondAttribute="leading" constant="20" id="Ff1-dF-V3A"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="width" secondItem="wjM-xb-1Cu" secondAttribute="width" constant="-40" id="P5f-Ri-aOo"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="trailing" secondItem="vfG-Nm-z9q" secondAttribute="trailing" id="Yp1-ey-k8H"/>
+                                    <constraint firstItem="XhO-RK-4hn" firstAttribute="bottom" secondItem="vfG-Nm-z9q" secondAttribute="bottom" id="anN-6W-vMD"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="vfG-Nm-z9q"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="wjM-xb-1Cu"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="cjq-Lx-ysY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="vfG-Nm-z9q" firstAttribute="top" secondItem="XhO-RK-4hn" secondAttribute="top" constant="-40" id="1XS-LU-K7P"/>
+                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="top" secondItem="IHf-QC-6uu" secondAttribute="top" id="5Rg-px-B9t"/>
+                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="leading" secondItem="IHf-QC-6uu" secondAttribute="leading" id="6X0-Li-YSX"/>
+                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="trailing" secondItem="IHf-QC-6uu" secondAttribute="trailing" id="AIZ-Sw-gIv"/>
+                            <constraint firstItem="PsG-Ew-M3b" firstAttribute="bottom" secondItem="IHf-QC-6uu" secondAttribute="bottom" id="Z2Y-ks-ba4"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="szZ-fe-x7w"/>
                     <connections>

--- a/Expo1900/Expo1900/Controller/ContainerViewController.swift
+++ b/Expo1900/Expo1900/Controller/ContainerViewController.swift
@@ -2,6 +2,6 @@ import UIKit
 
 class ContainerViewController: UINavigationController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-          return self.topViewController?.supportedInterfaceOrientations ?? [.all]
-          }
+        return self.topViewController?.supportedInterfaceOrientations ?? [.all]
+    }
 }

--- a/Expo1900/Expo1900/Controller/ContainerViewController.swift
+++ b/Expo1900/Expo1900/Controller/ContainerViewController.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+class ContainerViewController: UINavigationController {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+          return self.topViewController?.supportedInterfaceOrientations ?? [.all]
+          }
+}

--- a/Expo1900/Expo1900/Controller/EntriesTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntriesTableViewController.swift
@@ -48,12 +48,16 @@ class EntriesTableViewController: UITableViewController {
         cellForRowAt indexPath: IndexPath
     ) -> UIListContentConfiguration {
         var configuration = defaultConfiguration
-        configuration.textProperties.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        configuration.textProperties.font = UIFont.preferredFont(forTextStyle: .title1)
+        configuration.textProperties.adjustsFontForContentSizeCategory = true
         configuration.text = expositionEntries?[indexPath.row].name
         configuration.secondaryText = expositionEntries?[indexPath.row].shortDescription
+        configuration.secondaryTextProperties.font = UIFont.preferredFont(forTextStyle: .body)
+        configuration.secondaryTextProperties.adjustsFontForContentSizeCategory = true
         configuration.image = expositionEntries?[indexPath.row].image
         configuration.imageProperties.maximumSize.height = 50
         configuration.imageProperties.maximumSize.width = 50
+        configuration.imageProperties.reservedLayoutSize.width = 50
         return configuration
     }
 }

--- a/Expo1900/Expo1900/Controller/EntriesTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntriesTableViewController.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 class EntriesTableViewController: UITableViewController {
-    private let expositionEntries: [ExpositionEntry]? = JSONParser<[ExpositionEntry]>.decode(from: "items")
+    private let expositionEntries: [ExpositionEntry]? = JSONParser<[ExpositionEntry]>.decode(
+        from: "items")
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
@@ -40,9 +40,9 @@ class ExpositionInformationViewController: UIViewController {
         
         titleLabel.text = expositionInformation?.title
         posterImageView.image = expositionInformation?.poster
-        numberOfVisitorsLabel.text = expositionInformation?.visitors
-        durationLabel.text = expositionInformation?.duration
-        locationLabel.text = expositionInformation?.location
+        numberOfVisitorsLabel.attributedText = expositionInformation?.visitors
+        durationLabel.attributedText = expositionInformation?.duration
+        locationLabel.attributedText = expositionInformation?.location
         desciptionTextView.text = expositionInformation?.description
         let nationalFlag = UIImage(named: "flag")
         nationalFlagLeftImage.image = nationalFlag

--- a/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
@@ -55,7 +55,7 @@ class ExpositionInformationViewController: UIViewController {
     }
     
     private func setNavigationItem() {
-        navigationItem.backButtonTitle = "메인"
+        navigationItem.title = "메인"
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
@@ -18,8 +18,8 @@ class ExpositionInformationViewController: UIViewController {
     @IBOutlet private weak var nationalFlagRightImage: UIImageView!
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-           return [.portrait]
-       }
+        return [.portrait]
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionInformationViewController.swift
@@ -17,6 +17,10 @@ class ExpositionInformationViewController: UIViewController {
     @IBOutlet private weak var transitionToEntriesListButton: UIButton!
     @IBOutlet private weak var nationalFlagRightImage: UIImageView!
     
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+           return [.portrait]
+       }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setExpositionInformation()

--- a/Expo1900/Expo1900/Model/ExpositionInformation.swift
+++ b/Expo1900/Expo1900/Model/ExpositionInformation.swift
@@ -21,8 +21,14 @@ struct ExpositionInformation: Decodable {
             attributedString.append(NSAttributedString(string: "잘못된 방문객 정보"))
             return attributedString
         }
-        let subject = NSAttributedString(string: "방문객 ", attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)])
-        let value = NSAttributedString(string: ": \(visitorsNumber)명", attributes: [.font: UIFont.preferredFont(forTextStyle: .body)])
+        let subject = NSAttributedString(
+            string: "방문객 ",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)]
+        )
+        let value = NSAttributedString(
+            string: ": \(visitorsNumber)명",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
         attributedString.append(subject)
         attributedString.append(value)
         return attributedString
@@ -30,8 +36,14 @@ struct ExpositionInformation: Decodable {
     var location: NSMutableAttributedString {
         let attributedString = NSMutableAttributedString()
 
-        let subject = NSAttributedString(string: "개최지 ", attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)])
-        let value = NSAttributedString(string: ": \(locationInformation)", attributes: [.font: UIFont.preferredFont(forTextStyle: .body)])
+        let subject = NSAttributedString(
+            string: "개최지 ",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)]
+        )
+        let value = NSAttributedString(
+            string: ": \(locationInformation)",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
         attributedString.append(subject)
         attributedString.append(value)
         return attributedString
@@ -39,8 +51,14 @@ struct ExpositionInformation: Decodable {
     var duration: NSMutableAttributedString {
         let attributedString = NSMutableAttributedString()
 
-        let subject = NSAttributedString(string: "개최 기간 ", attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)])
-        let value = NSAttributedString(string: ": \(durationInformation)", attributes: [.font: UIFont.preferredFont(forTextStyle: .body)])
+        let subject = NSAttributedString(
+            string: "개최 기간 ",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)]
+        )
+        let value = NSAttributedString(
+            string: ": \(durationInformation)",
+            attributes: [.font: UIFont.preferredFont(forTextStyle: .body)]
+        )
         attributedString.append(subject)
         attributedString.append(value)
         

--- a/Expo1900/Expo1900/Model/ExpositionInformation.swift
+++ b/Expo1900/Expo1900/Model/ExpositionInformation.swift
@@ -1,32 +1,55 @@
 import UIKit
 
 struct ExpositionInformation: Decodable {
-    let title: String
+    private let titleInformation: String
     private let visitorsInformation: Int
     private let locationInformation: String
     private let durationInformation: String
     let description: String
 
+    var title: String {
+        return titleInformation.replacingOccurrences(of: "(", with: "\n(")
+    }
     var poster: UIImage? {
         return UIImage(named: "poster")
     }
-    var visitors: String {
+    var visitors: NSMutableAttributedString {
+        let attributedString = NSMutableAttributedString()
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         guard let visitorsNumber = formatter.string(for: visitorsInformation) else {
-            return "잘못된 방문객 정보"
+            attributedString.append(NSAttributedString(string: "잘못된 방문객 정보"))
+            return attributedString
         }
-        return "방문객 : \(visitorsNumber)명"
+        let subject = NSAttributedString(string: "방문객 ", attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)])
+        let value = NSAttributedString(string: ": \(visitorsNumber)명", attributes: [.font: UIFont.preferredFont(forTextStyle: .body)])
+        attributedString.append(subject)
+        attributedString.append(value)
+        return attributedString
     }
-    var location: String {
-        return "개최지 : \(locationInformation)"
+    var location: NSMutableAttributedString {
+        let attributedString = NSMutableAttributedString()
+
+        let subject = NSAttributedString(string: "개최지 ", attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)])
+        let value = NSAttributedString(string: ": \(locationInformation)", attributes: [.font: UIFont.preferredFont(forTextStyle: .body)])
+        attributedString.append(subject)
+        attributedString.append(value)
+        return attributedString
     }
-    var duration: String {
-        return "개최 기간 : \(durationInformation)"
+    var duration: NSMutableAttributedString {
+        let attributedString = NSMutableAttributedString()
+
+        let subject = NSAttributedString(string: "개최 기간 ", attributes: [.font: UIFont.preferredFont(forTextStyle: .title3)])
+        let value = NSAttributedString(string: ": \(durationInformation)", attributes: [.font: UIFont.preferredFont(forTextStyle: .body)])
+        attributedString.append(subject)
+        attributedString.append(value)
+        
+        return attributedString
     }
     
     private enum CodingKeys: String, CodingKey {
-        case title, description
+        case description
+        case titleInformation = "title"
         case visitorsInformation = "visitors"
         case locationInformation = "location"
         case durationInformation = "duration"


### PR DESCRIPTION
안녕하세요 그린! @GREENOVER
릴리, 니콜라스, 아카페라 커피입니다~
@yeahg-dev @Kim-EunsooSilver @aCafela-coffee

## 질문드리고 싶은 점

### 오토 레이아웃 제약을 추가하는 커밋의 제목

첫번째 뷰가 스크롤 되도록 제약을 수정했습니다.
[Karma](http://karma-runner.github.io/6.3/dev/git-commit-msg.html) 여기 내용을 따른다면 제목이 뭘로 시작해야 할까요?
feat, fix, refactor 중에서 고민이 됩니다.

의견 1 feat: 스크롤이 안되는 상태가 의도된 부분이고, 지금은 스크롤 기능을 추가한 것임
의견 2 fix: Scroll View의 사용목적에 따르면 기본적으로 스크롤이가능한 것이 맞으므로 오토레이아웃 이슈에의한 빨간줄을 없애줌으로써 버그를 수정했다고 볼 수 있음.

## 고민한 부분

### 첫번째 화면만 세로로 고정하기

```swift
class ExpositionInformationViewController: UIViewController {
    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return [.portrait]
    }
}
```

`ExpositionInformationViewController`에서 위 `supportedInterfaceOrientations` 프로퍼티를 수정했습니다.

그리고 위의 뷰 컨트롤러는 `UINavigationController`에 있기 때문에 아래 코드도 필요했습니다.

```swift
class ContainerViewController: UINavigationController {
    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return self.topViewController?.supportedInterfaceOrientations ?? [.all]
    }
}
```

### 첫 화면 레이블의 폰트크기에 대한 고민

- 요구사항 화면상에서는 `방문객` 과 해당 값의 폰트 사이즈가 상이합니다.
- 레이블 타이틀 역할을 하는 레이블을 생성할지에대해서 고민했지만, step1 피드백(view를 생성하면 뷰/뷰컨이 커진다)을 반영하여 하나의 레이블로 통일 후, `NSMutableAttributedString` 을 이용하여 구연하였습니다.

### EntriesTableView에서 셀의 이미지 레이아웃 크기 정하기

```swift
private func setCellConfiguration(from:, cellForRowAt:) -> UIListContentConfiguration {
    configuration.imageProperties.reservedLayoutSize.width = 50
    return configuration
}
```

셀의 글이 아래 화면의 주황선을 넘기지 않도록 수정했습니다.
<img width="234" alt="61ab8a44e4081120ba7854a9" src="https://user-images.githubusercontent.com/70484506/146511528-f3b4ac04-35d7-424d-8526-8fb4b1525119.png">

### StackView내 ItemImageView의 제약

<img width="234" alt="스크린샷 2021-12-17 오후 5 04 05" src="https://user-images.githubusercontent.com/70484506/146511626-58cbc03b-7a0d-45da-a807-a97a8e3097d4.png">

- 해금, 나전칠기 등 몇몇의 이미지가 위 사진과 같이 넓이는 꽉 채우면서 위아래로 공백을 만드는 이슈가 있었습니다.
- ItemImageView의 Content Hugging Priority를 높이는 방법으로 해결하려고 했으나, 여전히 공백을 만들어서
- `ItemImageView의 width : height 의 aspect ratio = 1:1` 제약을 추가해서 공백을 줄여주었습니다.
- 그런데 다른 출품작들에서는 네비게이션바와 이미지사이에 공백이 오히려 더 추가되는 것 같아, best practice는 아닌 것 같다는 생각이 들었습니다.
- 이와 관련해서 더 나은 수정 방향은 어떤게 있을까요??

## 해결하지 못한 부분

- Entry Detail View(세번째 화면) 가로 화면에서 스크롤바를 오른쪽 끝에 붙이기
- ExpositionInformationView 에서 National Flag의 Adjust Image Size 사용해서 크기 조절하기
- EntriesTableView에서 셀의 이미지 Adjust Image Size 사용해서 크기 조절하기
