### PR TITLE
만국 박람회 [STEP 2] Lingo, 마이노

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		A11391D32804487600679361 /* ExpoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11391D22804487600679361 /* ExpoItem.swift */; };
 		A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14C2806940C006C3119 /* Decodable+Extension.swift */; };
 		A17EB1502806953A006C3119 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14F2806953A006C3119 /* DecodeError.swift */; };
+		B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD91A2806A3130000F636 /* Int+Extension.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
@@ -36,6 +37,7 @@
 		A11391D22804487600679361 /* ExpoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItem.swift; sourceTree = "<group>"; };
 		A17EB14C2806940C006C3119 /* Decodable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Extension.swift"; sourceTree = "<group>"; };
 		A17EB14F2806953A006C3119 /* DecodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
+		B05DD91A2806A3130000F636 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
 		B0749BF8280546E100836C3F /* AssetName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetName.swift; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				A17EB14C2806940C006C3119 /* Decodable+Extension.swift */,
+				B05DD91A2806A3130000F636 /* Int+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -279,6 +282,7 @@
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */,
 				A17EB1502806953A006C3119 /* DecodeError.swift in Sources */,
+				B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */,
 				A11391D1280447CA00679361 /* Expo.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				A11391D32804487600679361 /* ExpoItem.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD91A2806A3130000F636 /* Int+Extension.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
-		B07D87C62807F25300BE825B /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07D87C52807F25300BE825B /* Const.swift */; };
+		B07D87C62807F25300BE825B /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07D87C52807F25300BE825B /* Constants.swift */; };
 		B0A8E92A2807FFDB00A0EA98 /* UITableViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A8E9292807FFDB00A0EA98 /* UITableViewCell+Extension.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
@@ -53,7 +53,7 @@
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
 		B0749BF8280546E100836C3F /* AssetName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetName.swift; sourceTree = "<group>"; };
-		B07D87C52807F25300BE825B /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
+		B07D87C52807F25300BE825B /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		B0A8E9292807FFDB00A0EA98 /* UITableViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Extension.swift"; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -163,7 +163,7 @@
 				A17EB14E2806952B006C3119 /* Error */,
 				A17EB14B280693F2006C3119 /* Extension */,
 				B0749BF8280546E100836C3F /* AssetName.swift */,
-				B07D87C52807F25300BE825B /* Const.swift */,
+				B07D87C52807F25300BE825B /* Constants.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -323,7 +323,7 @@
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				A1DFB23B2807ED5E00375A6E /* AlertBuilder.swift in Sources */,
 				B0749BF9280546E100836C3F /* AssetName.swift in Sources */,
-				B07D87C62807F25300BE825B /* Const.swift in Sources */,
+				B07D87C62807F25300BE825B /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		A11391D32804487600679361 /* ExpoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11391D22804487600679361 /* ExpoItem.swift */; };
 		A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14C2806940C006C3119 /* Decodable+Extension.swift */; };
 		A17EB1502806953A006C3119 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14F2806953A006C3119 /* DecodeError.swift */; };
+		A17EB1522806A74A006C3119 /* ExpoItemTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1512806A74A006C3119 /* ExpoItemTableViewController.swift */; };
+		A17EB1542806AC13006C3119 /* ExpoItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */; };
 		B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD91A2806A3130000F636 /* Int+Extension.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
@@ -37,6 +39,8 @@
 		A11391D22804487600679361 /* ExpoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItem.swift; sourceTree = "<group>"; };
 		A17EB14C2806940C006C3119 /* Decodable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Extension.swift"; sourceTree = "<group>"; };
 		A17EB14F2806953A006C3119 /* DecodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
+		A17EB1512806A74A006C3119 /* ExpoItemTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemTableViewController.swift; sourceTree = "<group>"; };
+		A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemTableViewCell.swift; sourceTree = "<group>"; };
 		B05DD91A2806A3130000F636 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
@@ -100,6 +104,7 @@
 			children = (
 				C79FF4BA2589F401005FB0FD /* Main.storyboard */,
 				C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */,
+				A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -108,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
+				A17EB1512806A74A006C3119 /* ExpoItemTableViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -281,10 +287,12 @@
 			files = (
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */,
+				A17EB1542806AC13006C3119 /* ExpoItemTableViewCell.swift in Sources */,
 				A17EB1502806953A006C3119 /* DecodeError.swift in Sources */,
 				B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */,
 				A11391D1280447CA00679361 /* Expo.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
+				A17EB1522806A74A006C3119 /* ExpoItemTableViewController.swift in Sources */,
 				A11391D32804487600679361 /* ExpoItem.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				B0749BF9280546E100836C3F /* AssetName.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD91A2806A3130000F636 /* Int+Extension.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
+		B07D87C62807F25300BE825B /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07D87C52807F25300BE825B /* Const.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* MainViewController.swift */; };
@@ -51,6 +52,7 @@
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
 		B0749BF8280546E100836C3F /* AssetName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetName.swift; sourceTree = "<group>"; };
+		B07D87C52807F25300BE825B /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -158,6 +160,7 @@
 				A17EB14E2806952B006C3119 /* Error */,
 				A17EB14B280693F2006C3119 /* Extension */,
 				B0749BF8280546E100836C3F /* AssetName.swift */,
+				B07D87C52807F25300BE825B /* Const.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				A1DFB23B2807ED5E00375A6E /* AlertBuilder.swift in Sources */,
 				B0749BF9280546E100836C3F /* AssetName.swift in Sources */,
+				B07D87C62807F25300BE825B /* Const.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A17EB1542806AC13006C3119 /* ExpoItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */; };
 		A1CFA1192807B84F0084988D /* ExpoItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CFA1182807B84F0084988D /* ExpoItemDetailViewController.swift */; };
 		A1CFA11B2807BDF40084988D /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CFA11A2807BDF40084988D /* UIViewController+Extension.swift */; };
+		A1DFB23B2807ED5E00375A6E /* AlertBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DFB23A2807ED5E00375A6E /* AlertBuilder.swift */; };
 		B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD91A2806A3130000F636 /* Int+Extension.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
@@ -45,6 +46,7 @@
 		A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemTableViewCell.swift; sourceTree = "<group>"; };
 		A1CFA1182807B84F0084988D /* ExpoItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemDetailViewController.swift; sourceTree = "<group>"; };
 		A1CFA11A2807BDF40084988D /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
+		A1DFB23A2807ED5E00375A6E /* AlertBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertBuilder.swift; sourceTree = "<group>"; };
 		B05DD91A2806A3130000F636 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
@@ -104,6 +106,14 @@
 			path = Error;
 			sourceTree = "<group>";
 		};
+		A1DFB2392807ED3C00375A6E /* AlertBuilder */ = {
+			isa = PBXGroup;
+			children = (
+				A1DFB23A2807ED5E00375A6E /* AlertBuilder.swift */,
+			);
+			path = AlertBuilder;
+			sourceTree = "<group>";
+		};
 		B065BE702804432E00B92346 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +154,7 @@
 		B0749BF7280546CF00836C3F /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				A1DFB2392807ED3C00375A6E /* AlertBuilder */,
 				A17EB14E2806952B006C3119 /* Error */,
 				A17EB14B280693F2006C3119 /* Extension */,
 				B0749BF8280546E100836C3F /* AssetName.swift */,
@@ -303,6 +314,7 @@
 				A17EB1522806A74A006C3119 /* ExpoItemTableViewController.swift in Sources */,
 				A11391D32804487600679361 /* ExpoItem.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
+				A1DFB23B2807ED5E00375A6E /* AlertBuilder.swift in Sources */,
 				B0749BF9280546E100836C3F /* AssetName.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		A11391D1280447CA00679361 /* Expo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11391D0280447CA00679361 /* Expo.swift */; };
 		A11391D32804487600679361 /* ExpoItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11391D22804487600679361 /* ExpoItem.swift */; };
+		A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14C2806940C006C3119 /* Decodable+Extension.swift */; };
+		A17EB1502806953A006C3119 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14F2806953A006C3119 /* DecodeError.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
@@ -32,6 +34,8 @@
 /* Begin PBXFileReference section */
 		A11391D0280447CA00679361 /* Expo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expo.swift; sourceTree = "<group>"; };
 		A11391D22804487600679361 /* ExpoItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItem.swift; sourceTree = "<group>"; };
+		A17EB14C2806940C006C3119 /* Decodable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Extension.swift"; sourceTree = "<group>"; };
+		A17EB14F2806953A006C3119 /* DecodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
 		B0749BF8280546E100836C3F /* AssetName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetName.swift; sourceTree = "<group>"; };
@@ -72,6 +76,22 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		A17EB14B280693F2006C3119 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				A17EB14C2806940C006C3119 /* Decodable+Extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		A17EB14E2806952B006C3119 /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				A17EB14F2806953A006C3119 /* DecodeError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		B065BE702804432E00B92346 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -109,6 +129,8 @@
 		B0749BF7280546CF00836C3F /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				A17EB14E2806952B006C3119 /* Error */,
