### PR TITLE
만국박람회 [STEP 3] July, Jane, 신나

### DIFF
--- a/Expo1900/Expo1900/Model/ExpositionViewModel.swift
+++ b/Expo1900/Expo1900/Model/ExpositionViewModel.swift
@@ -2,26 +2,25 @@ struct ExpositionViewModel {
     
     var exposition: Exposition
     let posterName = "poster"
-    let visitorDescription = "방문객 : "
   
     var title: String {
         exposition.title.replacingOccurrences(of: "(", with: "\n(")
     }
     
     var image: String {
-        "poster"
+        posterName
     }
     
     var visitors: String {
-        "방문객 : " + exposition.visitor + "명"
+        exposition.visitor
     }
     
     var location: String {
-        "개최지 : " + exposition.location
+        exposition.location
     }
     
     var duration: String {
-        "개최 기간 : " + exposition.duration
+        exposition.duration
     }
     
     var description: String {

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -285,14 +285,17 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="agB-gH-Xnn">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="45" translatesAutoresizingMaskIntoConstraints="NO" id="aDx-Io-tXL">
-                                        <rect key="frame" x="20" y="0.0" width="374" height="1132"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="aDx-Io-tXL">
+                                        <rect key="frame" x="20" y="0.0" width="374" height="1347.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="jikji" translatesAutoresizingMaskIntoConstraints="NO" id="Oy4-Rb-CEU">
-                                                <rect key="frame" x="0.0" y="0.0" width="374" height="133.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="374"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="Oy4-Rb-CEU" secondAttribute="height" multiplier="1:1" id="h3Z-LY-G0K"/>
+                                                </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="          Label          label            label          label       la be l        " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JoT-hA-mqq">
-                                                <rect key="frame" x="0.0" y="178.5" width="374" height="953.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="          Label          label            label          label       la be l        " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JoT-hA-mqq">
+                                                <rect key="frame" x="0.0" y="394" width="374" height="953.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -32,24 +32,81 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="BcU-zr-uYb">
                                                 <rect key="frame" x="115" y="33" width="144" height="200"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객: 40 명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Gp-yX-eri">
-                                                <rect key="frame" x="140.5" y="243" width="93" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지: 프랑스 파리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i83-sw-Z8d">
-                                                <rect key="frame" x="121.5" y="273.5" width="131" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간: 1900.04.14 - 1900.11.12" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wcc-3X-t7s">
-                                                <rect key="frame" x="62" y="304" width="250.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="FPO-DK-QGl">
+                                                <rect key="frame" x="102.5" y="243" width="169" height="20.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6t-Si-EoL">
+                                                        <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wWN-I9-Vco">
+                                                        <rect key="frame" x="47.5" y="0.0" width="5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="123,456,789" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Gp-yX-eri">
+                                                        <rect key="frame" x="55.5" y="0.0" width="95.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J3b-RU-ngJ">
+                                                        <rect key="frame" x="154" y="0.0" width="15" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fo-vA-kwr">
+                                                <rect key="frame" x="123.5" y="273.5" width="127.5" height="20.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuS-HD-3yv">
+                                                        <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zsi-8X-vld">
+                                                        <rect key="frame" x="44.5" y="0.0" width="5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="프랑스 파리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i83-sw-Z8d">
+                                                        <rect key="frame" x="49.5" y="0.0" width="78" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="doH-9V-qXU">
+                                                <rect key="frame" x="60.5" y="304" width="253" height="20.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3AI-ax-410">
+                                                        <rect key="frame" x="0.0" y="0.0" width="63.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f5T-3N-t6H">
+                                                        <rect key="frame" x="66.5" y="0.0" width="5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1900.04.14 - 1900.11.12" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wcc-3X-t7s">
+                                                        <rect key="frame" x="74.5" y="0.0" width="178.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JK7-4C-fiC">
                                                 <rect key="frame" x="0.0" y="334.5" width="374" height="1400"/>
                                                 <string key="text">1900년 파리 만국박람회(지금의 세계 박람회[World’s Fair/Exposition/Expo])는 지난 세기를 기념하고 다음 세기를 향한 발전을 가속하자는 의미에서 1900년 4월 14일부터 11월 12일까지 프랑스 파리에서 열린 세계 박람회였다. 이 박람회에서 널리 선보였던 건축 양식이 바로 '아르누보'였다. 총 관람객수가 5000만 명에 달한 1900년 세계 박람회에서는 수많은 기계와 발명품, 그리고 건축물들이 전시됐는데 그 중에는 그랑드 루 드 파리 대관람차, 마트료시카 인형, 디젤 엔진, 유성영화, 에스컬레이터, 텔레그라폰 (최초의 자석식 녹음기) 등 지금도 널리 알려져 있는 것들도 등장했다.\n\n프랑스는 1855년에도 만국 박람회를 개최한 전력이 있었는데 전쟁 후 국가의 자부심과 신념을 다시 세우고자 하는 욕구로부터 비롯된 것이었다. 1900년 박람회가 성공을 거둔 것도 전후 국가 부흥이라는 똑같은 주제에 따른 것이었다. 1900년 파리 세계 박람회가 개최되기 8년 전인 1892년, 프랑스 정부는 새 세기의 도래를 환영하고 축하하는 박람회를 열 것이라고 발표했다.\n\n프랑스는 전세계 56개국에 초청장을 보냈고, 그 중 40개국이 수락하여 참가했다.참가국들이 이룬 것과 생활양식을 전시했다. 이 세계 박람회는 여러 가지 체험을 종합하여 익히도록 한 것이었다. 이를 통해 외국인들에게 각 국가들 간의 유사성은 물론 그 사이의 독특한 다양성을 깨닫도록 하는 기회를 제공했다. 또 새로운 문화를 경험하고 각국이 전시해 놓은 자국의 가치들을 전반적으로 더욱 이해할 수 있도록 했다. 이러한 상호 이해의 환경이 전쟁 시대 이후 필요하다고 여겨졌던 문화적 관용을 늘리는데 한몫하도록 했다. 박람회 개최 소식이 발표되자 독일에서 처음으로 열린 국제 박람회에 쏠렸던 관심은 풀리고 박람회 개최에 대한 호응이 어마어마하게 쏟아졌다. 박람회에 대한 지지도 대단해서 각국에서는 즉시 자국 전시관 계획을 세우기 시작했다. \n\n파리 만국박람회가 개최된 1900년 4월 14일부터 11월 12일까지 프랑스 파리에는 대한제국의 문화와 문물이 전시된 한국관이 세워졌습니다. 한국관은 경복궁의 근정전을 재현한 주전시관과 옛 국왕들의 위패를 모셔놓은 사당을 별채로 구성되었는데, 이는 우리 건축의 아름다움을 세계에 알린 첫 건축물이 되었습니다. 특히 만국박 람회의 대한제국관을 묘사한 프랑스 잡지 ‘르 프티 주르날(Le Petit Journal)’은 태극기를 표시해 당당하게 대한 제국의 상징으로 많은 관심을 받을 수 있었습니다.\n\n한국관의 전시품은 정확하게 어떤 것이 전시되었는지 알 수는 없지만 대한제국과 프랑스 정부간에 오고 간 문 서를 통해 짐작할 수 있습니다. 대한제국 정부는 우리의 다양한 전통문화를 나타내는 비단, 놋그릇, 도자기, 칠 보 등의 공예품을 제공한 것으로 보이며, 이 밖에도 악기, 옷, 가구, 예술품 등도 있었다고 합니다. 만국박람회는 참가한 나라들의 산업을 소개하는 역할을 했고, 전시는 물론 시상도 했는데 대한제국은 식물성 농업식품 분야 에서 그랑프리(대상)을 수상하였다고 합니다.\n\n1900년 11월 12일 파리 만국박람회가 폐막된 후 한국관에 출품되었던 전시품들은 다시 본국으로 돌아오지 못하고 대부분 현지에 기증되었는데, 이는 일종의 관례이기도 했지만 본국으로 회수하는데 드는 과도한 운송비용 때문이기도 했습니다.\n\n현재 이 전시품들은 프랑스에 있는 국립공예박물관, 국립예술직업전문학교, 국립음악원 음악박물관, 국립 기메 아시아박물관 등에 소장되어있습니다. 특히 전시품으로 기증된 악기들 중 해금은 현존하는 해금 가운데 가장 오래된 것으로 추정되고 있다고도 합니다. 우리의 소중한 역사적 유물을 멀리 두고 올 수 밖에 없던 상황이 안타깝게 느껴집니다.\n\n작고 힘없는 나라 대한제국이 세계 강국들이 모인 만국박람회에 참가한다는 자체가 불가능하다는 의견이 지배 적이었지만 1900년 프랑스 파리에 근정전을 본뜬 한국관이 우뚝 세워졌습니다. 그 존재만으로 독립된 나라임을 세계에 알리고자 했던 목표는 이루어진 것 같습니다. 그러나 안타깝게도 그로부터 5년 후인 1905년 을사늑약이 체결되었고, 대한제국은 독립국가로서 세계에서 점점 잊혀져 갔습니다."</string>
@@ -211,18 +268,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="agB-gH-Xnn">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="agB-gH-Xnn">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="45" translatesAutoresizingMaskIntoConstraints="NO" id="aDx-Io-tXL">
-                                        <rect key="frame" x="20" y="20" width="354" height="1132"/>
+                                        <rect key="frame" x="20" y="0.0" width="374" height="1132"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="jikji" translatesAutoresizingMaskIntoConstraints="NO" id="Oy4-Rb-CEU">
-                                                <rect key="frame" x="0.0" y="0.0" width="354" height="133.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="133.5"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="          Label          label            label          label       la be l        " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JoT-hA-mqq">
-                                                <rect key="frame" x="0.0" y="178.5" width="354" height="953.5"/>
+                                                <rect key="frame" x="0.0" y="178.5" width="374" height="953.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -231,11 +287,11 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="oNt-dU-9jp" firstAttribute="trailing" secondItem="aDx-Io-tXL" secondAttribute="trailing" constant="40" id="0Sv-qW-KCr"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="bottom" secondItem="eWk-iR-XWp" secondAttribute="bottom" constant="-10" id="2Mh-RJ-DKR"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="top" secondItem="eWk-iR-XWp" secondAttribute="top" constant="20" id="fVD-GM-A7j"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="width" secondItem="eWk-iR-XWp" secondAttribute="width" id="vpt-rO-s9g"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="leading" secondItem="oNt-dU-9jp" secondAttribute="leading" constant="20" id="wcV-ec-j4q"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="leading" secondItem="oNt-dU-9jp" secondAttribute="leading" constant="20" id="5nP-KV-vWW"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="top" secondItem="eWk-iR-XWp" secondAttribute="top" id="FNK-5D-OcA"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="bottom" secondItem="eWk-iR-XWp" secondAttribute="bottom" id="Lwd-VQ-5dx"/>
+                                    <constraint firstItem="oNt-dU-9jp" firstAttribute="trailing" secondItem="aDx-Io-tXL" secondAttribute="trailing" constant="20" id="lgv-Fw-Svl"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="width" secondItem="eWk-iR-XWp" secondAttribute="width" id="pef-pG-Lw5"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="eWk-iR-XWp"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="oNt-dU-9jp"/>
@@ -243,6 +299,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="4AX-h2-5cC"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="agB-gH-Xnn" firstAttribute="leading" secondItem="W88-ha-ZBB" secondAttribute="leading" id="KlW-KB-IP5"/>
+                            <constraint firstAttribute="bottom" secondItem="agB-gH-Xnn" secondAttribute="bottom" id="hfa-YX-ezS"/>
+                            <constraint firstAttribute="trailing" secondItem="agB-gH-Xnn" secondAttribute="trailing" id="i4l-PO-V8F"/>
+                            <constraint firstItem="agB-gH-Xnn" firstAttribute="top" secondItem="W88-ha-ZBB" secondAttribute="top" id="mV1-Qa-wNr"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="title" id="byl-s0-rIF"/>
                     <connections>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -216,13 +216,13 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="45" translatesAutoresizingMaskIntoConstraints="NO" id="aDx-Io-tXL">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1132"/>
+                                        <rect key="frame" x="20" y="20" width="354" height="1132"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="jikji" translatesAutoresizingMaskIntoConstraints="NO" id="Oy4-Rb-CEU">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="133.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="354" height="133.5"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="          Label          label            label          label       la be l        " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JoT-hA-mqq">
-                                                <rect key="frame" x="0.0" y="178.5" width="414" height="953.5"/>
+                                                <rect key="frame" x="0.0" y="178.5" width="354" height="953.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -231,11 +231,11 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="width" secondItem="oNt-dU-9jp" secondAttribute="width" id="3PX-Mv-nm2"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="bottom" secondItem="eWk-iR-XWp" secondAttribute="bottom" id="K7v-yq-Rfn"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="trailing" secondItem="eWk-iR-XWp" secondAttribute="trailing" id="M9s-mc-wsD"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="top" secondItem="eWk-iR-XWp" secondAttribute="top" id="Vcg-aq-cAa"/>
-                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="leading" secondItem="eWk-iR-XWp" secondAttribute="leading" id="iAa-R5-OWO"/>
+                                    <constraint firstItem="oNt-dU-9jp" firstAttribute="trailing" secondItem="aDx-Io-tXL" secondAttribute="trailing" constant="40" id="0Sv-qW-KCr"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="bottom" secondItem="eWk-iR-XWp" secondAttribute="bottom" constant="-10" id="2Mh-RJ-DKR"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="top" secondItem="eWk-iR-XWp" secondAttribute="top" constant="20" id="fVD-GM-A7j"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="width" secondItem="eWk-iR-XWp" secondAttribute="width" id="vpt-rO-s9g"/>
+                                    <constraint firstItem="aDx-Io-tXL" firstAttribute="leading" secondItem="oNt-dU-9jp" secondAttribute="leading" constant="20" id="wcV-ec-j4q"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="eWk-iR-XWp"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="oNt-dU-9jp"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -213,37 +214,50 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="artWorkItem" textLabel="qf6-UE-vHX" detailTextLabel="P2A-uh-ehs" imageView="SP5-IQ-r9q" style="IBUITableViewCellStyleSubtitle" id="g3F-pW-XbG" customClass="KoreanArtWorkTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="artWorkItem" rowHeight="108" id="g3F-pW-XbG" customClass="KoreanArtWorkTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="108"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="g3F-pW-XbG" id="u7i-M3-Svz">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="108"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qf6-UE-vHX">
-                                            <rect key="frame" x="55.5" y="6" width="25" height="14.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="P2A-uh-ehs">
-                                            <rect key="frame" x="55.5" y="22.5" width="30.5" height="13.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="pencil.circle" catalog="system" id="SP5-IQ-r9q">
-                                            <rect key="frame" x="20.25" y="12" width="20" height="19"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rw2-hs-mOB">
+                                            <rect key="frame" x="20" y="16" width="77" height="76"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" secondItem="rw2-hs-mOB" secondAttribute="height" multiplier="1:1" id="Gdf-MD-KIj"/>
+                                            </constraints>
+                                            <imageReference key="image" image="pencil.circle" catalog="system" symbolScale="default"/>
                                         </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bzs-PH-bgJ">
+                                            <rect key="frame" x="107" y="16" width="265.5" height="37"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SubTitle" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K3j-NM-een">
+                                            <rect key="frame" x="107" y="56" width="265.5" height="36"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="bzs-PH-bgJ" firstAttribute="top" secondItem="u7i-M3-Svz" secondAttribute="topMargin" constant="5" id="HAC-z5-J24"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="K3j-NM-een" secondAttribute="trailing" constant="5" id="HEl-88-Uay"/>
+                                        <constraint firstItem="bzs-PH-bgJ" firstAttribute="leading" secondItem="rw2-hs-mOB" secondAttribute="trailing" constant="10" id="I7l-gs-E4D"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="bzs-PH-bgJ" secondAttribute="trailing" constant="5" id="Jj8-cD-JN5"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="K3j-NM-een" secondAttribute="bottom" constant="5" id="T05-ij-eL4"/>
+                                        <constraint firstItem="rw2-hs-mOB" firstAttribute="centerY" secondItem="u7i-M3-Svz" secondAttribute="centerY" id="W75-Qe-Rjw"/>
+                                        <constraint firstItem="rw2-hs-mOB" firstAttribute="leading" secondItem="u7i-M3-Svz" secondAttribute="leadingMargin" id="WXI-oj-upj"/>
+                                        <constraint firstItem="K3j-NM-een" firstAttribute="top" secondItem="bzs-PH-bgJ" secondAttribute="bottom" constant="3" id="Ze8-R7-qLo"/>
+                                        <constraint firstItem="K3j-NM-een" firstAttribute="leading" secondItem="bzs-PH-bgJ" secondAttribute="leading" id="s39-uD-2uq"/>
+                                        <constraint firstItem="rw2-hs-mOB" firstAttribute="width" secondItem="u7i-M3-Svz" secondAttribute="width" multiplier="20%" id="tGZ-Ci-d6c"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <outlet property="cellDetailLabel" destination="P2A-uh-ehs" id="yjn-5v-GAY"/>
-                                    <outlet property="cellImageViewLabel" destination="SP5-IQ-r9q" id="TIO-La-BXK"/>
-                                    <outlet property="cellTitleLabel" destination="qf6-UE-vHX" id="Rz4-pF-bAE"/>
+                                    <outlet property="cellDetailLabel" destination="K3j-NM-een" id="n5Q-Zg-RcK"/>
+                                    <outlet property="cellImageViewLabel" destination="rw2-hs-mOB" id="B3C-ey-0Oq"/>
+                                    <outlet property="cellTitleLabel" destination="bzs-PH-bgJ" id="BVP-Ex-agE"/>
                                     <segue destination="FNP-c8-ha3" kind="show" id="x0i-NH-qJH"/>
                                 </connections>
                             </tableViewCell>
@@ -258,7 +272,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9Jd-3W-cSB" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1891" y="119"/>
+            <point key="canvasLocation" x="1889.8550724637682" y="118.52678571428571"/>
         </scene>
         <!--title-->
         <scene sceneID="nnS-TJ-CBi">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -22,111 +22,114 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="iNn-xM-HW1">
-                                        <rect key="frame" x="20" y="20" width="374" height="1784.5"/>
+                                        <rect key="frame" x="20" y="20" width="374" height="1469.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="파리 만국박람회 1900" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ZE-Wj-1Qh">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="파리 만국박람회 1900" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ZE-Wj-1Qh">
                                                 <rect key="frame" x="103.5" y="0.0" width="167.5" height="23"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="BcU-zr-uYb">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BcU-zr-uYb">
                                                 <rect key="frame" x="115" y="33" width="144" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="FPO-DK-QGl">
-                                                <rect key="frame" x="102.5" y="243" width="169" height="20.5"/>
+                                                <rect key="frame" x="111.5" y="243" width="151.5" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6t-Si-EoL">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6t-Si-EoL">
                                                         <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wWN-I9-Vco">
-                                                        <rect key="frame" x="47.5" y="0.0" width="5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wWN-I9-Vco">
+                                                        <rect key="frame" x="47.5" y="0.0" width="4.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="123,456,789" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Gp-yX-eri">
-                                                        <rect key="frame" x="55.5" y="0.0" width="95.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="123,456,789" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Gp-yX-eri">
+                                                        <rect key="frame" x="55" y="0.0" width="81" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J3b-RU-ngJ">
-                                                        <rect key="frame" x="154" y="0.0" width="15" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J3b-RU-ngJ">
+                                                        <rect key="frame" x="139" y="0.0" width="12.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2fo-vA-kwr">
-                                                <rect key="frame" x="123.5" y="273.5" width="127.5" height="20.5"/>
+                                                <rect key="frame" x="130.5" y="273.5" width="113.5" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuS-HD-3yv">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EuS-HD-3yv">
                                                         <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zsi-8X-vld">
-                                                        <rect key="frame" x="44.5" y="0.0" width="5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zsi-8X-vld">
+                                                        <rect key="frame" x="44.5" y="0.0" width="4.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="프랑스 파리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i83-sw-Z8d">
-                                                        <rect key="frame" x="49.5" y="0.0" width="78" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="프랑스 파리" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i83-sw-Z8d">
+                                                        <rect key="frame" x="49" y="0.0" width="64.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="doH-9V-qXU">
-                                                <rect key="frame" x="60.5" y="304" width="253" height="20.5"/>
+                                                <rect key="frame" x="74.5" y="304" width="225.5" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3AI-ax-410">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3AI-ax-410">
                                                         <rect key="frame" x="0.0" y="0.0" width="63.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f5T-3N-t6H">
-                                                        <rect key="frame" x="66.5" y="0.0" width="5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f5T-3N-t6H">
+                                                        <rect key="frame" x="66.5" y="0.0" width="4.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1900.04.14 - 1900.11.12" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wcc-3X-t7s">
-                                                        <rect key="frame" x="74.5" y="0.0" width="178.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1900.04.14 - 1900.11.12" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wcc-3X-t7s">
+                                                        <rect key="frame" x="74" y="0.0" width="151.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JK7-4C-fiC">
-                                                <rect key="frame" x="0.0" y="334.5" width="374" height="1400"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JK7-4C-fiC">
+                                                <rect key="frame" x="0.0" y="334.5" width="374" height="1081"/>
                                                 <string key="text">1900년 파리 만국박람회(지금의 세계 박람회[World’s Fair/Exposition/Expo])는 지난 세기를 기념하고 다음 세기를 향한 발전을 가속하자는 의미에서 1900년 4월 14일부터 11월 12일까지 프랑스 파리에서 열린 세계 박람회였다. 이 박람회에서 널리 선보였던 건축 양식이 바로 '아르누보'였다. 총 관람객수가 5000만 명에 달한 1900년 세계 박람회에서는 수많은 기계와 발명품, 그리고 건축물들이 전시됐는데 그 중에는 그랑드 루 드 파리 대관람차, 마트료시카 인형, 디젤 엔진, 유성영화, 에스컬레이터, 텔레그라폰 (최초의 자석식 녹음기) 등 지금도 널리 알려져 있는 것들도 등장했다.\n\n프랑스는 1855년에도 만국 박람회를 개최한 전력이 있었는데 전쟁 후 국가의 자부심과 신념을 다시 세우고자 하는 욕구로부터 비롯된 것이었다. 1900년 박람회가 성공을 거둔 것도 전후 국가 부흥이라는 똑같은 주제에 따른 것이었다. 1900년 파리 세계 박람회가 개최되기 8년 전인 1892년, 프랑스 정부는 새 세기의 도래를 환영하고 축하하는 박람회를 열 것이라고 발표했다.\n\n프랑스는 전세계 56개국에 초청장을 보냈고, 그 중 40개국이 수락하여 참가했다.참가국들이 이룬 것과 생활양식을 전시했다. 이 세계 박람회는 여러 가지 체험을 종합하여 익히도록 한 것이었다. 이를 통해 외국인들에게 각 국가들 간의 유사성은 물론 그 사이의 독특한 다양성을 깨닫도록 하는 기회를 제공했다. 또 새로운 문화를 경험하고 각국이 전시해 놓은 자국의 가치들을 전반적으로 더욱 이해할 수 있도록 했다. 이러한 상호 이해의 환경이 전쟁 시대 이후 필요하다고 여겨졌던 문화적 관용을 늘리는데 한몫하도록 했다. 박람회 개최 소식이 발표되자 독일에서 처음으로 열린 국제 박람회에 쏠렸던 관심은 풀리고 박람회 개최에 대한 호응이 어마어마하게 쏟아졌다. 박람회에 대한 지지도 대단해서 각국에서는 즉시 자국 전시관 계획을 세우기 시작했다. \n\n파리 만국박람회가 개최된 1900년 4월 14일부터 11월 12일까지 프랑스 파리에는 대한제국의 문화와 문물이 전시된 한국관이 세워졌습니다. 한국관은 경복궁의 근정전을 재현한 주전시관과 옛 국왕들의 위패를 모셔놓은 사당을 별채로 구성되었는데, 이는 우리 건축의 아름다움을 세계에 알린 첫 건축물이 되었습니다. 특히 만국박 람회의 대한제국관을 묘사한 프랑스 잡지 ‘르 프티 주르날(Le Petit Journal)’은 태극기를 표시해 당당하게 대한 제국의 상징으로 많은 관심을 받을 수 있었습니다.\n\n한국관의 전시품은 정확하게 어떤 것이 전시되었는지 알 수는 없지만 대한제국과 프랑스 정부간에 오고 간 문 서를 통해 짐작할 수 있습니다. 대한제국 정부는 우리의 다양한 전통문화를 나타내는 비단, 놋그릇, 도자기, 칠 보 등의 공예품을 제공한 것으로 보이며, 이 밖에도 악기, 옷, 가구, 예술품 등도 있었다고 합니다. 만국박람회는 참가한 나라들의 산업을 소개하는 역할을 했고, 전시는 물론 시상도 했는데 대한제국은 식물성 농업식품 분야 에서 그랑프리(대상)을 수상하였다고 합니다.\n\n1900년 11월 12일 파리 만국박람회가 폐막된 후 한국관에 출품되었던 전시품들은 다시 본국으로 돌아오지 못하고 대부분 현지에 기증되었는데, 이는 일종의 관례이기도 했지만 본국으로 회수하는데 드는 과도한 운송비용 때문이기도 했습니다.\n\n현재 이 전시품들은 프랑스에 있는 국립공예박물관, 국립예술직업전문학교, 국립음악원 음악박물관, 국립 기메 아시아박물관 등에 소장되어있습니다. 특히 전시품으로 기증된 악기들 중 해금은 현존하는 해금 가운데 가장 오래된 것으로 추정되고 있다고도 합니다. 우리의 소중한 역사적 유물을 멀리 두고 올 수 밖에 없던 상황이 안타깝게 느껴집니다.\n\n작고 힘없는 나라 대한제국이 세계 강국들이 모인 만국박람회에 참가한다는 자체가 불가능하다는 의견이 지배 적이었지만 1900년 프랑스 파리에 근정전을 본뜬 한국관이 우뚝 세워졌습니다. 그 존재만으로 독립된 나라임을 세계에 알리고자 했던 목표는 이루어진 것 같습니다. 그러나 안타깝게도 그로부터 5년 후인 1905년 을사늑약이 체결되었고, 대한제국은 독립국가로서 세계에서 점점 잊혀져 갔습니다."</string>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="26Q-sx-npb">
-                                                <rect key="frame" x="66.5" y="1744.5" width="241" height="40"/>
+                                                <rect key="frame" x="66.5" y="1425.5" width="241" height="44"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="Rb6-60-sZi">
-                                                        <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                                                        <rect key="frame" x="0.0" y="2" width="40" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="Rb6-60-sZi" secondAttribute="height" multiplier="1:1" id="3S2-kN-W8N"/>
                                                             <constraint firstAttribute="width" constant="40" id="Koj-74-ilD"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ngw-Qr-8Ze">
-                                                        <rect key="frame" x="65" y="7" width="111" height="26.5"/>
+                                                        <rect key="frame" x="65" y="0.0" width="111" height="44"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="44" id="8M6-uw-uo0"/>
+                                                        </constraints>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal">
                                                             <attributedString key="attributedTitle">
@@ -142,7 +145,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="uwI-7W-5ox">
-                                                        <rect key="frame" x="201" y="0.0" width="40" height="40"/>
+                                                        <rect key="frame" x="201" y="2" width="40" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="40" id="7Iy-fW-KEp"/>
                                                             <constraint firstAttribute="width" secondItem="uwI-7W-5ox" secondAttribute="height" multiplier="1:1" id="NZl-He-mb2"/>
@@ -221,22 +224,22 @@
                                     <rect key="frame" x="0.0" y="0.0" width="385.5" height="108"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rw2-hs-mOB">
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rw2-hs-mOB">
                                             <rect key="frame" x="20" y="16" width="77" height="76"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="rw2-hs-mOB" secondAttribute="height" multiplier="1:1" id="Gdf-MD-KIj"/>
                                             </constraints>
                                             <imageReference key="image" image="pencil.circle" catalog="system" symbolScale="default"/>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bzs-PH-bgJ">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bzs-PH-bgJ">
                                             <rect key="frame" x="107" y="16" width="265.5" height="37"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SubTitle" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K3j-NM-een">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SubTitle" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K3j-NM-een">
                                             <rect key="frame" x="107" y="56" width="265.5" height="36"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
@@ -286,17 +289,17 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="aDx-Io-tXL">
-                                        <rect key="frame" x="20" y="0.0" width="374" height="1347.5"/>
+                                        <rect key="frame" x="20" y="0.0" width="374" height="1285"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="jikji" translatesAutoresizingMaskIntoConstraints="NO" id="Oy4-Rb-CEU">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="jikji" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Oy4-Rb-CEU">
                                                 <rect key="frame" x="0.0" y="0.0" width="374" height="374"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="Oy4-Rb-CEU" secondAttribute="height" multiplier="1:1" id="h3Z-LY-G0K"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="          Label          label            label          label       la be l        " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JoT-hA-mqq">
-                                                <rect key="frame" x="0.0" y="394" width="374" height="953.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="          Label          label            label          label       la be l        " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JoT-hA-mqq">
+                                                <rect key="frame" x="0.0" y="394" width="374" height="891"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>


### PR DESCRIPTION
안녕하세요 메이슨(@myssun0325) 😄
신나, 줄라이, 제인입니다!
STEP 3 진행 완료하여 PR 요청드립니다.
생각보다 너무 늦어졌네요 .... 죄송합니다.
그래도 이번 프로젝트에서는 오토레이아웃 공부와 접근성 지원 향상을 공부를 많이 한 것 같아
따로 질문 드릴 내용은 많이 없습니다. 
잘 부탁드립니다!! 👍


# 고민했던 부분

### 스크롤 뷰 오토레이아웃 설정 

첫번째와 세번째 화면을 스크롤 뷰에 스택 뷰를 넣어서 구성하였습니다.
스크롤뷰 오토레이아웃을 잡는데에 많은 시간이 걸렸는데, 정리해본 방법은 다음과 같습니다. 

1. 스크롤뷰 제약 설정: 상위뷰에 0 0 0 0 만큼 떨어지도록 제약 걸어주기
-> 스크롤뷰의 크기, 위치는 지정이됨 
-> 이때 빨간색 오류가 뜨는데 그것은 스크롤뷰가 안에있는 뷰의 크기에 따라 크기가 결정되기 때문이다
3. (스택)뷰를 스크롤뷰에 넣기
4. 스택뷰와 스크롤뷰의 Content Layout Guide에 Top, Bottom을 걸어준다
→ 스크롤뷰가 얼마만큼의 높이를 가지는지 알기때문에 스크롤이 동작한다 (최대 얼만큼 올라가고 내려가는지 알고있는 상태)
5. 스택뷰와 frame에 leading, trailing 걸어줘서 화면에 나올 폭을 설정해주기 (20 20 만큼 떨어지게)
6. content랑 equal width 갖는다고 설정



### 화면을 구성하는 좌표 

![](https://i.imgur.com/DPBDjEb.jpg)
![](https://i.imgur.com/p48i1zZ.jpg)


이번 프로젝트는 저희가 배우는 부분이 중요하다고 말씀해주셔서, 저희끼리 오토레이아웃에서 중요한 constrains이 어떻게 적용되는지, 왜 음수인 부분과 양수인 부분이 있는지에 대하여 이야기를 나눠봤습니다. 


## 질문 드리고 싶은 부분 


### 오토레이아웃

1. 세번째 화면에서 아이템에 관한 세부적인 항목을 보여줄 때, 스택뷰 내부의 이미지뷰의 Intrinsic 크기가 실제 보여지는 이미지의 크기와 일치하지 않는 경우가 있었습니다. 현재 이 현상을 이해해보고자 Autolayout의 hugging, content compression resistance priority 를 조정해보려고 시도했지만 1차적으로 실패했습니다. 따라서 임시방편으로 이미지뷰의 aspect ratio를 1:1로 주어해결해본 상황이지만 본질적으로 이 현상이 왜 발생하는지 이해하기 어려웠습니다.
    
    
    
2. 오토레이아웃을 잡아보고, 동적타입으로 화면의 구성요소를 바꿔봤는데, 스토리보드로 하나하나 보면서도 오토레이아웃을 제대로 못잡는데 코드로 훗날 UI를 구성하고 오토레이아웃을 잡는게 가능한지 ... 
물론 이번 프로젝트를 하면서 오토레이아웃에 대한 이야기를 정말 많이 나눠서 얻은건 많았지만 
* 어떤 개념을 추후에 더 공부해보면 될지 
* 팁 ? 같은게 있는지 궁금합니다. 