+				A17EB14B280693F2006C3119 /* Extension */,
 				B0749BF8280546E100836C3F /* AssetName.swift */,
 			);
 			path = Util;
@@ -255,6 +277,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
+				A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */,
+				A17EB1502806953A006C3119 /* DecodeError.swift in Sources */,
 				A11391D1280447CA00679361 /* Expo.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				A11391D32804487600679361 /* ExpoItem.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
 		B07D87C62807F25300BE825B /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = B07D87C52807F25300BE825B /* Const.swift */; };
+		B0A8E92A2807FFDB00A0EA98 /* UITableViewCell+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A8E9292807FFDB00A0EA98 /* UITableViewCell+Extension.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* MainViewController.swift */; };
@@ -53,6 +54,7 @@
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
 		B0749BF8280546E100836C3F /* AssetName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetName.swift; sourceTree = "<group>"; };
 		B07D87C52807F25300BE825B /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
+		B0A8E9292807FFDB00A0EA98 /* UITableViewCell+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Extension.swift"; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 				A17EB14C2806940C006C3119 /* Decodable+Extension.swift */,
 				B05DD91A2806A3130000F636 /* Int+Extension.swift */,
 				A1CFA11A2807BDF40084988D /* UIViewController+Extension.swift */,
+				B0A8E9292807FFDB00A0EA98 /* UITableViewCell+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -306,6 +309,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
+				B0A8E92A2807FFDB00A0EA98 /* UITableViewCell+Extension.swift in Sources */,
 				A1CFA11B2807BDF40084988D /* UIViewController+Extension.swift in Sources */,
 				A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */,
 				A17EB1542806AC13006C3119 /* ExpoItemTableViewCell.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		A17EB1502806953A006C3119 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB14F2806953A006C3119 /* DecodeError.swift */; };
 		A17EB1522806A74A006C3119 /* ExpoItemTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1512806A74A006C3119 /* ExpoItemTableViewController.swift */; };
 		A17EB1542806AC13006C3119 /* ExpoItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */; };
+		A1CFA1192807B84F0084988D /* ExpoItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CFA1182807B84F0084988D /* ExpoItemDetailViewController.swift */; };
+		A1CFA11B2807BDF40084988D /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CFA11A2807BDF40084988D /* UIViewController+Extension.swift */; };
 		B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05DD91A2806A3130000F636 /* Int+Extension.swift */; };
 		B065BF1228044A9800B92346 /* JSONDecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B065BF1128044A9800B92346 /* JSONDecodeTests.swift */; };
 		B0749BF9280546E100836C3F /* AssetName.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0749BF8280546E100836C3F /* AssetName.swift */; };
@@ -41,6 +43,8 @@
 		A17EB14F2806953A006C3119 /* DecodeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
 		A17EB1512806A74A006C3119 /* ExpoItemTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemTableViewController.swift; sourceTree = "<group>"; };
 		A17EB1532806AC13006C3119 /* ExpoItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemTableViewCell.swift; sourceTree = "<group>"; };
+		A1CFA1182807B84F0084988D /* ExpoItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoItemDetailViewController.swift; sourceTree = "<group>"; };
+		A1CFA11A2807BDF40084988D /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		B05DD91A2806A3130000F636 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		B065BF0F28044A9800B92346 /* Expo1900Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Expo1900Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B065BF1128044A9800B92346 /* JSONDecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodeTests.swift; sourceTree = "<group>"; };
@@ -87,6 +91,7 @@
 			children = (
 				A17EB14C2806940C006C3119 /* Decodable+Extension.swift */,
 				B05DD91A2806A3130000F636 /* Int+Extension.swift */,
+				A1CFA11A2807BDF40084988D /* UIViewController+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -114,6 +119,7 @@
 			children = (
 				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
 				A17EB1512806A74A006C3119 /* ExpoItemTableViewController.swift */,
+				A1CFA1182807B84F0084988D /* ExpoItemDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -286,11 +292,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
+				A1CFA11B2807BDF40084988D /* UIViewController+Extension.swift in Sources */,
 				A17EB14D2806940C006C3119 /* Decodable+Extension.swift in Sources */,
 				A17EB1542806AC13006C3119 /* ExpoItemTableViewCell.swift in Sources */,
 				A17EB1502806953A006C3119 /* DecodeError.swift in Sources */,
 				B05DD91B2806A3130000F636 /* Int+Extension.swift in Sources */,
 				A11391D1280447CA00679361 /* Expo.swift in Sources */,
+				A1CFA1192807B84F0084988D /* ExpoItemDetailViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				A17EB1522806A74A006C3119 /* ExpoItemTableViewController.swift in Sources */,
 				A11391D32804487600679361 /* ExpoItem.swift in Sources */,

--- a/Expo1900/Expo1900/Controller/ExpoItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemDetailViewController.swift
@@ -12,7 +12,7 @@ final class ExpoItemDetailViewController: UIViewController {
   @IBOutlet private weak var expoItemImageView: UIImageView!
   @IBOutlet private weak var expoItemDescriptionLabel: UILabel!
   
-  var expoItem: ExpoItem?
+  private var expoItem: ExpoItem?
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -20,11 +20,15 @@ final class ExpoItemDetailViewController: UIViewController {
   }
 }
 
-// MARK: - Private Extension
+// MARK: - Set Up
 
-private extension ExpoItemDetailViewController {
+extension ExpoItemDetailViewController {
   
-  func setUpView() {
+  func setUpExpoItem(_ expoItem: ExpoItem) {
+    self.expoItem = expoItem
+  }
+  
+  private func setUpView() {
     guard let expoItem = self.expoItem else {
       return
     }

--- a/Expo1900/Expo1900/Controller/ExpoItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemDetailViewController.swift
@@ -1,0 +1,35 @@
+//
+//  ExpoItemDetailViewController.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/14.
+//
+
+import UIKit
+
+final class ExpoItemDetailViewController: UIViewController {
+  
+  @IBOutlet private weak var expoItemImageView: UIImageView!
+  @IBOutlet private weak var expoItemDescriptionLabel: UILabel!
+  
+  var expoItem: ExpoItem?
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.setUpView()
+  }
+}
+
+// MARK: - Private Extension
+
+private extension ExpoItemDetailViewController {
+  
+  func setUpView() {
+    guard let expoItem = self.expoItem else {
+      return
+    }
+    self.navigationItem.title = expoItem.name
+    self.expoItemImageView.image = UIImage(named: expoItem.imageName)
+    self.expoItemDescriptionLabel.text = expoItem.description
+  }
+}

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -48,7 +48,7 @@ extension ExpoItemTableViewController {
     else {
       return
     }
-    detailViewController.expoItem = self.expoItems[indexPath.row]
+    detailViewController.setUpExpoItem(self.expoItems[indexPath.row])
     self.navigationController?.pushViewController(detailViewController, animated: true)
   }
 }

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -38,7 +38,9 @@ extension ExpoItemTableViewController {
     _ tableView: UITableView,
     didSelectRowAt indexPath: IndexPath
   ) {
-    guard let detailViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpoItemDetailViewController.identifier) as? ExpoItemDetailViewController else {
+    guard let detailViewController = self.storyboard?.instantiateViewController(
+      withIdentifier: ExpoItemDetailViewController.identifier) as? ExpoItemDetailViewController
+    else {
       return
     }
     detailViewController.expoItem = self.expoItems[indexPath.row]

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -1,0 +1,51 @@
+//
+//  ExpoItemTableViewController.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/13.
+//
+
+import UIKit
+
+final class ExpoItemTableViewController: UITableViewController {
+  
+  private var expoItems = [ExpoItem]()
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.parse()
+  }
+}
+
+private extension ExpoItemTableViewController {
+  
+  func parse() {
+    let parsedResult = [ExpoItem].decode(with: AssetName.expoItem)
+    guard let expoItems = try? parsedResult.get() else {
+      return
+    }
+    self.expoItems = expoItems
+  }
+}
+
+extension ExpoItemTableViewController {
+  
+  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return self.expoItems.count
+  }
+  
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    guard let cell = self.tableView.dequeueReusableCell(
+      withIdentifier: ExpoItemTableViewCell.identifier,
+      for: indexPath) as? ExpoItemTableViewCell
+    else {
+      return UITableViewCell()
+    }
+    
+    cell.expoItemTitleLabel.text = self.expoItems[indexPath.row].name
+    cell.expoItemDescriptionLabel.text = self.expoItems[indexPath.row].shortDescription
+    cell.expoItemImageView.image = UIImage(named: self.expoItems[indexPath.row].imageName)
+    
+    return cell
+  }
+}

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -28,24 +28,30 @@ private extension ExpoItemTableViewController {
   }
 }
 
+// MARK: - DataSource
+
 extension ExpoItemTableViewController {
-  
-  override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+
+  override func tableView(
+    _ tableView: UITableView,
+    numberOfRowsInSection section: Int
+  ) -> Int {
     return self.expoItems.count
   }
   
-  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+  override func tableView(
+    _ tableView: UITableView,
+    cellForRowAt indexPath: IndexPath
+  ) -> UITableViewCell {
     guard let cell = self.tableView.dequeueReusableCell(
       withIdentifier: ExpoItemTableViewCell.identifier,
       for: indexPath) as? ExpoItemTableViewCell
     else {
       return UITableViewCell()
     }
-    
     cell.expoItemTitleLabel.text = self.expoItems[indexPath.row].name
     cell.expoItemDescriptionLabel.text = self.expoItems[indexPath.row].shortDescription
     cell.expoItemImageView.image = UIImage(named: self.expoItems[indexPath.row].imageName)
-    
     return cell
   }
 }

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -17,6 +17,8 @@ final class ExpoItemTableViewController: UITableViewController {
   }
 }
 
+// MARK: - Private Extension
+
 private extension ExpoItemTableViewController {
   
   func parse() {
@@ -25,6 +27,22 @@ private extension ExpoItemTableViewController {
       return
     }
     self.expoItems = expoItems
+  }
+}
+
+// MARK: - Delegate
+
+extension ExpoItemTableViewController {
+  
+  override func tableView(
+    _ tableView: UITableView,
+    didSelectRowAt indexPath: IndexPath
+  ) {
+    guard let detailViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpoItemDetailViewController.identifier) as? ExpoItemDetailViewController else {
+      return
+    }
+    detailViewController.expoItem = self.expoItems[indexPath.row]
+    self.navigationController?.pushViewController(detailViewController, animated: true)
   }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -7,9 +7,11 @@
 
 import UIKit
 
-final class ExpoItemTableViewController: UITableViewController {
+final class ExpoItemTableViewController: UITableViewController, AlertPresentable {
   
   private var expoItems = [ExpoItem]()
+  
+  lazy var alertBuilder: AlertBuilderable = AlertBuilder(viewController: self)
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -22,7 +24,7 @@ final class ExpoItemTableViewController: UITableViewController {
 private extension ExpoItemTableViewController {
   
   func parse() {
-    let parsedResult = [ExpoItem].decode(with: "AssetName.expoItem")
+    let parsedResult = [ExpoItem].parseJSON(with: AssetName.expoItem)
     switch parsedResult {
     case let .success(expoItems):
       self.expoItems = expoItems

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -22,13 +22,13 @@ final class ExpoItemTableViewController: UITableViewController {
 private extension ExpoItemTableViewController {
   
   func parse() {
-    let parsedResult = [ExpoItem].decode(with: AssetName.expoItem)
+    let parsedResult = [ExpoItem].decode(with: "AssetName.expoItem")
     switch parsedResult {
     case let .success(expoItems):
       self.expoItems = expoItems
     case let .failure(error):
       alertBuilder
-        .setTitle(error.decription)
+        .setTitle(error.localizedDescription)
         .setConfirmTitle(Const.confirm)
         .showAlert()
     }

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -80,9 +80,7 @@ extension ExpoItemTableViewController {
     else {
       return UITableViewCell()
     }
-    cell.expoItemTitleLabel.text = self.expoItems[indexPath.row].name
-    cell.expoItemDescriptionLabel.text = self.expoItems[indexPath.row].shortDescription
-    cell.expoItemImageView.image = UIImage(named: self.expoItems[indexPath.row].imageName)
+    cell.setUpContentView(self.expoItems[indexPath.row])
     return cell
   }
 }

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+fileprivate extension Constants {
+  static let confirm = "확인"
+}
+
 final class ExpoItemTableViewController: UITableViewController, AlertPresentable {
   
   private var expoItems = [ExpoItem]()
@@ -31,7 +35,7 @@ private extension ExpoItemTableViewController {
     case let .failure(error):
       alertBuilder
         .setTitle(error.localizedDescription)
-        .setConfirmTitle(Const.confirm)
+        .setConfirmTitle(Constants.confirm)
         .showAlert()
     }
   }

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -29,7 +29,7 @@ private extension ExpoItemTableViewController {
     case let .failure(error):
       alertBuilder
         .setTitle(error.decription)
-        .setConfirmTitle("확인")
+        .setConfirmTitle(Const.confirm)
         .showAlert()
     }
   }

--- a/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoItemTableViewController.swift
@@ -23,10 +23,15 @@ private extension ExpoItemTableViewController {
   
   func parse() {
     let parsedResult = [ExpoItem].decode(with: AssetName.expoItem)
-    guard let expoItems = try? parsedResult.get() else {
-      return
+    switch parsedResult {
+    case let .success(expoItems):
+      self.expoItems = expoItems
+    case let .failure(error):
+      alertBuilder
+        .setTitle(error.decription)
+        .setConfirmTitle("확인")
+        .showAlert()
     }
-    self.expoItems = expoItems
   }
 }
 

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -49,7 +49,7 @@ private extension MainViewController {
       self.setUpView(from: expo)
     case let .failure(error):
       alertBuilder
-        .setTitle(error.decription)
+        .setTitle(error.localizedDescription)
         .setConfirmTitle(Const.confirm)
         .showAlert()
     }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -35,10 +35,15 @@ private extension MainViewController {
   
   func parse() {
     let parsedResult = Expo.decode(with: AssetName.expo)
-    guard let expo = try? parsedResult.get() else {
-      return
+    switch parsedResult {
+    case let .success(expo):
+      self.setUpView(from: expo)
+    case let .failure(error):
+      alertBuilder
+        .setTitle(error.decription)
+        .setConfirmTitle("확인")
+        .showAlert()
     }
-    self.setUpView(from: expo)
   }
   
   func setUpView(from expo: Expo) {

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -7,7 +7,17 @@ import UIKit
 
 final class MainViewController: UIViewController {
   
+  @IBOutlet private weak var titleLabel: UILabel!
+  @IBOutlet private weak var posterImageView: UIImageView!
+  @IBOutlet private weak var visitorsLabel: UILabel!
+  @IBOutlet private weak var locationLabel: UILabel!
+  @IBOutlet private weak var durationLabel: UILabel!
+  @IBOutlet private weak var descriptionLabel: UILabel!
+  
   override func viewDidLoad() {
     super.viewDidLoad()
+  }
+  
+  @IBAction private func didTapShowExpoItemsButton(_ sender: UIButton) {
   }
 }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -16,8 +16,34 @@ final class MainViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
+    self.configure()
   }
   
   @IBAction private func didTapShowExpoItemsButton(_ sender: UIButton) {
+  }
+}
+
+private extension MainViewController {
+  
+  func configure() {
+    self.navigationController?.isNavigationBarHidden = true
+    self.parse()
+  }
+  
+  func parse() {
+    let parsedResult = Expo.decode(with: AssetName.expo)
+    guard let expo = try? parsedResult.get() else {
+      return
+    }
+    self.setUpView(from: expo)
+  }
+  
+  func setUpView(from expo: Expo) {
+    self.titleLabel.text = expo.title.replacingOccurrences(of: "(", with: "\n(")
+    self.posterImageView.image = UIImage(named: AssetName.poster)
+    self.visitorsLabel.text = "방문객 : \(expo.visitors.toDecimal()) 명"
+    self.locationLabel.text = "개최지 : \(expo.location)"
+    self.durationLabel.text = "개최 기간 : \(expo.duration)"
+    self.descriptionLabel.text = expo.description
   }
 }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -19,6 +19,11 @@ final class MainViewController: UIViewController {
     self.configure()
   }
   
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    self.navigationController?.isNavigationBarHidden = false
+  }
+  
   @IBAction private func didTapShowExpoItemsButton(_ sender: UIButton) {
   }
 }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -32,6 +32,7 @@ final class MainViewController: UIViewController, AlertPresentable {
   }
   
   override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
     self.navigationController?.isNavigationBarHidden = true
   }
   

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -14,7 +14,7 @@ fileprivate extension Const {
   static let spacingBracket = "\n("
 }
 
-final class MainViewController: UIViewController {
+final class MainViewController: UIViewController, AlertPresentable {
   
   @IBOutlet private weak var titleLabel: UILabel!
   @IBOutlet private weak var posterImageView: UIImageView!
@@ -22,6 +22,9 @@ final class MainViewController: UIViewController {
   @IBOutlet private weak var locationLabel: UILabel!
   @IBOutlet private weak var durationLabel: UILabel!
   @IBOutlet private weak var descriptionLabel: UILabel!
+  
+  lazy var alertBuilder: AlertBuilderable = AlertBuilder(viewController: self)
+  
   
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -43,7 +46,7 @@ final class MainViewController: UIViewController {
 private extension MainViewController {
   
   func parse() {
-    let parsedResult = Expo.decode(with: AssetName.expo)
+    let parsedResult = Expo.parseJSON(with: AssetName.expo)
     switch parsedResult {
     case let .success(expo):
       self.setUpView(from: expo)

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -5,7 +5,8 @@
 
 import UIKit
 
-fileprivate extension Const {
+fileprivate extension Constants {
+  static let confirm = "확인"
   static let visitor = "방문객 : "
   static let personUnit = " 명"
   static let location = "개최지 : "
@@ -53,20 +54,20 @@ private extension MainViewController {
     case let .failure(error):
       alertBuilder
         .setTitle(error.localizedDescription)
-        .setConfirmTitle(Const.confirm)
+        .setConfirmTitle(Constants.confirm)
         .showAlert()
     }
   }
   
   func setUpView(from expo: Expo) {
     self.titleLabel.text = expo.title.replacingOccurrences(
-      of: Const.bracket,
-      with: Const.spacingBracket
+      of: Constants.bracket,
+      with: Constants.spacingBracket
     )
     self.posterImageView.image = UIImage(named: AssetName.poster)
-    self.visitorsLabel.text = Const.visitor + expo.visitors.toDecimal() + Const.personUnit
-    self.locationLabel.text = Const.location + expo.location
-    self.durationLabel.text = Const.duration + expo.duration
+    self.visitorsLabel.text = Constants.visitor + expo.visitors.toDecimal() + Constants.personUnit
+    self.locationLabel.text = Constants.location + expo.location
+    self.durationLabel.text = Constants.duration + expo.duration
     self.descriptionLabel.text = expo.description
   }
 }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -7,8 +7,7 @@ import UIKit
 
 fileprivate extension Constants {
   static let confirm = "확인"
-  static let visitor = "방문객 : "
-  static let personUnit = " 명"
+  static let visitor = "방문객 : %@ 명"
   static let location = "개최지 : "
   static let duration = "개최 기간 : "
   static let bracket = "("
@@ -65,7 +64,7 @@ private extension MainViewController {
       with: Constants.spacingBracket
     )
     self.posterImageView.image = UIImage(named: AssetName.poster)
-    self.visitorsLabel.text = Constants.visitor + expo.visitors.toDecimal() + Constants.personUnit
+    self.visitorsLabel.text = String(format: Constants.visitor, expo.visitors.toDecimal())
     self.locationLabel.text = Constants.location + expo.location
     self.durationLabel.text = Constants.duration + expo.duration
     self.descriptionLabel.text = expo.description

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -16,24 +16,22 @@ final class MainViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.configure()
+    self.parse()
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    self.navigationController?.isNavigationBarHidden = true
   }
   
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
     self.navigationController?.isNavigationBarHidden = false
   }
-  
-  @IBAction private func didTapShowExpoItemsButton(_ sender: UIButton) {
-  }
 }
 
+// MARK: - Private Extension
+
 private extension MainViewController {
-  
-  func configure() {
-    self.navigationController?.isNavigationBarHidden = true
-    self.parse()
-  }
   
   func parse() {
     let parsedResult = Expo.decode(with: AssetName.expo)

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -5,6 +5,15 @@
 
 import UIKit
 
+fileprivate extension Const {
+  static let visitor = "방문객 : "
+  static let personUnit = " 명"
+  static let location = "개최지 : "
+  static let duration = "개최 기간 : "
+  static let bracket = "("
+  static let spacingBracket = "\n("
+}
+
 final class MainViewController: UIViewController {
   
   @IBOutlet private weak var titleLabel: UILabel!
@@ -41,17 +50,20 @@ private extension MainViewController {
     case let .failure(error):
       alertBuilder
         .setTitle(error.decription)
-        .setConfirmTitle("확인")
+        .setConfirmTitle(Const.confirm)
         .showAlert()
     }
   }
   
   func setUpView(from expo: Expo) {
-    self.titleLabel.text = expo.title.replacingOccurrences(of: "(", with: "\n(")
+    self.titleLabel.text = expo.title.replacingOccurrences(
+      of: Const.bracket,
+      with: Const.spacingBracket
+    )
     self.posterImageView.image = UIImage(named: AssetName.poster)
-    self.visitorsLabel.text = "방문객 : \(expo.visitors.toDecimal()) 명"
-    self.locationLabel.text = "개최지 : \(expo.location)"
-    self.durationLabel.text = "개최 기간 : \(expo.duration)"
+    self.visitorsLabel.text = Const.visitor + expo.visitors.toDecimal() + Const.personUnit
+    self.locationLabel.text = Const.location + expo.location
+    self.durationLabel.text = Const.duration + expo.duration
     self.descriptionLabel.text = expo.description
   }
 }

--- a/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
+++ b/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
@@ -1,0 +1,88 @@
+//
+//  AlertBuilder.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/14.
+//
+
+import UIKit
+
+struct AlertProduct {
+  var title: String?
+  var confirmTitle: String?
+  var message: String?
+  var cancelTitle: String?
+  var confirmHandler: (() -> Void)?
+  var cancelHandler: (() -> Void)?
+}
+
+protocol AlertBuilderable {
+  init(viewController: UIViewController)
+  func setTitle(_ title: String) -> AlertBuilderable
+  func setConfirmTitle(_ confirmTitle: String) -> AlertBuilderable
+  func setMessage(_ message: String) -> AlertBuilderable
+  func setCancelTitle(_ cancelTitle: String) -> AlertBuilderable
+  func setConfirmHandler(_ confirmHandler: @escaping (() -> Void)) -> AlertBuilderable
+  func setCancelHandler(_ cancelHandler: @escaping (() -> Void)) -> AlertBuilderable
+  func showAlert()
+}
+
+final class AlertBuilder: AlertBuilderable {
+  private weak var viewController: UIViewController?
+  private var product = AlertProduct()
+  
+  init(viewController: UIViewController) {
+    self.viewController = viewController
+  }
+  
+  func setTitle(_ title: String) -> AlertBuilderable {
+    product.title = title
+    return self
+  }
+  
+  func setConfirmTitle(_ confirmTitle: String) -> AlertBuilderable {
+    product.confirmTitle = confirmTitle
+    return self
+  }
+  
+  func setMessage(_ message: String) -> AlertBuilderable {
+    product.message = message
+    return self
+  }
+  
+  func setCancelTitle(_ cancelTitle: String) -> AlertBuilderable {
+    product.cancelTitle = cancelTitle
+    return self
+  }
+  
+  func setConfirmHandler(_ confirmHandler: @escaping (() -> Void)) -> AlertBuilderable {
+    product.confirmHandler = confirmHandler
+    return self
+  }
+  
+  func setCancelHandler(_ cancelHandler: @escaping (() -> Void)) -> AlertBuilderable {
+    product.cancelHandler = cancelHandler
+    return self
+  }
+  
+  func showAlert() {
+    let alert = UIAlertController(title: product.title, message: product.message, preferredStyle: .alert)
+    
+    if let cancelTitle = product.cancelTitle {
+      let cancelButton = UIAlertAction(title: cancelTitle, style: .destructive, handler: { _ in
+        self.product.cancelHandler?()
+      })
+      alert.addAction(cancelButton)
+    }
+    
+    let confirmButton = UIAlertAction(title: product.confirmTitle, style: .default, handler: { [weak self] _ in
+      self?.product.confirmHandler?()
+    })
+    
+    alert.addAction(confirmButton)
+    
+    viewController?.present(alert, animated: true, completion: nil)
+  }
+}
+
+

--- a/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
+++ b/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
@@ -16,6 +16,10 @@ struct AlertProduct {
   var cancelHandler: (() -> Void)?
 }
 
+protocol AlertPresentable {
+  var alertBuilder: AlertBuilderable { get }
+}
+
 protocol AlertBuilderable {
   init(viewController: UIViewController)
   func setTitle(_ title: String) -> AlertBuilderable

--- a/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
+++ b/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
@@ -11,9 +11,6 @@ struct AlertProduct {
   var title: String?
   var confirmTitle: String?
   var message: String?
-  var cancelTitle: String?
-  var confirmHandler: (() -> Void)?
-  var cancelHandler: (() -> Void)?
 }
 
 protocol AlertPresentable {
@@ -24,10 +21,6 @@ protocol AlertBuilderable {
   init(viewController: UIViewController)
   func setTitle(_ title: String) -> AlertBuilderable
   func setConfirmTitle(_ confirmTitle: String) -> AlertBuilderable
-  func setMessage(_ message: String) -> AlertBuilderable
-  func setCancelTitle(_ cancelTitle: String) -> AlertBuilderable
-  func setConfirmHandler(_ confirmHandler: @escaping (() -> Void)) -> AlertBuilderable
-  func setCancelHandler(_ cancelHandler: @escaping (() -> Void)) -> AlertBuilderable
   func showAlert()
 }
 
@@ -49,26 +42,6 @@ final class AlertBuilder: AlertBuilderable {
     return self
   }
   
-  func setMessage(_ message: String) -> AlertBuilderable {
-    product.message = message
-    return self
-  }
-  
-  func setCancelTitle(_ cancelTitle: String) -> AlertBuilderable {
-    product.cancelTitle = cancelTitle
-    return self
-  }
-  
-  func setConfirmHandler(_ confirmHandler: @escaping (() -> Void)) -> AlertBuilderable {
-    product.confirmHandler = confirmHandler
-    return self
-  }
-  
-  func setCancelHandler(_ cancelHandler: @escaping (() -> Void)) -> AlertBuilderable {
-    product.cancelHandler = cancelHandler
-    return self
-  }
-  
   func showAlert() {
     let alert = UIAlertController(
       title: product.title,
@@ -76,23 +49,11 @@ final class AlertBuilder: AlertBuilderable {
       preferredStyle: .alert
     )
     
-    if let cancelTitle = product.cancelTitle {
-      let cancelButton = UIAlertAction(
-        title: cancelTitle,
-        style: .destructive
-      ) { _ in
-        self.product.cancelHandler?()
-      }
-      alert.addAction(cancelButton)
-    }
-    
     let confirmButton = UIAlertAction(
       title: product.confirmTitle,
       style: .default
-    ) { [weak self] _ in
-      self?.product.confirmHandler?()
-    }
-    
+    )
+        
     alert.addAction(confirmButton)
     viewController?.present(alert, animated: true, completion: nil)
   }

--- a/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
+++ b/Expo1900/Expo1900/Util/AlertBuilder/AlertBuilder.swift
@@ -66,21 +66,30 @@ final class AlertBuilder: AlertBuilderable {
   }
   
   func showAlert() {
-    let alert = UIAlertController(title: product.title, message: product.message, preferredStyle: .alert)
+    let alert = UIAlertController(
+      title: product.title,
+      message: product.message,
+      preferredStyle: .alert
+    )
     
     if let cancelTitle = product.cancelTitle {
-      let cancelButton = UIAlertAction(title: cancelTitle, style: .destructive, handler: { _ in
+      let cancelButton = UIAlertAction(
+        title: cancelTitle,
+        style: .destructive
+      ) { _ in
         self.product.cancelHandler?()
-      })
+      }
       alert.addAction(cancelButton)
     }
     
-    let confirmButton = UIAlertAction(title: product.confirmTitle, style: .default, handler: { [weak self] _ in
+    let confirmButton = UIAlertAction(
+      title: product.confirmTitle,
+      style: .default
+    ) { [weak self] _ in
       self?.product.confirmHandler?()
-    })
+    }
     
     alert.addAction(confirmButton)
-    
     viewController?.present(alert, animated: true, completion: nil)
   }
 }

--- a/Expo1900/Expo1900/Util/AssetName.swift
+++ b/Expo1900/Expo1900/Util/AssetName.swift
@@ -10,4 +10,5 @@ import Foundation
 enum AssetName {
   static let expo = "exposition_universelle_1900"
   static let expoItem = "items"
+  static let poster = "poster"
 }

--- a/Expo1900/Expo1900/Util/Const.swift
+++ b/Expo1900/Expo1900/Util/Const.swift
@@ -1,0 +1,12 @@
+//
+//  Const.swift
+//  Expo1900
+//
+//  Created by Lingo on 2022/04/14.
+//
+
+import Foundation
+
+enum Const {
+  static let confirm = "확인"
+}

--- a/Expo1900/Expo1900/Util/Constants.swift
+++ b/Expo1900/Expo1900/Util/Constants.swift
@@ -1,5 +1,5 @@
 //
-//  Const.swift
+//  Constants.swift
 //  Expo1900
 //
 //  Created by Lingo on 2022/04/14.
@@ -7,6 +7,4 @@
 
 import Foundation
 
-enum Const {
-  static let confirm = "확인"
-}
+enum Constants {}

--- a/Expo1900/Expo1900/Util/Error/DecodeError.swift
+++ b/Expo1900/Expo1900/Util/Error/DecodeError.swift
@@ -7,13 +7,13 @@
 
 import Foundation
 
-enum DecodeError: Error {
+enum DecodeError: LocalizedError {
   case notFoundAsset
   case decodeFail
 }
 
 extension DecodeError {
-  var decription: String {
+  var errorDescription: String? {
     switch self {
     case .notFoundAsset:
       return "에셋을 찾을 수 없습니다."

--- a/Expo1900/Expo1900/Util/Error/DecodeError.swift
+++ b/Expo1900/Expo1900/Util/Error/DecodeError.swift
@@ -11,3 +11,14 @@ enum DecodeError: Error {
   case notFoundAsset
   case decodeFail
 }
+
+extension DecodeError {
+  var decription: String {
+    switch self {
+    case .notFoundAsset:
+      return "에셋을 찾을 수 없습니다."
+    case .decodeFail:
+      return "서버와 연결에 실패했습니다."
+    }
+  }
+}

--- a/Expo1900/Expo1900/Util/Error/DecodeError.swift
+++ b/Expo1900/Expo1900/Util/Error/DecodeError.swift
@@ -8,5 +8,6 @@
 import Foundation
 
 enum DecodeError: Error {
+  case notFoundAsset
   case decodeFail
 }

--- a/Expo1900/Expo1900/Util/Error/DecodeError.swift
+++ b/Expo1900/Expo1900/Util/Error/DecodeError.swift
@@ -1,0 +1,12 @@
+//
+//  DecodeError.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/13.
+//
+
+import Foundation
+
+enum DecodeError: Error {
+  case decodeFail
+}

--- a/Expo1900/Expo1900/Util/Extension/Decodable+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/Decodable+Extension.swift
@@ -1,0 +1,21 @@
+//
+//  Decodable+Extension.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/13.
+//
+
+import UIKit
+
+extension Decodable {
+  
+  static func decode(with assetName: String) -> Result<Self, DecodeError> {
+    let decoder = JSONDecoder()
+    guard let asset = NSDataAsset(name: assetName, bundle: .main),
+          let data = try? decoder.decode(Self.self, from: asset.data)
+    else {
+      return .failure(.decodeFail)
+    }
+    return .success(data)
+  }
+}

--- a/Expo1900/Expo1900/Util/Extension/Decodable+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/Decodable+Extension.swift
@@ -11,9 +11,10 @@ extension Decodable {
   
   static func decode(with assetName: String) -> Result<Self, DecodeError> {
     let decoder = JSONDecoder()
-    guard let asset = NSDataAsset(name: assetName, bundle: .main),
-          let data = try? decoder.decode(Self.self, from: asset.data)
-    else {
+    guard let asset = NSDataAsset(name: assetName) else {
+      return .failure(.notFoundAsset)
+    }
+    guard let data = try? decoder.decode(Self.self, from: asset.data) else {
       return .failure(.decodeFail)
     }
     return .success(data)

--- a/Expo1900/Expo1900/Util/Extension/Decodable+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/Decodable+Extension.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension Decodable {
   
-  static func decode(with assetName: String) -> Result<Self, DecodeError> {
+  static func parseJSON(with assetName: String) -> Result<Self, DecodeError> {
     let decoder = JSONDecoder()
     guard let asset = NSDataAsset(name: assetName) else {
       return .failure(.notFoundAsset)

--- a/Expo1900/Expo1900/Util/Extension/Int+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/Int+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  Int+Extension.swift
+//  Expo1900
+//
+//  Created by Lingo on 2022/04/13.
+//
+
+import Foundation
+
+extension Int {
+  
+  func toDecimal() -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(for: self) ?? ""
+  }
+}

--- a/Expo1900/Expo1900/Util/Extension/UITableViewCell+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/UITableViewCell+Extension.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 extension UITableViewCell {
+  
   static var identifier: String {
     return String(describing: self)
   }

--- a/Expo1900/Expo1900/Util/Extension/UITableViewCell+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/UITableViewCell+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UITableViewCell+Extension.swift
+//  Expo1900
+//
+//  Created by Lingo on 2022/04/14.
+//
+
+import UIKit
+
+extension UITableViewCell {
+  static var identifier: String {
+    return String(describing: self)
+  }
+}

--- a/Expo1900/Expo1900/Util/Extension/UIViewController+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/UIViewController+Extension.swift
@@ -7,8 +7,16 @@
 
 import UIKit
 
-extension UIViewController {
+protocol UIViewControllerable {
+  var alertBuilder: AlertBuilderable { get }
+}
+
+extension UIViewController: UIViewControllerable {
   static var identifier: String {
     return String(describing: self)
+  }
+  
+  var alertBuilder: AlertBuilderable {
+    AlertBuilder(viewController: self)
   }
 }

--- a/Expo1900/Expo1900/Util/Extension/UIViewController+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/UIViewController+Extension.swift
@@ -1,0 +1,14 @@
+//
+//  UIViewController+Extension.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/14.
+//
+
+import UIKit
+
+extension UIViewController {
+  static var identifier: String {
+    return String(describing: self)
+  }
+}

--- a/Expo1900/Expo1900/Util/Extension/UIViewController+Extension.swift
+++ b/Expo1900/Expo1900/Util/Extension/UIViewController+Extension.swift
@@ -7,16 +7,9 @@
 
 import UIKit
 
-protocol UIViewControllerable {
-  var alertBuilder: AlertBuilderable { get }
-}
-
-extension UIViewController: UIViewControllerable {
+extension UIViewController {
+  
   static var identifier: String {
     return String(describing: self)
-  }
-  
-  var alertBuilder: AlertBuilderable {
-    AlertBuilder(viewController: self)
   }
 }

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -200,6 +200,62 @@
             </objects>
             <point key="canvasLocation" x="1908" y="-8"/>
         </scene>
+        <!--Expo Item Detail View Controller-->
+        <scene sceneID="A7O-mr-wlM">
+            <objects>
+                <viewController storyboardIdentifier="ExpoItemDetailViewController" id="R7f-Do-S29" customClass="ExpoItemDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="VPo-TE-clf">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2So-Kp-XhC">
+                                <rect key="frame" x="0.0" y="44" width="390" height="766"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bJq-S8-fw2">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="148.33333333333334"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="flR-uk-Km7">
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="128"/>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dKB-ZY-84b">
+                                                <rect key="frame" x="0.0" y="127.99999999999999" width="390" height="20.333333333333329"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="bJq-S8-fw2" firstAttribute="top" secondItem="2So-Kp-XhC" secondAttribute="top" id="0BX-dd-w7u"/>
+                                    <constraint firstItem="bJq-S8-fw2" firstAttribute="width" secondItem="2So-Kp-XhC" secondAttribute="width" id="0e6-yV-xJ2"/>
+                                    <constraint firstItem="bJq-S8-fw2" firstAttribute="leading" secondItem="2So-Kp-XhC" secondAttribute="leading" id="CfW-uz-1En"/>
+                                    <constraint firstAttribute="trailing" secondItem="bJq-S8-fw2" secondAttribute="trailing" id="GvN-Ww-leW"/>
+                                    <constraint firstItem="bJq-S8-fw2" firstAttribute="height" secondItem="Fbx-rG-Dqz" secondAttribute="height" priority="250" id="dbk-A8-kg2"/>
+                                    <constraint firstAttribute="bottom" secondItem="bJq-S8-fw2" secondAttribute="bottom" id="m7F-iC-D48"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="mSc-as-0IY"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="Fbx-rG-Dqz"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="GRC-o9-ndj"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="GRC-o9-ndj" firstAttribute="leading" secondItem="2So-Kp-XhC" secondAttribute="leading" id="GpZ-u0-Ses"/>
+                            <constraint firstItem="GRC-o9-ndj" firstAttribute="top" secondItem="2So-Kp-XhC" secondAttribute="top" id="JEW-NE-BFC"/>
+                            <constraint firstItem="2So-Kp-XhC" firstAttribute="bottom" secondItem="GRC-o9-ndj" secondAttribute="bottom" id="RWw-1e-Stc"/>
+                            <constraint firstItem="GRC-o9-ndj" firstAttribute="trailing" secondItem="2So-Kp-XhC" secondAttribute="trailing" id="sEd-fz-9bm"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="expoItemDescriptionLabel" destination="dKB-ZY-84b" id="gw4-C8-tu1"/>
+                        <outlet property="expoItemImageView" destination="flR-uk-Km7" id="BBf-pI-8XO"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="YhF-7X-XYY" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2717" y="-6"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="j8R-KK-paY">
             <objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -20,8 +20,8 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NaJ-XX-Xwe">
                                 <rect key="frame" x="0.0" y="0.0" width="390" height="810"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QaZ-UD-jdK">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="295.33333333333331"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QaZ-UD-jdK">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="355.33333333333331"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-HW-xwt">
                                                 <rect key="frame" x="0.0" y="0.0" width="390" height="36"/>
@@ -30,34 +30,34 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ifB-rw-ULd">
-                                                <rect key="frame" x="0.0" y="36" width="390" height="128"/>
+                                                <rect key="frame" x="0.0" y="46" width="390" height="128"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40W-Ig-kQc">
-                                                <rect key="frame" x="0.0" y="164" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="184" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9U-Wq-qoa">
-                                                <rect key="frame" x="0.0" y="184.33333333333334" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="214.33333333333334" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-9B-Ab4">
-                                                <rect key="frame" x="0.0" y="204.66666666666666" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="244.66666666666666" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-L4-glZ">
-                                                <rect key="frame" x="0.0" y="225" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="275" width="390" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UST-BH-vuV">
-                                                <rect key="frame" x="0.0" y="245.33333333333337" width="390" height="50"/>
+                                                <rect key="frame" x="0.0" y="305.33333333333331" width="390" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="Lbp-19-QQI">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -211,14 +211,14 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2So-Kp-XhC">
                                 <rect key="frame" x="0.0" y="44" width="390" height="766"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bJq-S8-fw2">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="148.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="bJq-S8-fw2">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="199"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="flR-uk-Km7">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="128"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="168.66666666666666"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dKB-ZY-84b">
-                                                <rect key="frame" x="0.0" y="127.99999999999999" width="390" height="20.333333333333329"/>
+                                                <rect key="frame" x="0.0" y="178.66666666666666" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -244,6 +244,7 @@
                             <constraint firstItem="GRC-o9-ndj" firstAttribute="leading" secondItem="2So-Kp-XhC" secondAttribute="leading" id="GpZ-u0-Ses"/>
                             <constraint firstItem="GRC-o9-ndj" firstAttribute="top" secondItem="2So-Kp-XhC" secondAttribute="top" id="JEW-NE-BFC"/>
                             <constraint firstItem="2So-Kp-XhC" firstAttribute="bottom" secondItem="GRC-o9-ndj" secondAttribute="bottom" id="RWw-1e-Stc"/>
+                            <constraint firstItem="flR-uk-Km7" firstAttribute="height" secondItem="VPo-TE-clf" secondAttribute="height" multiplier="0.2" id="gW0-7Q-bus"/>
                             <constraint firstItem="GRC-o9-ndj" firstAttribute="trailing" secondItem="2So-Kp-XhC" secondAttribute="trailing" id="sEd-fz-9bm"/>
                         </constraints>
                     </view>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -21,45 +21,45 @@
                                 <rect key="frame" x="0.0" y="0.0" width="390" height="810"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QaZ-UD-jdK">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="279.66666666666669"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="295.33333333333331"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-HW-xwt">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="20.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-HW-xwt">
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="36"/>
+                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ifB-rw-ULd">
-                                                <rect key="frame" x="0.0" y="20.333333333333329" width="390" height="127.99999999999999"/>
+                                                <rect key="frame" x="0.0" y="36" width="390" height="128"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40W-Ig-kQc">
-                                                <rect key="frame" x="0.0" y="148.33333333333334" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="164" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9U-Wq-qoa">
-                                                <rect key="frame" x="0.0" y="168.66666666666666" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="184.33333333333334" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-9B-Ab4">
-                                                <rect key="frame" x="0.0" y="189" width="390" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="204.66666666666666" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-L4-glZ">
-                                                <rect key="frame" x="0.0" y="209.33333333333334" width="390" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-L4-glZ">
+                                                <rect key="frame" x="0.0" y="225" width="390" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UST-BH-vuV">
-                                                <rect key="frame" x="0.0" y="229.66666666666666" width="390" height="49.999999999999972"/>
+                                                <rect key="frame" x="0.0" y="245.33333333333337" width="390" height="50"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Lbp-19-QQI">
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="Lbp-19-QQI">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="wMn-cX-C4d"/>
@@ -69,12 +69,12 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="97r-67-9OL">
                                                         <rect key="frame" x="50" y="0.0" width="290" height="50"/>
                                                         <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
                                                             <action selector="didTapShowExpoItemsButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="33z-7t-yM4"/>
                                                         </connections>
                                                     </button>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RlA-eQ-kDS">
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="RlA-eQ-kDS">
                                                         <rect key="frame" x="340" y="0.0" width="50" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="50" id="DeA-IC-L0X"/>
@@ -139,6 +139,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="flag" width="851" height="567"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Main View Controller-->
+        <!--메인-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
@@ -72,6 +72,7 @@
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
                                                             <action selector="didTapShowExpoItemsButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="33z-7t-yM4"/>
+                                                            <segue destination="13a-EP-orK" kind="show" id="7W3-ZR-lzw"/>
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="RlA-eQ-kDS">
@@ -107,7 +108,7 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="NaJ-XX-Xwe" secondAttribute="bottom" id="gfF-HX-4D0"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="g05-h8-2tk"/>
+                    <navigationItem key="navigationItem" title="메인" id="g05-h8-2tk"/>
                     <connections>
                         <outlet property="descriptionLabel" destination="J2e-L4-glZ" id="wi5-uN-8df"/>
                         <outlet property="durationLabel" destination="XRZ-9B-Ab4" id="Y4f-wZ-sus"/>
@@ -120,6 +121,85 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1073.8461538461538" y="-6.3981042654028437"/>
+        </scene>
+        <!--한국의 출품작-->
+        <scene sceneID="od8-qX-dAB">
+            <objects>
+                <tableViewController id="13a-EP-orK" customClass="ExpoItemTableViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="8RL-ub-xQY">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="ExpoItemTableViewCell" id="8XE-f3-rpL" customClass="ExpoItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="51.666667938232422"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8XE-f3-rpL" id="pXi-28-ulE">
+                                    <rect key="frame" x="0.0" y="0.0" width="361.33333333333331" height="51.666667938232422"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hfN-rW-9lY">
+                                            <rect key="frame" x="10" y="0.0" width="351.33333333333331" height="51.666666666666664"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OMo-20-HGm">
+                                                    <rect key="frame" x="0.0" y="0.0" width="50" height="51.666666666666664"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XK0-MA-kXf">
+                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="51.666666666666664"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="50" id="XMv-yL-lKJ"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                    </subviews>
+                                                </stackView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="W8A-b9-85J">
+                                                    <rect key="frame" x="60" y="0.0" width="291.33333333333331" height="51.666666666666664"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4gD-gf-VvS">
+                                                            <rect key="frame" x="0.0" y="0.0" width="291.33333333333331" height="30"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="30" id="kD3-e3-KAX"/>
+                                                            </constraints>
+                                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="24"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zql-9c-jx2">
+                                                            <rect key="frame" x="0.0" y="30" width="291.33333333333331" height="21.666666666666671"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="XK0-MA-kXf" firstAttribute="height" secondItem="pXi-28-ulE" secondAttribute="height" id="9HH-n9-yT7"/>
+                                        <constraint firstItem="hfN-rW-9lY" firstAttribute="leading" secondItem="pXi-28-ulE" secondAttribute="leading" constant="10" id="T8M-uV-bvG"/>
+                                        <constraint firstAttribute="trailing" secondItem="hfN-rW-9lY" secondAttribute="trailing" id="TB4-Al-iXZ"/>
+                                        <constraint firstAttribute="bottom" secondItem="hfN-rW-9lY" secondAttribute="bottom" id="Y9D-Bo-Cfn"/>
+                                        <constraint firstItem="hfN-rW-9lY" firstAttribute="top" secondItem="pXi-28-ulE" secondAttribute="top" id="zft-cH-aRu"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="expoItemDescriptionLabel" destination="Zql-9c-jx2" id="1E1-Ia-KfY"/>
+                                    <outlet property="expoItemImageView" destination="XK0-MA-kXf" id="RZV-dd-oMi"/>
+                                    <outlet property="expoItemTitleLabel" destination="4gD-gf-VvS" id="pnm-nO-nvz"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="13a-EP-orK" id="G1l-KV-TIu"/>
+                            <outlet property="delegate" destination="13a-EP-orK" id="MBh-j5-wp7"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="한국의 출품작" id="h7R-NN-wkR"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Foh-q2-ggL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1908" y="-8"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="j8R-KK-paY">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -21,43 +21,43 @@
                                 <rect key="frame" x="0.0" y="0.0" width="390" height="810"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QaZ-UD-jdK">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="355.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="388"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-HW-xwt">
-                                                <rect key="frame" x="0.0" y="0.0" width="390" height="36"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-HW-xwt">
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="30"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ifB-rw-ULd">
-                                                <rect key="frame" x="0.0" y="46" width="390" height="128"/>
+                                                <rect key="frame" x="0.0" y="10" width="390" height="128"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40W-Ig-kQc">
-                                                <rect key="frame" x="0.0" y="184" width="390" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40W-Ig-kQc">
+                                                <rect key="frame" x="0.0" y="148" width="390" height="50"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9U-Wq-qoa">
-                                                <rect key="frame" x="0.0" y="214.33333333333334" width="390" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9U-Wq-qoa">
+                                                <rect key="frame" x="0.0" y="208" width="390" height="50"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-9B-Ab4">
-                                                <rect key="frame" x="0.0" y="244.66666666666666" width="390" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-9B-Ab4">
+                                                <rect key="frame" x="0.0" y="268" width="390" height="50"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-L4-glZ">
-                                                <rect key="frame" x="0.0" y="275" width="390" height="20.333333333333314"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-L4-glZ">
+                                                <rect key="frame" x="0.0" y="328" width="390" height="0.0"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UST-BH-vuV">
-                                                <rect key="frame" x="0.0" y="305.33333333333331" width="390" height="50"/>
+                                                <rect key="frame" x="0.0" y="338" width="390" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="Lbp-19-QQI">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="EeU-HP-OJ9">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -10,16 +12,130 @@
         <!--Main View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NaJ-XX-Xwe">
+                                <rect key="frame" x="0.0" y="0.0" width="390" height="810"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QaZ-UD-jdK">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="279.66666666666669"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uEK-HW-xwt">
+                                                <rect key="frame" x="0.0" y="0.0" width="390" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ifB-rw-ULd">
+                                                <rect key="frame" x="0.0" y="20.333333333333329" width="390" height="127.99999999999999"/>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="40W-Ig-kQc">
+                                                <rect key="frame" x="0.0" y="148.33333333333334" width="390" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b9U-Wq-qoa">
+                                                <rect key="frame" x="0.0" y="168.66666666666666" width="390" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XRZ-9B-Ab4">
+                                                <rect key="frame" x="0.0" y="189" width="390" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J2e-L4-glZ">
+                                                <rect key="frame" x="0.0" y="209.33333333333334" width="390" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UST-BH-vuV">
+                                                <rect key="frame" x="0.0" y="229.66666666666666" width="390" height="49.999999999999972"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Lbp-19-QQI">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="50" id="wMn-cX-C4d"/>
+                                                            <constraint firstAttribute="width" constant="50" id="yc7-DH-O21"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="97r-67-9OL">
+                                                        <rect key="frame" x="50" y="0.0" width="290" height="50"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                        <connections>
+                                                            <action selector="didTapShowExpoItemsButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="33z-7t-yM4"/>
+                                                        </connections>
+                                                    </button>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RlA-eQ-kDS">
+                                                        <rect key="frame" x="340" y="0.0" width="50" height="50"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="50" id="DeA-IC-L0X"/>
+                                                            <constraint firstAttribute="height" constant="50" id="ZCn-b2-J2y"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="QaZ-UD-jdK" firstAttribute="height" secondItem="oOH-0n-wxj" secondAttribute="height" priority="250" id="Dn7-Zm-JwQ"/>
+                                    <constraint firstItem="QaZ-UD-jdK" firstAttribute="top" secondItem="NaJ-XX-Xwe" secondAttribute="top" id="h95-E4-oBw"/>
+                                    <constraint firstItem="QaZ-UD-jdK" firstAttribute="width" secondItem="NaJ-XX-Xwe" secondAttribute="width" id="lHs-Su-Ymf"/>
+                                    <constraint firstItem="QaZ-UD-jdK" firstAttribute="leading" secondItem="NaJ-XX-Xwe" secondAttribute="leading" id="ppF-cW-err"/>
+                                    <constraint firstAttribute="trailing" secondItem="QaZ-UD-jdK" secondAttribute="trailing" id="pr7-b6-K6l"/>
+                                    <constraint firstAttribute="bottom" secondItem="QaZ-UD-jdK" secondAttribute="bottom" id="yoi-vc-uAR"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="MyX-NO-hD1"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="oOH-0n-wxj"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="NaJ-XX-Xwe" secondAttribute="trailing" id="OiX-WF-Bi8"/>
+                            <constraint firstItem="NaJ-XX-Xwe" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="RNr-gC-iHm"/>
+                            <constraint firstItem="NaJ-XX-Xwe" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="bly-Oy-iTT"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="NaJ-XX-Xwe" secondAttribute="bottom" id="gfF-HX-4D0"/>
+                        </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="g05-h8-2tk"/>
+                    <connections>
+                        <outlet property="descriptionLabel" destination="J2e-L4-glZ" id="wi5-uN-8df"/>
+                        <outlet property="durationLabel" destination="XRZ-9B-Ab4" id="Y4f-wZ-sus"/>
+                        <outlet property="locationLabel" destination="b9U-Wq-qoa" id="kCF-9L-Nig"/>
+                        <outlet property="posterImageView" destination="ifB-rw-ULd" id="KAG-hK-v4R"/>
+                        <outlet property="titleLabel" destination="uEK-HW-xwt" id="XSm-ox-BkO"/>
+                        <outlet property="visitorsLabel" destination="40W-Ig-kQc" id="hXs-t1-qB6"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="1073.8461538461538" y="-6.3981042654028437"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="j8R-KK-paY">
+            <objects>
+                <navigationController id="EeU-HP-OJ9" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Q9C-1N-NVo">
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="otu-g7-ZAI"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yhp-Ht-1N7" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="314" y="-6"/>
         </scene>
     </scenes>
     <resources>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -71,7 +71,6 @@
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
-                                                            <action selector="didTapShowExpoItemsButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="33z-7t-yM4"/>
                                                             <segue destination="13a-EP-orK" kind="show" id="7W3-ZR-lzw"/>
                                                         </connections>
                                                     </button>

--- a/Expo1900/Expo1900/View/ExpoItemTableViewCell.swift
+++ b/Expo1900/Expo1900/View/ExpoItemTableViewCell.swift
@@ -1,0 +1,25 @@
+//
+//  ExpoItemTableViewCell.swift
+//  Expo1900
+//
+//  Created by 조민호 on 2022/04/13.
+//
+
+import UIKit
+
+final class ExpoItemTableViewCell: UITableViewCell {
+  
+  static let identifier = String(describing: ExpoItemTableViewCell.self)
+  
+  @IBOutlet weak var expoItemImageView: UIImageView!
+  @IBOutlet weak var expoItemTitleLabel: UILabel!
+  @IBOutlet weak var expoItemDescriptionLabel: UILabel!
+  
+  override func awakeFromNib() {
+    super.awakeFromNib()
+  }
+  
+  override func setSelected(_ selected: Bool, animated: Bool) {
+    super.setSelected(selected, animated: animated)
+  }
+}

--- a/Expo1900/Expo1900/View/ExpoItemTableViewCell.swift
+++ b/Expo1900/Expo1900/View/ExpoItemTableViewCell.swift
@@ -20,4 +20,10 @@ final class ExpoItemTableViewCell: UITableViewCell {
   override func setSelected(_ selected: Bool, animated: Bool) {
     super.setSelected(selected, animated: animated)
   }
+  
+  func setUpContentView(_ expoItem: ExpoItem) {
+    self.expoItemTitleLabel.text = expoItem.name
+    self.expoItemDescriptionLabel.text = expoItem.shortDescription
+    self.expoItemImageView.image = UIImage(named: expoItem.imageName)
+  }
 }

--- a/Expo1900/Expo1900/View/ExpoItemTableViewCell.swift
+++ b/Expo1900/Expo1900/View/ExpoItemTableViewCell.swift
@@ -9,8 +9,6 @@ import UIKit
 
 final class ExpoItemTableViewCell: UITableViewCell {
   
-  static let identifier = String(describing: ExpoItemTableViewCell.self)
-  
   @IBOutlet weak var expoItemImageView: UIImageView!
   @IBOutlet weak var expoItemTitleLabel: UILabel!
   @IBOutlet weak var expoItemDescriptionLabel: UILabel!

--- a/Expo1900/Expo1900Tests/JSONDecodeTests.swift
+++ b/Expo1900/Expo1900Tests/JSONDecodeTests.swift
@@ -61,4 +61,10 @@ final class JSONDecodeTests: XCTestCase {
     }
     XCTAssertEqual(expoItems[0].name, "직지심체요절")
   }
+  
+  func testDecode_WhenExpoItemDataProvided_ResultShouldNotThrowError() {
+    // given when then
+    let expoItemResult = [ExpoItem].decode(with: AssetName.expoItem)
+    XCTAssertNoThrow(try? expoItemResult.get())
+  }
 }

--- a/Expo1900/Expo1900Tests/JSONDecodeTests.swift
+++ b/Expo1900/Expo1900Tests/JSONDecodeTests.swift
@@ -64,7 +64,7 @@ final class JSONDecodeTests: XCTestCase {
   
   func testDecode_WhenExpoItemDataProvided_ResultShouldNotThrowError() {
     // given when then
-    let expoItemResult = [ExpoItem].decode(with: AssetName.expoItem)
+    let expoItemResult = [ExpoItem].parseJSON(with: AssetName.expoItem)
     XCTAssertNoThrow(try? expoItemResult.get())
   }
 }


### PR DESCRIPTION
@wonhee009 
안녕하세요 라자냐 👍
만국 박람회 [STEP 2] PR 보냅니다. 잘 부탁드립니다!

### 고민 및 해결한 점
- 요구사항에 오토레이아웃은 STEP 3부터 적용한다고 되어있었지만 보기에 불편하지 않게끔만 적용했습니다. 
- Decodable Extension으로 JSON 디코딩 기능을 분리하여 재사용할 수 있도록 했습니다.
- Asset을 가져오는 과정에서의 에러와 Decode 에러 처리를 분리하였습니다.
- 디코딩의 결과를 Result 타입을 통해 반환하여 ViewController에서 `success`, `failure` 케이스에 따라 사용할 수 있도록 했습니다.
- 테이블 뷰를 ViewController에 Delegate, Datasource로 생성하는 방법도 있지만 이번 프로젝트에서는 UITableViewController를 사용해봤습니다.
- Alert을 효율적으로 재사용하기 위해 Builder 패턴을 적용하여 AlertBuilder로 생성할 수 있도록 했습니다.
- 매직리터널을 제거하기 위해 상수로 분리했습니다.
- MainViewController의 크기가 다른 Label을 하나의 Label로 할지 Label를 분리할 지 고민하였고 
STEP 3에서 `AttributedText`를 사용해서 각 문자의 크기를 변경해보기로 했습니다.
- ViewController과 TableViewCell의 identifier를 사용하는 코드의 중복을 막기 위해 Extension으로 아래와 같이 분리했습니다.
```swift
extension UIViewController: UIViewControllerable {
  static var identifier: String {
    return String(describing: self)
  }
}

extension UITableViewCell {
  static var identifier: String {
    return String(describing: self)
  }
}
```

### 조언 받고 싶은 점
MainViewController의 네비게이션바를 MainViewController의 라이프사이클에서 hidden 처리를 했는데 더 좋은 방법이 있을 지 궁금합니다.
```swift
override func viewWillAppear(_ animated: Bool) {
  self.navigationController?.isNavigationBarHidden = true
}

override func viewWillDisappear(_ animated: Bool) {
  super.viewWillDisappear(animated)
  self.navigationController?.isNavigationBarHidden = false
}
```



