### PR TITLE
만국 박람회 [STEP 3] 쿼카, Tiana

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0EA3879128044C07005A48A6 /* KoreanHistoricalItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */; };
 		0EA38799280458CF005A48A6 /* KoreanHistoricalItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */; };
 		AB03BD66280806D100F3A2B4 /* KoreanItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03BD65280806D100F3A2B4 /* KoreanItemTableViewCell.swift */; };
+		AB206D42280EC6570048649B /* AlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB206D41280EC6570048649B /* AlertMessage.swift */; };
+		AB206D44280EC9130048649B /* FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB206D43280EC9130048649B /* FileName.swift */; };
 		AB245AD02804569A0061D087 /* ParisExpo.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB245ACF2804569A0061D087 /* ParisExpo.swift */; };
 		AB245AD828045FFB0061D087 /* ParisExpoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB245AD728045FFB0061D087 /* ParisExpoTests.swift */; };
 		AB717BC32807C6E4001B7F6B /* ExpoAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AB717BC22807C6E4001B7F6B /* ExpoAssets.xcassets */; };
@@ -52,6 +54,8 @@
 		0EA38796280458CE005A48A6 /* KoreanHistoricalItemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KoreanHistoricalItemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanHistoricalItemTests.swift; sourceTree = "<group>"; };
 		AB03BD65280806D100F3A2B4 /* KoreanItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemTableViewCell.swift; sourceTree = "<group>"; };
+		AB206D41280EC6570048649B /* AlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessage.swift; sourceTree = "<group>"; };
+		AB206D43280EC9130048649B /* FileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileName.swift; sourceTree = "<group>"; };
 		AB245ACF2804569A0061D087 /* ParisExpo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParisExpo.swift; sourceTree = "<group>"; };
 		AB245AD528045FFB0061D087 /* ParisExpoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParisExpoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB245AD728045FFB0061D087 /* ParisExpoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParisExpoTests.swift; sourceTree = "<group>"; };
@@ -95,6 +99,7 @@
 		0E9E5A7628088B810079B650 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				AB206D40280EC6460048649B /* Constant */,
 				0E9E5A7728088B8F0079B650 /* Extension */,
 			);
 			path = Utils;
@@ -125,6 +130,15 @@
 				0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */,
 			);
 			path = KoreanHistoricalItemTests;
+			sourceTree = "<group>";
+		};
+		AB206D40280EC6460048649B /* Constant */ = {
+			isa = PBXGroup;
+			children = (
+				AB206D41280EC6570048649B /* AlertMessage.swift */,
+				AB206D43280EC9130048649B /* FileName.swift */,
+			);
+			path = Constant;
 			sourceTree = "<group>";
 		};
 		AB245ACB280445070061D087 /* Controller */ = {
@@ -355,6 +369,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C79FF4B92589F401005FB0FD /* ParisExpoViewController.swift in Sources */,
+				AB206D44280EC9130048649B /* FileName.swift in Sources */,
 				0E0348612807AEA000B1A9C6 /* Decodable+extension.swift in Sources */,
 				0E9E5A75280873D80079B650 /* UIViewController+extension.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
@@ -364,6 +379,7 @@
 				0E9E5A6F28081C9F0079B650 /* KoreanItemViewController.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				AB03BD66280806D100F3A2B4 /* KoreanItemTableViewCell.swift in Sources */,
+				AB206D42280EC6570048649B /* AlertMessage.swift in Sources */,
 				0E9E5A73280863C40079B650 /* KoreanItemDetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		0E9E5A75280873D80079B650 /* UIViewController+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E5A74280873D80079B650 /* UIViewController+extension.swift */; };
 		0EA3879128044C07005A48A6 /* KoreanHistoricalItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */; };
 		0EA38799280458CF005A48A6 /* KoreanHistoricalItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */; };
+		0EA983B3280ECAE500C81A5F /* ParsorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA983B2280ECAE500C81A5F /* ParsorManager.swift */; };
+		0EA983B5280ECBA600C81A5F /* AssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA983B4280ECBA600C81A5F /* AssetData.swift */; };
 		AB03BD66280806D100F3A2B4 /* KoreanItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03BD65280806D100F3A2B4 /* KoreanItemTableViewCell.swift */; };
 		AB206D42280EC6570048649B /* AlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB206D41280EC6570048649B /* AlertMessage.swift */; };
 		AB206D44280EC9130048649B /* FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB206D43280EC9130048649B /* FileName.swift */; };
@@ -53,6 +55,8 @@
 		0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanHistoricalItem.swift; sourceTree = "<group>"; };
 		0EA38796280458CE005A48A6 /* KoreanHistoricalItemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KoreanHistoricalItemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanHistoricalItemTests.swift; sourceTree = "<group>"; };
+		0EA983B2280ECAE500C81A5F /* ParsorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsorManager.swift; sourceTree = "<group>"; };
+		0EA983B4280ECBA600C81A5F /* AssetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetData.swift; sourceTree = "<group>"; };
 		AB03BD65280806D100F3A2B4 /* KoreanItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemTableViewCell.swift; sourceTree = "<group>"; };
 		AB206D41280EC6570048649B /* AlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessage.swift; sourceTree = "<group>"; };
 		AB206D43280EC9130048649B /* FileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileName.swift; sourceTree = "<group>"; };
@@ -166,6 +170,8 @@
 			children = (
 				0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */,
 				AB245ACF2804569A0061D087 /* ParisExpo.swift */,
+				0EA983B2280ECAE500C81A5F /* ParsorManager.swift */,
+				0EA983B4280ECBA600C81A5F /* AssetData.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -375,11 +381,13 @@
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				AB245AD02804569A0061D087 /* ParisExpo.swift in Sources */,
 				0EA3879128044C07005A48A6 /* KoreanHistoricalItem.swift in Sources */,
+				0EA983B5280ECBA600C81A5F /* AssetData.swift in Sources */,
 				ABDD6762280D0B1D0048C425 /* UITableViewCell+extension.swift in Sources */,
 				0E9E5A6F28081C9F0079B650 /* KoreanItemViewController.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				AB03BD66280806D100F3A2B4 /* KoreanItemTableViewCell.swift in Sources */,
 				AB206D42280EC6570048649B /* AlertMessage.swift in Sources */,
+				0EA983B3280ECAE500C81A5F /* ParsorManager.swift in Sources */,
 				0E9E5A73280863C40079B650 /* KoreanItemDetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0E0348612807AEA000B1A9C6 /* Decodable+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0348602807AE9F00B1A9C6 /* Decodable+extension.swift */; };
+		0E0348612807AEA000B1A9C6 /* DecoderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0348602807AE9F00B1A9C6 /* DecoderError.swift */; };
 		0E9E5A6F28081C9F0079B650 /* KoreanItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E5A6E28081C9F0079B650 /* KoreanItemViewController.swift */; };
 		0E9E5A73280863C40079B650 /* KoreanItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E5A72280863C40079B650 /* KoreanItemDetailViewController.swift */; };
 		0E9E5A75280873D80079B650 /* UIViewController+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E9E5A74280873D80079B650 /* UIViewController+extension.swift */; };
 		0EA3879128044C07005A48A6 /* KoreanHistoricalItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */; };
 		0EA38799280458CF005A48A6 /* KoreanHistoricalItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */; };
-		0EA983B3280ECAE500C81A5F /* ParsorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA983B2280ECAE500C81A5F /* ParsorManager.swift */; };
+		0EA983B3280ECAE500C81A5F /* ParserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA983B2280ECAE500C81A5F /* ParserManager.swift */; };
 		0EA983B5280ECBA600C81A5F /* AssetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA983B4280ECBA600C81A5F /* AssetData.swift */; };
 		AB03BD66280806D100F3A2B4 /* KoreanItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03BD65280806D100F3A2B4 /* KoreanItemTableViewCell.swift */; };
 		AB206D42280EC6570048649B /* AlertMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB206D41280EC6570048649B /* AlertMessage.swift */; };
@@ -48,14 +48,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0E0348602807AE9F00B1A9C6 /* Decodable+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+extension.swift"; sourceTree = "<group>"; };
+		0E0348602807AE9F00B1A9C6 /* DecoderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderError.swift; sourceTree = "<group>"; };
 		0E9E5A6E28081C9F0079B650 /* KoreanItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemViewController.swift; sourceTree = "<group>"; };
 		0E9E5A72280863C40079B650 /* KoreanItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemDetailViewController.swift; sourceTree = "<group>"; };
 		0E9E5A74280873D80079B650 /* UIViewController+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+extension.swift"; sourceTree = "<group>"; };
 		0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanHistoricalItem.swift; sourceTree = "<group>"; };
 		0EA38796280458CE005A48A6 /* KoreanHistoricalItemTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KoreanHistoricalItemTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EA38798280458CF005A48A6 /* KoreanHistoricalItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanHistoricalItemTests.swift; sourceTree = "<group>"; };
-		0EA983B2280ECAE500C81A5F /* ParsorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsorManager.swift; sourceTree = "<group>"; };
+		0EA983B2280ECAE500C81A5F /* ParserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserManager.swift; sourceTree = "<group>"; };
 		0EA983B4280ECBA600C81A5F /* AssetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetData.swift; sourceTree = "<group>"; };
 		AB03BD65280806D100F3A2B4 /* KoreanItemTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemTableViewCell.swift; sourceTree = "<group>"; };
 		AB206D41280EC6570048649B /* AlertMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMessage.swift; sourceTree = "<group>"; };
@@ -103,6 +103,7 @@
 		0E9E5A7628088B810079B650 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				AB206D45280ED1460048649B /* Error */,
 				AB206D40280EC6460048649B /* Constant */,
 				0E9E5A7728088B8F0079B650 /* Extension */,
 			);
@@ -112,7 +113,6 @@
 		0E9E5A7728088B8F0079B650 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
-				0E0348602807AE9F00B1A9C6 /* Decodable+extension.swift */,
 				0E9E5A74280873D80079B650 /* UIViewController+extension.swift */,
 				ABDD6761280D0B1D0048C425 /* UITableViewCell+extension.swift */,
 			);
@@ -145,6 +145,14 @@
 			path = Constant;
 			sourceTree = "<group>";
 		};
+		AB206D45280ED1460048649B /* Error */ = {
+			isa = PBXGroup;
+			children = (
+				0E0348602807AE9F00B1A9C6 /* DecoderError.swift */,
+			);
+			path = Error;
+			sourceTree = "<group>";
+		};
 		AB245ACB280445070061D087 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
@@ -170,7 +178,7 @@
 			children = (
 				0EA3879028044C07005A48A6 /* KoreanHistoricalItem.swift */,
 				AB245ACF2804569A0061D087 /* ParisExpo.swift */,
-				0EA983B2280ECAE500C81A5F /* ParsorManager.swift */,
+				0EA983B2280ECAE500C81A5F /* ParserManager.swift */,
 				0EA983B4280ECBA600C81A5F /* AssetData.swift */,
 			);
 			path = Model;
@@ -376,7 +384,7 @@
 			files = (
 				C79FF4B92589F401005FB0FD /* ParisExpoViewController.swift in Sources */,
 				AB206D44280EC9130048649B /* FileName.swift in Sources */,
-				0E0348612807AEA000B1A9C6 /* Decodable+extension.swift in Sources */,
+				0E0348612807AEA000B1A9C6 /* DecoderError.swift in Sources */,
 				0E9E5A75280873D80079B650 /* UIViewController+extension.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				AB245AD02804569A0061D087 /* ParisExpo.swift in Sources */,
@@ -387,7 +395,7 @@
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				AB03BD66280806D100F3A2B4 /* KoreanItemTableViewCell.swift in Sources */,
 				AB206D42280EC6570048649B /* AlertMessage.swift in Sources */,
-				0EA983B3280ECAE500C81A5F /* ParsorManager.swift in Sources */,
+				0EA983B3280ECAE500C81A5F /* ParserManager.swift in Sources */,
 				0E9E5A73280863C40079B650 /* KoreanItemDetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900/Application/AppDelegate.swift
+++ b/Expo1900/Expo1900/Application/AppDelegate.swift
@@ -6,6 +6,8 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    var isFirstViewController: Bool = true
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool { return true }
 
     // MARK: UISceneSession Lifecycle
@@ -15,5 +17,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) { }
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if isFirstViewController {
+            return .portrait
+        }
+        return .all
+    }
 }
 

--- a/Expo1900/Expo1900/Application/AppDelegate.swift
+++ b/Expo1900/Expo1900/Application/AppDelegate.swift
@@ -6,8 +6,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var isFirstViewController: Bool = true
-    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool { return true }
 
     // MARK: UISceneSession Lifecycle
@@ -19,7 +17,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) { }
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        if isFirstViewController {
+        if let nv: UINavigationController = window?.rootViewController as? UINavigationController,
+           let _ = nv.topViewController as? ParisExpoViewController
+             {
             return .portrait
         }
         return .all

--- a/Expo1900/Expo1900/Application/AppDelegate.swift
+++ b/Expo1900/Expo1900/Application/AppDelegate.swift
@@ -17,8 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) { }
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        if let nv: UINavigationController = window?.rootViewController as? UINavigationController,
-           let _ = nv.topViewController as? ParisExpoViewController
+        if let navigationController: UINavigationController = window?.rootViewController as? UINavigationController,
+           let _ = navigationController.topViewController as? ParisExpoViewController
              {
             return .portrait
         }

--- a/Expo1900/Expo1900/Controller/KoreanItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemDetailViewController.swift
@@ -1,9 +1,6 @@
-//
 //  KoreanItemDetailVC.swift
 //  Expo1900
-//
-//  Created by 김태현 on 2022/04/14.
-//
+//  Created by 김태현 on 2022/04/14
 
 import UIKit
 

--- a/Expo1900/Expo1900/Controller/KoreanItemTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemTableViewCell.swift
@@ -1,9 +1,6 @@
-//
 //  KoreanItemTableViewCell.swift
 //  Expo1900
-//
-//  Created by LIMGAUI on 2022/04/14.
-//
+//  Created by LIMGAUI on 2022/04/14
 
 import UIKit
 

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -31,10 +31,10 @@ final class KoreanItemViewController: UIViewController {
 
 extension KoreanItemViewController {
     private func initializeKoreanItemsData() {
-        guard let items = try? [KoreanHistoricalItem].convert(from: "items") else {
-            return
-        }
-        koreanItems = items
+//        guard let items = try? [KoreanHistoricalItem].convert(from: "items") else {
+//            return
+//        }
+//        koreanItems = items
     }
 }
 
@@ -49,7 +49,7 @@ extension KoreanItemViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: KoreanItemTableViewCell.identifier, for: indexPath) as? KoreanItemTableViewCell,
            let koreanItems = koreanItems else {
-            showFailureAlert()
+            showFailureAlert(message: "데이터 로딩에 실패했습니다.")
             tableView.register(UITableViewCell.self, forCellReuseIdentifier: "empty cell")
             return tableView.dequeueReusableCell(withIdentifier: "empty cell", for: indexPath)
         }
@@ -63,14 +63,5 @@ extension KoreanItemViewController: UITableViewDelegate, UITableViewDataSource {
         }
         koreanItemDetailVC.koreanItem = koreanItems?[indexPath.row]
         navigationController?.pushViewController(koreanItemDetailVC, animated: true)
-    }
-}
-
-extension KoreanItemViewController {
-    private func showFailureAlert() {
-        let alertController = UIAlertController(title: nil, message: "적절한 데이터를 불러올 수 없습니다.", preferredStyle: .alert)
-        let confirmButton = UIAlertAction(title: "ok", style: .default)
-        alertController.addAction(confirmButton)
-        present(alertController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -31,10 +31,11 @@ final class KoreanItemViewController: UIViewController {
 
 extension KoreanItemViewController {
     private func initializeKoreanItemsData() {
-//        guard let items = try? [KoreanHistoricalItem].convert(from: "items") else {
-//            return
-//        }
-//        koreanItems = items
+        do {
+            koreanItems = try [KoreanHistoricalItem].parse(fileName: "items")
+        } catch {
+            showFailureAlert(message: "데이터 로드를 실패했습니다.")
+        }
     }
 }
 

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -21,6 +21,7 @@ final class KoreanItemViewController: UIViewController {
         super.viewDidLoad()
         configurateDelegateProperties()
         initializeKoreanItemsData()
+        registerEmptyCell()
         navigationItem.title = UItitle.koreaItemsText
     }
     
@@ -42,6 +43,10 @@ extension KoreanItemViewController {
             showFailureAlert(message: AlertMessage.notFoundData)
         }
     }
+    
+    private func registerEmptyCell() {
+        koreanItemsTableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.empty)
+    }
 }
 
 extension KoreanItemViewController: UITableViewDelegate, UITableViewDataSource {
@@ -56,7 +61,6 @@ extension KoreanItemViewController: UITableViewDelegate, UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: KoreanItemTableViewCell.identifier, for: indexPath) as? KoreanItemTableViewCell,
            let koreanItems = koreanItems else {
             showFailureAlert(message: AlertMessage.notFoundData)
-            tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.empty)
             return tableView.dequeueReusableCell(withIdentifier: CellIdentifier.empty, for: indexPath)
         }
         cell.assignValue(from: koreanItems[indexPath.row])

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -1,9 +1,6 @@
-//
 //  KoreanItemVC.swift
 //  Expo1900
-//
-//  Created by 김태현 on 2022/04/14.
-//
+//  Created by 김태현 on 2022/04/14
 
 import UIKit
 

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -4,6 +4,14 @@
 
 import UIKit
 
+fileprivate enum UItitle {
+    static let koreaItemsText = "한국의 출품작"
+}
+
+fileprivate enum CellIdentifier {
+    static let empty = "empty cell"
+}
+
 final class KoreanItemViewController: UIViewController {
     var koreanItems: [KoreanHistoricalItem]?
     
@@ -13,7 +21,7 @@ final class KoreanItemViewController: UIViewController {
         super.viewDidLoad()
         configurateDelegateProperties()
         initializeKoreanItemsData()
-        navigationItem.title = "한국의 출품작"
+        navigationItem.title = UItitle.koreaItemsText
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -29,9 +37,9 @@ final class KoreanItemViewController: UIViewController {
 extension KoreanItemViewController {
     private func initializeKoreanItemsData() {
         do {
-            koreanItems = try [KoreanHistoricalItem].parse(fileName: "items")
+            koreanItems = try [KoreanHistoricalItem].parse(fileName: FileName.items)
         } catch {
-            showFailureAlert(message: "데이터 로드를 실패했습니다.")
+            showFailureAlert(message: AlertMessage.notFoundData)
         }
     }
 }
@@ -41,15 +49,15 @@ extension KoreanItemViewController: UITableViewDelegate, UITableViewDataSource {
         if let koreanItemsCount = koreanItems?.count {
             return koreanItemsCount
         }
-        return 0
+        return .zero
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: KoreanItemTableViewCell.identifier, for: indexPath) as? KoreanItemTableViewCell,
            let koreanItems = koreanItems else {
-            showFailureAlert(message: "데이터 로딩에 실패했습니다.")
-            tableView.register(UITableViewCell.self, forCellReuseIdentifier: "empty cell")
-            return tableView.dequeueReusableCell(withIdentifier: "empty cell", for: indexPath)
+            showFailureAlert(message: AlertMessage.notFoundData)
+            tableView.register(UITableViewCell.self, forCellReuseIdentifier: CellIdentifier.empty)
+            return tableView.dequeueReusableCell(withIdentifier: CellIdentifier.empty, for: indexPath)
         }
         cell.assignValue(from: koreanItems[indexPath.row])
         return cell

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -37,7 +37,7 @@ final class KoreanItemViewController: UIViewController {
 extension KoreanItemViewController {
     private func initializeKoreanItemsData() {
         do {
-            koreanItems = try [KoreanHistoricalItem].parse(fileName: FileName.items)
+            koreanItems = try AssetData.assignKoreanItems()
         } catch {
             showFailureAlert(message: AlertMessage.notFoundData)
         }

--- a/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanItemViewController.swift
@@ -38,7 +38,7 @@ final class KoreanItemViewController: UIViewController {
 extension KoreanItemViewController {
     private func initializeKoreanItemsData() {
         do {
-            koreanItems = try AssetData.assignKoreanItems()
+            koreanItems = try AssetData().assignKoreanItems()
         } catch {
             showFailureAlert(message: AlertMessage.notFoundData)
         }

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -8,7 +8,6 @@ fileprivate enum UITitle {
     static let visitorText = "방문객 :"
     static let locationText = "개최지 :"
     static let durationText = "개최 기간 :"
-    static let goToKoreanItemsText = "한국의 출품작 보러가기"
     static let mainText = "메인"
 }
 
@@ -47,6 +46,8 @@ final class ParisExpoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.navigationBar.isHidden = true
+        
+        koreanItemsButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
     }
     
     override func viewDidLoad() {
@@ -69,7 +70,6 @@ final class ParisExpoViewController: UIViewController {
         configureLocationLabel()
         configureDurationLabel()
         configureDesciptionLabel()
-        configureKoreanItemsButtonLabel()
     }
     
     private func configureTitleLabel() {
@@ -101,10 +101,6 @@ final class ParisExpoViewController: UIViewController {
     
     private func configureDesciptionLabel() {
         descriptionLabel.text = parisExpoData?.description
-    }
-    
-    private func configureKoreanItemsButtonLabel() {
-        koreanItemsButton.titleLabel?.text = UITitle.goToKoreanItemsText
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -112,7 +112,7 @@ final class ParisExpoViewController: UIViewController {
 extension ParisExpoViewController {
     private func initializeParisExpoData() {
         do {
-            parisExpoData = try parisExpoData?.convert(from: FileName.parisExpo)
+            parisExpoData = try ParisExpo.parse(fileName: FileName.parisExpo)
         } catch {
             showFailureAlert(message: "데이터 로드를 실패했습니다.")
         }

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -20,6 +20,10 @@ fileprivate enum Sign {
     static let linebreakAndParentheses = "\n("
 }
 
+fileprivate enum UIDeviceKey {
+    static let orientation = "orientation"
+}
+
 final class ParisExpoViewController: UIViewController {
     private var parisExpoData: ParisExpo?
     
@@ -48,6 +52,12 @@ final class ParisExpoViewController: UIViewController {
         navigationController?.navigationBar.isHidden = true
         
         koreanItemsButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+        switchAppDelegateFlag(true)
+        UIDevice.current.setValue(UIDeviceOrientation.portrait.rawValue, forKey: UIDeviceKey.orientation)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        switchAppDelegateFlag(false)
     }
     
     override func viewDidLoad() {
@@ -56,6 +66,12 @@ final class ParisExpoViewController: UIViewController {
         configureImages()
         configureLabels()
         navigationItem.title = UITitle.mainText
+    }
+    
+    private func switchAppDelegateFlag(_ isFirstViewControllerValue: Bool) {
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.isFirstViewController = isFirstViewControllerValue
+        }
     }
     
     private func configureImages() {
@@ -111,20 +127,5 @@ extension ParisExpoViewController {
         } catch {
             showFailureAlert(message: AlertMessage.notFoundData)
         }
-    }
-}
-
-extension UINavigationController {
-    override open var shouldAutorotate: Bool {
-        get {
-            if let _ = topViewController as? ParisExpoViewController {
-                return false
-            }
-            return true
-        }
-    }
-    
-    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .landscape
     }
 }

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -123,7 +123,7 @@ final class ParisExpoViewController: UIViewController {
 extension ParisExpoViewController {
     private func initializeParisExpoData() {
         do {
-            parisExpoData = try AssetData.assignParisExpo()
+            parisExpoData = try AssetData().assignParisExpo()
         } catch {
             showFailureAlert(message: AlertMessage.notFoundData)
         }

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -117,3 +117,18 @@ extension ParisExpoViewController {
         }
     }
 }
+
+extension UINavigationController {
+    override open var shouldAutorotate: Bool {
+        get {
+            if let _ = topViewController as? ParisExpoViewController {
+                return false
+            }
+            return true
+        }
+    }
+    
+    override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .landscape
+    }
+}

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -111,7 +111,7 @@ final class ParisExpoViewController: UIViewController {
 extension ParisExpoViewController {
     private func initializeParisExpoData() {
         do {
-            parisExpoData = try ParisExpo.parse(fileName: FileName.parisExpo)
+            parisExpoData = try AssetData.assignParisExpo()
         } catch {
             showFailureAlert(message: AlertMessage.notFoundData)
         }

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -49,11 +49,10 @@ final class ParisExpoViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.navigationBar.isHidden = true
-        
-        koreanItemsButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+        configureNavigationUI()
+        configurekoreanItemsButton()
         switchAppDelegateFlag(true)
-        UIDevice.current.setValue(UIDeviceOrientation.portrait.rawValue, forKey: UIDeviceKey.orientation)
+        configureUIDeviceOrientation()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -65,6 +64,10 @@ final class ParisExpoViewController: UIViewController {
         initializeParisExpoData()
         configureImages()
         configureLabels()
+    }
+    
+    private func configureNavigationUI() {
+        navigationController?.navigationBar.isHidden = true
         navigationItem.title = UITitle.mainText
     }
     
@@ -72,6 +75,10 @@ final class ParisExpoViewController: UIViewController {
         if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
             appDelegate.isFirstViewController = isFirstViewControllerValue
         }
+    }
+    
+    private func configureUIDeviceOrientation() {
+        UIDevice.current.setValue(UIDeviceOrientation.portrait.rawValue, forKey: UIDeviceKey.orientation)
     }
     
     private func configureImages() {
@@ -117,6 +124,10 @@ final class ParisExpoViewController: UIViewController {
     
     private func configureDesciptionLabel() {
         descriptionLabel.text = parisExpoData?.description
+    }
+    
+    private func configurekoreanItemsButton() {
+        koreanItemsButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -16,10 +16,9 @@ fileprivate enum Unit {
     static let people = " 명"
 }
 
-fileprivate enum FileName {
-    static let poster = "poster"
-    static let flag = "flag"
-    static let parisExpo = "exposition_universelle_1900"
+fileprivate enum Sign {
+    static let parentheses = "("
+    static let linebreakAndParentheses = "\n("
 }
 
 final class ParisExpoViewController: UIViewController {
@@ -74,7 +73,7 @@ final class ParisExpoViewController: UIViewController {
     }
     
     private func configureTitleLabel() {
-        titleLabel.text = parisExpoData?.title.replacingOccurrences(of: "(", with: "\n(")
+        titleLabel.text = parisExpoData?.title.replacingOccurrences(of: Sign.parentheses, with: Sign.linebreakAndParentheses)
     }
     
     private func configureVisitorLabel() {
@@ -114,7 +113,7 @@ extension ParisExpoViewController {
         do {
             parisExpoData = try ParisExpo.parse(fileName: FileName.parisExpo)
         } catch {
-            showFailureAlert(message: "데이터 로드를 실패했습니다.")
+            showFailureAlert(message: AlertMessage.notFoundData)
         }
     }
 }

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -51,12 +51,7 @@ final class ParisExpoViewController: UIViewController {
         super.viewWillAppear(animated)
         configureNavigationUI()
         configurekoreanItemsButton()
-        switchAppDelegateFlag(true)
         configureUIDeviceOrientation()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        switchAppDelegateFlag(false)
     }
     
     override func viewDidLoad() {
@@ -69,12 +64,6 @@ final class ParisExpoViewController: UIViewController {
     private func configureNavigationUI() {
         navigationController?.navigationBar.isHidden = true
         navigationItem.title = UITitle.mainText
-    }
-    
-    private func switchAppDelegateFlag(_ isFirstViewControllerValue: Bool) {
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.isFirstViewController = isFirstViewControllerValue
-        }
     }
     
     private func configureUIDeviceOrientation() {

--- a/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
+++ b/Expo1900/Expo1900/Controller/ParisExpoViewController.swift
@@ -111,9 +111,10 @@ final class ParisExpoViewController: UIViewController {
 
 extension ParisExpoViewController {
     private func initializeParisExpoData() {
-        guard let data = try? ParisExpo.convert(from: FileName.parisExpo) else {
-            return
+        do {
+            parisExpoData = try parisExpoData?.convert(from: FileName.parisExpo)
+        } catch {
+            showFailureAlert(message: "데이터 로드를 실패했습니다.")
         }
-        parisExpoData = data
     }
 }

--- a/Expo1900/Expo1900/Model/AssetData.swift
+++ b/Expo1900/Expo1900/Model/AssetData.swift
@@ -5,12 +5,12 @@
 //  Created by 김태현 on 2022/04/19.
 //
 
-enum AssetData {
-    static func assignParisExpo() throws -> ParisExpo {
-        return try ParserManager<ParisExpo>.parse(fileName: FileName.parisExpo)
+struct AssetData {
+    func assignParisExpo() throws -> ParisExpo {
+        return try ParserManager<ParisExpo>().parse(fileName: FileName.parisExpo)
     }
     
-    static func assignKoreanItems() throws -> [KoreanHistoricalItem] {
-        return try ParserManager<[KoreanHistoricalItem]>.parse(fileName: FileName.items)
+    func assignKoreanItems() throws -> [KoreanHistoricalItem] {
+        return try ParserManager<[KoreanHistoricalItem]>().parse(fileName: FileName.items)
     }
 }

--- a/Expo1900/Expo1900/Model/AssetData.swift
+++ b/Expo1900/Expo1900/Model/AssetData.swift
@@ -7,10 +7,10 @@
 
 enum AssetData {
     static func assignParisExpo() throws -> ParisExpo {
-        return try ParsorManager<ParisExpo>.parse(fileName: FileName.parisExpo) 
+        return try ParserManager<ParisExpo>.parse(fileName: FileName.parisExpo)
     }
     
     static func assignKoreanItems() throws -> [KoreanHistoricalItem] {
-        return try ParsorManager<[KoreanHistoricalItem]>.parse(fileName: FileName.items)
+        return try ParserManager<[KoreanHistoricalItem]>.parse(fileName: FileName.items)
     }
 }

--- a/Expo1900/Expo1900/Model/AssetData.swift
+++ b/Expo1900/Expo1900/Model/AssetData.swift
@@ -1,0 +1,16 @@
+//
+//  AssetData.swift
+//  Expo1900
+//
+//  Created by 김태현 on 2022/04/19.
+//
+
+enum AssetData {
+    static func assignParisExpo() throws -> ParisExpo {
+        return try ParsorManager<ParisExpo>.parse(fileName: FileName.parisExpo) 
+    }
+    
+    static func assignKoreanItems() throws -> [KoreanHistoricalItem] {
+        return try ParsorManager<[KoreanHistoricalItem]>.parse(fileName: FileName.items)
+    }
+}

--- a/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
+++ b/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
@@ -19,9 +19,11 @@ struct KoreanHistoricalItem: Decodable {
         case shortDesciption = "short_desc"
         case description = "desc"
     }
-    
-    func parse(fileName: String) throws -> Self {
-        guard let data = try? convert(from: fileName) else {
+}
+
+extension Array where KoreanHistoricalItem == Array.Element {
+    static func parse(fileName: String) throws -> Self {
+        guard let data = try? Self.convert(from: fileName) else {
             throw DecoderError.decodeFail
         }
         return data

--- a/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
+++ b/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
@@ -19,4 +19,11 @@ struct KoreanHistoricalItem: Decodable {
         case shortDesciption = "short_desc"
         case description = "desc"
     }
+    
+    func parse(fileName: String) throws -> Self {
+        guard let data = try? convert(from: fileName) else {
+            throw DecoderError.decodeFail
+        }
+        return data
+    }
 }

--- a/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
+++ b/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
@@ -1,9 +1,6 @@
-//
 //  ProductArtWork.swift
 //  Expo1900
-//
-//  Created by 김태현 on 2022/04/11.
-//
+//  Created by 김태현 on 2022/04/11
 
 import Foundation
 

--- a/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
+++ b/Expo1900/Expo1900/Model/KoreanHistoricalItem.swift
@@ -17,12 +17,3 @@ struct KoreanHistoricalItem: Decodable {
         case description = "desc"
     }
 }
-
-extension Array where KoreanHistoricalItem == Array.Element {
-    static func parse(fileName: String) throws -> Self {
-        guard let data = try? Self.convert(from: fileName) else {
-            throw DecoderError.decodeFail
-        }
-        return data
-    }
-}

--- a/Expo1900/Expo1900/Model/ParisExpo.swift
+++ b/Expo1900/Expo1900/Model/ParisExpo.swift
@@ -12,4 +12,11 @@ struct ParisExpo: Decodable {
     let location: String
     let duration: String
     let description: String
+    
+    static func parse(fileName: String) throws -> Self {
+        guard let data = try? Self.convert(from: fileName) else {
+            throw DecoderError.decodeFail
+        }
+        return data
+    }
 }

--- a/Expo1900/Expo1900/Model/ParisExpo.swift
+++ b/Expo1900/Expo1900/Model/ParisExpo.swift
@@ -1,8 +1,6 @@
-//
 //  ParisExpo.swift
 //  Expo1900
-//
-//  Created by LIMGAUI on 2022/04/11.
+//  Created by LIMGAUI on 2022/04/11
 
 import Foundation
 

--- a/Expo1900/Expo1900/Model/ParisExpo.swift
+++ b/Expo1900/Expo1900/Model/ParisExpo.swift
@@ -10,11 +10,4 @@ struct ParisExpo: Decodable {
     let location: String
     let duration: String
     let description: String
-    
-    static func parse(fileName: String) throws -> Self {
-        guard let data = try? Self.convert(from: fileName) else {
-            throw DecoderError.decodeFail
-        }
-        return data
-    }
 }

--- a/Expo1900/Expo1900/Model/ParserManager.swift
+++ b/Expo1900/Expo1900/Model/ParserManager.swift
@@ -1,15 +1,11 @@
-//
 //  ParsorManager.swift
 //  Expo1900
-//
 //  Created by 김태현 on 2022/04/19.
-//
 
-import Foundation
 import UIKit
 
-enum ParserManager<T: Decodable> {
-    static func parse(fileName: String) throws -> T {
+struct ParserManager<T: Decodable> {
+    func parse(fileName: String) throws -> T {
         guard let assetFile = NSDataAsset(name: fileName) else {
             throw DecoderError.dataAssetFail
         }

--- a/Expo1900/Expo1900/Model/ParserManager.swift
+++ b/Expo1900/Expo1900/Model/ParserManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-enum ParsorManager<T: Decodable> {
+enum ParserManager<T: Decodable> {
     static func parse(fileName: String) throws -> T {
         guard let assetFile = NSDataAsset(name: fileName) else {
             throw DecoderError.dataAssetFail

--- a/Expo1900/Expo1900/Model/ParsorManager.swift
+++ b/Expo1900/Expo1900/Model/ParsorManager.swift
@@ -1,0 +1,15 @@
+//
+//  ParsorManager.swift
+//  Expo1900
+//
+//  Created by 김태현 on 2022/04/19.
+//
+
+enum ParsorManager<T: Decodable> {
+    static func parse(fileName: String) throws -> T {
+        guard let data = try? T.convert(from: fileName) else {
+            throw DecoderError.decodeFail
+        }
+        return data
+    }
+}

--- a/Expo1900/Expo1900/Model/ParsorManager.swift
+++ b/Expo1900/Expo1900/Model/ParsorManager.swift
@@ -5,9 +5,15 @@
 //  Created by 김태현 on 2022/04/19.
 //
 
+import Foundation
+import UIKit
+
 enum ParsorManager<T: Decodable> {
     static func parse(fileName: String) throws -> T {
-        guard let data = try? T.convert(from: fileName) else {
+        guard let assetFile = NSDataAsset(name: fileName) else {
+            throw DecoderError.dataAssetFail
+        }
+        guard let data = try? JSONDecoder().decode(T.self, from: assetFile.data) else {
             throw DecoderError.decodeFail
         }
         return data

--- a/Expo1900/Expo1900/Utils/Constant/AlertMessage.swift
+++ b/Expo1900/Expo1900/Utils/Constant/AlertMessage.swift
@@ -1,0 +1,7 @@
+//  AlertMessage.swift
+//  Expo1900
+//  Created by LIMGAUI on 2022/04/19.
+
+enum AlertMessage {
+    static let notFoundData = "데이터를 가져올 수 없습니다."
+}

--- a/Expo1900/Expo1900/Utils/Constant/FileName.swift
+++ b/Expo1900/Expo1900/Utils/Constant/FileName.swift
@@ -1,0 +1,10 @@
+//  FileName.swift
+//  Expo1900
+//  Created by LIMGAUI on 2022/04/19
+
+enum FileName {
+    static let poster = "poster"
+    static let flag = "flag"
+    static let parisExpo = "exposition_universelle_1900"
+    static let items = "items"
+}

--- a/Expo1900/Expo1900/Utils/Error/DecoderError.swift
+++ b/Expo1900/Expo1900/Utils/Error/DecoderError.swift
@@ -2,9 +2,6 @@
 //  Expo1900
 //  Created by 김태현 on 2022/04/14
 
-import Foundation
-import UIKit
-
 enum DecoderError: Error {
     case decodeFail
     case dataAssetFail

--- a/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
@@ -14,7 +14,7 @@ enum DecoderError: Error {
 }
 
 extension Decodable {
-    static func convert(from fileName: String) throws -> Self {
+    func convert(from fileName: String) throws -> Self {
         guard let assetFile = NSDataAsset(name: fileName) else {
             throw DecoderError.dataAssetFail
         }

--- a/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
@@ -9,17 +9,3 @@ enum DecoderError: Error {
     case decodeFail
     case dataAssetFail
 }
-
-extension Decodable {
-    static func convert(from fileName: String) throws -> Self {
-        guard let assetFile = NSDataAsset(name: fileName) else {
-            throw DecoderError.dataAssetFail
-        }
-        
-        guard let data = try? JSONDecoder().decode(Self.self, from: assetFile.data) else {
-            throw DecoderError.decodeFail
-        }
-        
-        return data
-    }
-}

--- a/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
@@ -14,7 +14,7 @@ enum DecoderError: Error {
 }
 
 extension Decodable {
-    func convert(from fileName: String) throws -> Self {
+    static func convert(from fileName: String) throws -> Self {
         guard let assetFile = NSDataAsset(name: fileName) else {
             throw DecoderError.dataAssetFail
         }

--- a/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/Decodable+extension.swift
@@ -1,9 +1,6 @@
-//
 //  Decodable+extension.swift
 //  Expo1900
-//
-//  Created by 김태현 on 2022/04/14.
-//
+//  Created by 김태현 on 2022/04/14
 
 import Foundation
 import UIKit

--- a/Expo1900/Expo1900/Utils/Extension/UITableViewCell+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/UITableViewCell+extension.swift
@@ -1,7 +1,5 @@
-//
 //  UITableViewCell+extensionn.swift
 //  Expo1900
-//
 //  Created by LIMGAUI on 2022/04/18.
 
 import UIKit

--- a/Expo1900/Expo1900/Utils/Extension/UIViewController+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/UIViewController+extension.swift
@@ -11,4 +11,11 @@ extension UIViewController {
     static var identifier: String {
         return String(describing: self)
     }
+    
+    func showFailureAlert(message: String) {
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        let confirmButton = UIAlertAction(title: "ok", style: .default)
+        alertController.addAction(confirmButton)
+        present(alertController, animated: true)
+    }
 }

--- a/Expo1900/Expo1900/Utils/Extension/UIViewController+extension.swift
+++ b/Expo1900/Expo1900/Utils/Extension/UIViewController+extension.swift
@@ -1,9 +1,6 @@
-//
 //  UIViewController+extension.swift
 //  Expo1900
-//
-//  Created by 김태현 on 2022/04/15.
-//
+//  Created by 김태현 on 2022/04/15
 
 import UIKit
 

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -18,22 +18,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deo-Mu-dzb">
-                                <rect key="frame" x="20" y="0.0" width="394" height="896"/>
+                                <rect key="frame" x="15" y="0.0" width="399" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="406.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="384" height="406.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chQ-n8-6Jz">
-                                                <rect key="frame" x="157.5" y="0.0" width="59" height="30"/>
+                                                <rect key="frame" x="162.5" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="Wvk-Nr-QCu">
-                                                <rect key="frame" x="115" y="38" width="144" height="200"/>
+                                                <rect key="frame" x="0.0" y="38" width="384" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-hj-akY">
-                                                <rect key="frame" x="146" y="246" width="82" height="20.5"/>
+                                                <rect key="frame" x="151" y="246" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soz-LU-IgH">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -50,7 +50,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mJS-EG-9vB">
-                                                <rect key="frame" x="146" y="274.5" width="82" height="20.5"/>
+                                                <rect key="frame" x="151" y="274.5" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSg-WL-2Je">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -67,7 +67,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D0J-Go-gXt">
-                                                <rect key="frame" x="146" y="303" width="82" height="20.5"/>
+                                                <rect key="frame" x="151" y="303" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTa-NU-WdQ">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -84,23 +84,22 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-3s-icx">
-                                                <rect key="frame" x="169.5" y="331.5" width="35.5" height="17"/>
+                                                <rect key="frame" x="174.5" y="331.5" width="35.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="34" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
-                                                <rect key="frame" x="69.5" y="356.5" width="235" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
+                                                <rect key="frame" x="83.5" y="356.5" width="217" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZaG-bK-6GN">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="YBM-YB-hr6"/>
-                                                            <constraint firstAttribute="width" constant="50" id="yC7-w0-Pb7"/>
+                                                            <constraint firstAttribute="width" secondItem="ZaG-bK-6GN" secondAttribute="height" multiplier="1:1" id="JH9-cH-aeh"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IDL-Qd-vBi">
-                                                        <rect key="frame" x="84" y="9.5" width="67" height="31"/>
+                                                        <rect key="frame" x="75" y="9.5" width="67" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -110,19 +109,24 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jLf-WQ-wyj">
-                                                        <rect key="frame" x="185" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="167" y="0.0" width="50" height="50"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="PfH-YJ-Jdd"/>
-                                                            <constraint firstAttribute="width" constant="50" id="s72-jk-aT9"/>
+                                                            <constraint firstAttribute="width" secondItem="jLf-WQ-wyj" secondAttribute="height" multiplier="1:1" id="qVn-yY-1Y0"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="ZaG-bK-6GN" firstAttribute="width" secondItem="jLf-WQ-wyj" secondAttribute="width" id="1rF-Hg-ucU"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="ZaG-bK-6GN" firstAttribute="width" secondItem="Wvk-Nr-QCu" secondAttribute="width" multiplier="0.13" id="8ll-2H-XbF"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="clC-gd-j8i" firstAttribute="width" secondItem="72w-T2-ApN" secondAttribute="width" constant="-20" id="5my-iJ-pqN"/>
+                                    <constraint firstItem="clC-gd-j8i" firstAttribute="width" secondItem="72w-T2-ApN" secondAttribute="width" constant="-15" id="5my-iJ-pqN"/>
                                     <constraint firstItem="clC-gd-j8i" firstAttribute="trailing" secondItem="Kgq-wt-yRv" secondAttribute="trailing" id="Etj-cU-PGb"/>
                                     <constraint firstItem="clC-gd-j8i" firstAttribute="top" secondItem="Kgq-wt-yRv" secondAttribute="top" id="Zro-2v-BNg"/>
                                     <constraint firstItem="clC-gd-j8i" firstAttribute="leading" secondItem="Kgq-wt-yRv" secondAttribute="leading" id="oc4-Jl-p8K"/>
@@ -138,7 +142,7 @@
                             <constraint firstItem="deo-Mu-dzb" firstAttribute="bottom" secondItem="8bC-Xf-vdC" secondAttribute="bottom" id="K0z-52-Avb"/>
                             <constraint firstItem="deo-Mu-dzb" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="KDl-yp-uYt"/>
                             <constraint firstItem="deo-Mu-dzb" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="dFb-zg-CJH"/>
-                            <constraint firstItem="deo-Mu-dzb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="txb-vE-daM"/>
+                            <constraint firstItem="deo-Mu-dzb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="15" id="txb-vE-daM"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="nQV-bp-DT1"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -90,7 +90,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
-                                                <rect key="frame" x="83.5" y="356.5" width="217" height="50"/>
+                                                <rect key="frame" x="40.5" y="356.5" width="303" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZaG-bK-6GN">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -99,9 +99,9 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IDL-Qd-vBi">
-                                                        <rect key="frame" x="75" y="9.5" width="67" height="31"/>
+                                                        <rect key="frame" x="75" y="9.5" width="153" height="31"/>
                                                         <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="Button">
+                                                        <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                         </buttonConfiguration>
                                                         <connections>
@@ -109,7 +109,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jLf-WQ-wyj">
-                                                        <rect key="frame" x="167" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="253" y="0.0" width="50" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="jLf-WQ-wyj" secondAttribute="height" multiplier="1:1" id="qVn-yY-1Y0"/>
                                                         </constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -169,9 +169,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9zR-si-U3W">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9zR-si-U3W">
+                                <rect key="frame" x="10" y="10" width="414" height="886"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreanItemTableViewCell" rowHeight="178" id="gFg-7d-FQL" customClass="KoreanItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
@@ -181,14 +180,17 @@
                                             <rect key="frame" x="0.0" y="0.0" width="385.5" height="178"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="20l-C8-HRq">
-                                                    <rect key="frame" x="30" y="21" width="119" height="67"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="20l-C8-HRq">
+                                                    <rect key="frame" x="10" y="10" width="375.5" height="158"/>
                                                     <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IG5-vS-155">
-                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IG5-vS-155">
+                                                            <rect key="frame" x="0.0" y="39" width="80" height="80"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" secondItem="IG5-vS-155" secondAttribute="height" multiplier="1:1" id="X3r-SI-YEm"/>
+                                                            </constraints>
                                                         </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Anu-7G-8Nx">
-                                                            <rect key="frame" x="60" y="0.0" width="59" height="67"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="Anu-7G-8Nx">
+                                                            <rect key="frame" x="90" y="55" width="285.5" height="48"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ucp-TA-YJV">
                                                                     <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
@@ -197,7 +199,7 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7R2-lc-nep">
-                                                                    <rect key="frame" x="0.0" y="50" width="35.5" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="31" width="35.5" height="17"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -205,8 +207,17 @@
                                                             </subviews>
                                                         </stackView>
                                                     </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="IG5-vS-155" firstAttribute="width" secondItem="Anu-7G-8Nx" secondAttribute="width" multiplier="0.28" id="uLX-b8-aZ2"/>
+                                                    </constraints>
                                                 </stackView>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="20l-C8-HRq" firstAttribute="top" secondItem="hlu-fU-8Vi" secondAttribute="top" constant="10" id="63f-Gd-LBW"/>
+                                                <constraint firstItem="20l-C8-HRq" firstAttribute="leading" secondItem="hlu-fU-8Vi" secondAttribute="leading" constant="10" id="Dga-mp-cLC"/>
+                                                <constraint firstAttribute="bottom" secondItem="20l-C8-HRq" secondAttribute="bottom" constant="10" id="Efd-Vs-Lt4"/>
+                                                <constraint firstAttribute="trailing" secondItem="20l-C8-HRq" secondAttribute="trailing" id="Mi6-ZZ-5He"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="descriptionLabel" destination="7R2-lc-nep" id="fE9-rT-CWv"/>
@@ -219,6 +230,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Qir-E8-BwC"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="9zR-si-U3W" secondAttribute="bottom" id="JfK-Eb-GYz"/>
+                            <constraint firstItem="9zR-si-U3W" firstAttribute="trailing" secondItem="Qir-E8-BwC" secondAttribute="trailing" constant="10" id="XuE-H0-8bP"/>
+                            <constraint firstItem="9zR-si-U3W" firstAttribute="leading" secondItem="Qir-E8-BwC" secondAttribute="leading" constant="10" id="aEE-n4-uBu"/>
+                            <constraint firstItem="9zR-si-U3W" firstAttribute="top" secondItem="yut-iD-F1e" secondAttribute="top" constant="10" id="iEj-fE-4eE"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="koreanItemsTableView" destination="9zR-si-U3W" id="ZFQ-ZN-Gww"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="sc9-yK-WAf">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -14,35 +14,35 @@
             <objects>
                 <viewController storyboardIdentifier="ParisExpoViewController" id="BYZ-38-t0r" customClass="ParisExpoViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deo-Mu-dzb">
-                                <rect key="frame" x="15" y="0.0" width="399" height="896"/>
+                                <rect key="frame" x="15" y="0.0" width="413" height="926"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
-                                        <rect key="frame" x="0.0" y="0.0" width="384" height="406.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="398" height="406"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chQ-n8-6Jz">
-                                                <rect key="frame" x="162.5" y="0.0" width="59" height="30"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="chQ-n8-6Jz">
+                                                <rect key="frame" x="169.66666666666666" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="Wvk-Nr-QCu">
-                                                <rect key="frame" x="0.0" y="38" width="384" height="200"/>
+                                                <rect key="frame" x="6.6666666666666572" y="38" width="384.66666666666674" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-hj-akY">
-                                                <rect key="frame" x="151" y="246" width="82" height="20.5"/>
+                                                <rect key="frame" x="158.33333333333334" y="246.00000000000003" width="81.666666666666657" height="20.333333333333343"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soz-LU-IgH">
-                                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="soz-LU-IgH">
+                                                        <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDQ-oY-j3B">
-                                                        <rect key="frame" x="46.5" y="0.0" width="35.5" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="lDQ-oY-j3B">
+                                                        <rect key="frame" x="46.333333333333314" y="0.0" width="35.333333333333343" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -50,16 +50,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mJS-EG-9vB">
-                                                <rect key="frame" x="151" y="274.5" width="82" height="20.5"/>
+                                                <rect key="frame" x="158.33333333333334" y="274.33333333333331" width="81.666666666666657" height="20.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSg-WL-2Je">
-                                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bSg-WL-2Je">
+                                                        <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Bd-MI-uhz">
-                                                        <rect key="frame" x="46.5" y="0.0" width="35.5" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="9Bd-MI-uhz">
+                                                        <rect key="frame" x="46.333333333333314" y="0.0" width="35.333333333333343" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -67,30 +67,30 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D0J-Go-gXt">
-                                                <rect key="frame" x="151" y="303" width="82" height="20.5"/>
+                                                <rect key="frame" x="158.33333333333334" y="302.66666666666669" width="81.666666666666657" height="20.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTa-NU-WdQ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KTa-NU-WdQ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SwN-QD-oEs">
-                                                        <rect key="frame" x="46.5" y="0.0" width="35.5" height="20.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="SwN-QD-oEs">
+                                                        <rect key="frame" x="46.333333333333314" y="0.0" width="35.333333333333343" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-3s-icx">
-                                                <rect key="frame" x="174.5" y="331.5" width="35.5" height="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-3s-icx">
+                                                <rect key="frame" x="181.33333333333334" y="331" width="35.333333333333343" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
-                                                <rect key="frame" x="40.5" y="356.5" width="303" height="50"/>
+                                                <rect key="frame" x="47.666666666666657" y="356" width="303" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZaG-bK-6GN">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -99,7 +99,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IDL-Qd-vBi">
-                                                        <rect key="frame" x="75" y="9.5" width="153" height="31"/>
+                                                        <rect key="frame" x="75" y="9.6666666666666856" width="153" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -170,40 +170,40 @@
             <objects>
                 <viewController storyboardIdentifier="KoreanItemViewController" id="18W-Iu-Tei" customClass="KoreanItemViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="yut-iD-F1e">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9zR-si-U3W">
-                                <rect key="frame" x="10" y="10" width="414" height="886"/>
+                                <rect key="frame" x="10" y="10" width="428" height="916"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreanItemTableViewCell" rowHeight="178" id="gFg-7d-FQL" customClass="KoreanItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="178"/>
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="428" height="178"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gFg-7d-FQL" id="hlu-fU-8Vi">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="178"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="399.33333333333331" height="178"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="20l-C8-HRq">
-                                                    <rect key="frame" x="10" y="10" width="375.5" height="158"/>
+                                                    <rect key="frame" x="10" y="10" width="389.33333333333331" height="158"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IG5-vS-155">
-                                                            <rect key="frame" x="0.0" y="39" width="80" height="80"/>
+                                                            <rect key="frame" x="0.0" y="37.666666666666664" width="83" height="82.666666666666686"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="IG5-vS-155" secondAttribute="height" multiplier="1:1" id="X3r-SI-YEm"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="Anu-7G-8Nx">
-                                                            <rect key="frame" x="90" y="55" width="285.5" height="48"/>
+                                                            <rect key="frame" x="93" y="55" width="296.33333333333331" height="48"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ucp-TA-YJV">
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Ucp-TA-YJV">
                                                                     <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7R2-lc-nep">
-                                                                    <rect key="frame" x="0.0" y="31" width="35.5" height="17"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="7R2-lc-nep">
+                                                                    <rect key="frame" x="0.0" y="31" width="35.333333333333336" height="17"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -254,20 +254,20 @@
             <objects>
                 <viewController storyboardIdentifier="KoreanItemDetailViewController" id="sNb-hf-Nzh" customClass="KoreanItemDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="uQa-33-3pV">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KZE-7t-bZO">
-                                <rect key="frame" x="20" y="0.0" width="394" height="896"/>
+                                <rect key="frame" x="20" y="0.0" width="408" height="926"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GAH-A4-FWD">
-                                        <rect key="frame" x="0.0" y="20" width="374" height="251"/>
+                                        <rect key="frame" x="0.0" y="20" width="388" height="258.66666666666669"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="5Hd-as-Afy">
-                                                <rect key="frame" x="63" y="0.0" width="248" height="224"/>
+                                                <rect key="frame" x="65.666666666666657" y="0.0" width="256.66666666666674" height="231.66666666666666"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
-                                                <rect key="frame" x="169.5" y="234" width="35.5" height="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
+                                                <rect key="frame" x="176.33333333333334" y="241.66666666666669" width="35.333333333333343" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -312,7 +312,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="sc9-yK-WAf" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="e6v-H8-bk9">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="428" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -326,8 +326,8 @@
         </scene>
     </scenes>
     <resources>
-        <image name="bangjja" width="341.5" height="256"/>
-        <image name="poster" width="144" height="200"/>
+        <image name="bangjja" width="341.33334350585938" height="256"/>
+        <image name="poster" width="143.66667175292969" height="200"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -253,18 +253,17 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KZE-7t-bZO">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KZE-7t-bZO">
+                                <rect key="frame" x="20" y="0.0" width="394" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="GAH-A4-FWD">
-                                        <rect key="frame" x="8" y="87" width="341.5" height="278"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="GAH-A4-FWD">
+                                        <rect key="frame" x="0.0" y="20" width="374" height="251"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="5Hd-as-Afy">
-                                                <rect key="frame" x="0.0" y="0.0" width="341.5" height="256"/>
+                                                <rect key="frame" x="63" y="0.0" width="248" height="224"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
-                                                <rect key="frame" x="153" y="261" width="35.5" height="17"/>
+                                                <rect key="frame" x="169.5" y="234" width="35.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -272,12 +271,27 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="trailing" secondItem="7bh-Fa-Kfh" secondAttribute="trailing" id="Cy1-1w-Cwc"/>
+                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="width" secondItem="Qto-qn-SpL" secondAttribute="width" constant="-20" id="DCe-x0-1Wd"/>
+                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="leading" secondItem="7bh-Fa-Kfh" secondAttribute="leading" id="RpO-t4-KrA"/>
+                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="top" secondItem="7bh-Fa-Kfh" secondAttribute="top" constant="20" id="ayO-1K-BrK"/>
+                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="bottom" secondItem="7bh-Fa-Kfh" secondAttribute="bottom" id="tUg-61-cOa"/>
+                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="7bh-Fa-Kfh"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="Qto-qn-SpL"/>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="UwS-Bg-UIC"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="KZE-7t-bZO" secondAttribute="bottom" id="NMe-2c-SHM"/>
+                            <constraint firstItem="5Hd-as-Afy" firstAttribute="width" relation="lessThanOrEqual" secondItem="uQa-33-3pV" secondAttribute="width" multiplier="0.6" id="akz-VS-E8d"/>
+                            <constraint firstItem="5Hd-as-Afy" firstAttribute="height" relation="lessThanOrEqual" secondItem="uQa-33-3pV" secondAttribute="height" multiplier="0.25" id="e26-JY-g9t"/>
+                            <constraint firstAttribute="trailing" secondItem="KZE-7t-bZO" secondAttribute="trailing" id="g1q-km-hyP"/>
+                            <constraint firstItem="KZE-7t-bZO" firstAttribute="leading" secondItem="uQa-33-3pV" secondAttribute="leading" constant="20" id="s88-2K-tCd"/>
+                            <constraint firstItem="KZE-7t-bZO" firstAttribute="top" secondItem="uQa-33-3pV" secondAttribute="top" id="vNW-1H-bIk"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="descriptionLabel" destination="NFu-iN-ane" id="hsg-By-sWd"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -17,24 +17,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="deo-Mu-dzb">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deo-Mu-dzb">
+                                <rect key="frame" x="20" y="0.0" width="394" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
-                                        <rect key="frame" x="0.0" y="0.0" width="235" height="406.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="406.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chQ-n8-6Jz">
-                                                <rect key="frame" x="88" y="0.0" width="59" height="30"/>
+                                                <rect key="frame" x="157.5" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="Wvk-Nr-QCu">
-                                                <rect key="frame" x="45.5" y="38" width="144" height="200"/>
+                                                <rect key="frame" x="115" y="38" width="144" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-hj-akY">
-                                                <rect key="frame" x="76.5" y="246" width="82" height="20.5"/>
+                                                <rect key="frame" x="146" y="246" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soz-LU-IgH">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -51,7 +50,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mJS-EG-9vB">
-                                                <rect key="frame" x="76.5" y="274.5" width="82" height="20.5"/>
+                                                <rect key="frame" x="146" y="274.5" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSg-WL-2Je">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -68,7 +67,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D0J-Go-gXt">
-                                                <rect key="frame" x="76.5" y="303" width="82" height="20.5"/>
+                                                <rect key="frame" x="146" y="303" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTa-NU-WdQ">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -85,16 +84,20 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-3s-icx">
-                                                <rect key="frame" x="100" y="331.5" width="35.5" height="17"/>
+                                                <rect key="frame" x="169.5" y="331.5" width="35.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="34" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
-                                                <rect key="frame" x="0.0" y="356.5" width="235" height="50"/>
+                                                <rect key="frame" x="69.5" y="356.5" width="235" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZaG-bK-6GN">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="50" id="YBM-YB-hr6"/>
+                                                            <constraint firstAttribute="width" constant="50" id="yC7-w0-Pb7"/>
+                                                        </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IDL-Qd-vBi">
                                                         <rect key="frame" x="84" y="9.5" width="67" height="31"/>
@@ -108,18 +111,35 @@
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jLf-WQ-wyj">
                                                         <rect key="frame" x="185" y="0.0" width="50" height="50"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="50" id="PfH-YJ-Jdd"/>
+                                                            <constraint firstAttribute="width" constant="50" id="s72-jk-aT9"/>
+                                                        </constraints>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="clC-gd-j8i" firstAttribute="width" secondItem="72w-T2-ApN" secondAttribute="width" constant="-20" id="5my-iJ-pqN"/>
+                                    <constraint firstItem="clC-gd-j8i" firstAttribute="trailing" secondItem="Kgq-wt-yRv" secondAttribute="trailing" id="Etj-cU-PGb"/>
+                                    <constraint firstItem="clC-gd-j8i" firstAttribute="top" secondItem="Kgq-wt-yRv" secondAttribute="top" id="Zro-2v-BNg"/>
+                                    <constraint firstItem="clC-gd-j8i" firstAttribute="leading" secondItem="Kgq-wt-yRv" secondAttribute="leading" id="oc4-Jl-p8K"/>
+                                    <constraint firstItem="clC-gd-j8i" firstAttribute="bottom" secondItem="Kgq-wt-yRv" secondAttribute="bottom" id="xkR-wg-BAX"/>
+                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="Kgq-wt-yRv"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="72w-T2-ApN"/>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="deo-Mu-dzb" firstAttribute="bottom" secondItem="8bC-Xf-vdC" secondAttribute="bottom" id="K0z-52-Avb"/>
+                            <constraint firstItem="deo-Mu-dzb" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="KDl-yp-uYt"/>
+                            <constraint firstItem="deo-Mu-dzb" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="dFb-zg-CJH"/>
+                            <constraint firstItem="deo-Mu-dzb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="txb-vE-daM"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="nQV-bp-DT1"/>
                     <connections>
@@ -149,8 +169,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9zR-si-U3W">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="9zR-si-U3W">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreanItemTableViewCell" rowHeight="178" id="gFg-7d-FQL" customClass="KoreanItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
@@ -160,30 +181,23 @@
                                             <rect key="frame" x="0.0" y="0.0" width="385.5" height="178"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="20l-C8-HRq">
-                                                    <rect key="frame" x="30" y="21" width="226.5" height="50"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="20l-C8-HRq">
+                                                    <rect key="frame" x="30" y="21" width="119" height="67"/>
                                                     <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IG5-vS-155">
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IG5-vS-155">
                                                             <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" priority="1" constant="100" id="Qae-NK-TZh"/>
-                                                                <constraint firstAttribute="width" secondItem="IG5-vS-155" secondAttribute="height" multiplier="1:1" id="uuE-ub-o5f"/>
-                                                            </constraints>
                                                         </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Anu-7G-8Nx">
-                                                            <rect key="frame" x="60" y="0.0" width="166.5" height="50"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="top" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Anu-7G-8Nx">
+                                                            <rect key="frame" x="60" y="0.0" width="59" height="67"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ucp-TA-YJV">
                                                                     <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" priority="1" constant="30" id="ubW-XG-lwY"/>
-                                                                    </constraints>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7R2-lc-nep">
-                                                                    <rect key="frame" x="0.0" y="50" width="35.5" height="0.0"/>
+                                                                    <rect key="frame" x="0.0" y="50" width="35.5" height="17"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -191,18 +205,8 @@
                                                             </subviews>
                                                         </stackView>
                                                     </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="IG5-vS-155" firstAttribute="width" secondItem="Anu-7G-8Nx" secondAttribute="width" multiplier="0.3" id="zK5-bt-REr"/>
-                                                    </constraints>
                                                 </stackView>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="20l-C8-HRq" firstAttribute="leading" secondItem="hlu-fU-8Vi" secondAttribute="leading" constant="30" id="1hw-8v-z5h"/>
-                                                <constraint firstItem="20l-C8-HRq" firstAttribute="top" secondItem="hlu-fU-8Vi" secondAttribute="top" constant="21" id="KWe-jO-zff"/>
-                                                <constraint firstItem="IG5-vS-155" firstAttribute="height" secondItem="hlu-fU-8Vi" secondAttribute="height" multiplier="0.280899" id="WPF-P6-0JJ"/>
-                                                <constraint firstAttribute="trailing" secondItem="20l-C8-HRq" secondAttribute="trailing" constant="129" id="pX9-bI-Zpb"/>
-                                                <constraint firstAttribute="bottom" secondItem="20l-C8-HRq" secondAttribute="bottom" constant="219" id="wXf-Pp-dTG"/>
-                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="descriptionLabel" destination="7R2-lc-nep" id="fE9-rT-CWv"/>
@@ -215,12 +219,6 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Qir-E8-BwC"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="Qir-E8-BwC" firstAttribute="bottom" secondItem="9zR-si-U3W" secondAttribute="bottom" id="0Ry-NZ-j4X"/>
-                            <constraint firstItem="9zR-si-U3W" firstAttribute="top" secondItem="Qir-E8-BwC" secondAttribute="top" id="NJq-YM-5O6"/>
-                            <constraint firstItem="9zR-si-U3W" firstAttribute="leading" secondItem="Qir-E8-BwC" secondAttribute="leading" id="aD7-wH-wWR"/>
-                            <constraint firstItem="Qir-E8-BwC" firstAttribute="trailing" secondItem="9zR-si-U3W" secondAttribute="trailing" id="lRG-gp-B2r"/>
-                        </constraints>
                     </view>
                     <connections>
                         <outlet property="koreanItemsTableView" destination="9zR-si-U3W" id="ZFQ-ZN-Gww"/>
@@ -238,17 +236,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KZE-7t-bZO">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KZE-7t-bZO">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="GAH-A4-FWD">
-                                        <rect key="frame" x="8" y="87" width="341.5" height="281.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="GAH-A4-FWD">
+                                        <rect key="frame" x="8" y="87" width="341.5" height="278"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="5Hd-as-Afy">
-                                                <rect key="frame" x="0.0" y="0.0" width="341.5" height="259.5"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="5Hd-as-Afy">
+                                                <rect key="frame" x="0.0" y="0.0" width="341.5" height="256"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
-                                                <rect key="frame" x="153" y="264.5" width="35.5" height="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
+                                                <rect key="frame" x="153" y="261" width="35.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -256,27 +255,12 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="bottom" secondItem="7bh-Fa-Kfh" secondAttribute="bottom" constant="368.5" id="6t5-zL-Gpp"/>
-                                    <constraint firstAttribute="width" constant="414" id="Ca8-P3-wJc"/>
-                                    <constraint firstAttribute="height" constant="818" id="KAh-Iz-Tup"/>
-                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="width" secondItem="Qto-qn-SpL" secondAttribute="width" multiplier="0.824879" id="eDC-5N-NYf"/>
-                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="top" secondItem="7bh-Fa-Kfh" secondAttribute="top" constant="87" id="t9M-dp-cGO"/>
-                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="leading" secondItem="7bh-Fa-Kfh" secondAttribute="leading" constant="8" id="wAx-T7-vGf"/>
-                                    <constraint firstItem="GAH-A4-FWD" firstAttribute="trailing" secondItem="7bh-Fa-Kfh" secondAttribute="trailing" constant="349.5" id="z7X-Rv-WSo"/>
-                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="7bh-Fa-Kfh"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="Qto-qn-SpL"/>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="UwS-Bg-UIC"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="KZE-7t-bZO" firstAttribute="leading" secondItem="UwS-Bg-UIC" secondAttribute="leading" id="8mf-TE-Aeq"/>
-                            <constraint firstItem="UwS-Bg-UIC" firstAttribute="bottom" secondItem="KZE-7t-bZO" secondAttribute="bottom" id="Ic7-x0-WJf"/>
-                            <constraint firstItem="UwS-Bg-UIC" firstAttribute="trailing" secondItem="KZE-7t-bZO" secondAttribute="trailing" id="O7W-wh-yfp"/>
-                            <constraint firstItem="KZE-7t-bZO" firstAttribute="top" secondItem="UwS-Bg-UIC" secondAttribute="top" id="zv0-3O-unp"/>
-                        </constraints>
                     </view>
                     <connections>
                         <outlet property="descriptionLabel" destination="NFu-iN-ane" id="hsg-By-sWd"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="420.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="406.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chQ-n8-6Jz">
                                                 <rect key="frame" x="177.5" y="0.0" width="59" height="30"/>
@@ -33,64 +33,64 @@
                                                 <rect key="frame" x="135" y="38" width="144" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-hj-akY">
-                                                <rect key="frame" x="160" y="246" width="94.5" height="24"/>
+                                                <rect key="frame" x="166" y="246" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soz-LU-IgH">
-                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDQ-oY-j3B">
-                                                        <rect key="frame" x="53" y="0.0" width="41.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <rect key="frame" x="46.5" y="0.0" width="35.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mJS-EG-9vB">
-                                                <rect key="frame" x="160" y="278" width="94.5" height="24"/>
+                                                <rect key="frame" x="166" y="274.5" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSg-WL-2Je">
-                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Bd-MI-uhz">
-                                                        <rect key="frame" x="53" y="0.0" width="41.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <rect key="frame" x="46.5" y="0.0" width="35.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D0J-Go-gXt">
-                                                <rect key="frame" x="160" y="310" width="94.5" height="24"/>
+                                                <rect key="frame" x="166" y="303" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTa-NU-WdQ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SwN-QD-oEs">
-                                                        <rect key="frame" x="53" y="0.0" width="41.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <rect key="frame" x="46.5" y="0.0" width="35.5" height="20.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-3s-icx">
-                                                <rect key="frame" x="186.5" y="342" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <rect key="frame" x="189.5" y="331.5" width="35.5" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="34" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
-                                                <rect key="frame" x="89.5" y="370.5" width="235" height="50"/>
+                                                <rect key="frame" x="89.5" y="356.5" width="235" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZaG-bK-6GN">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -102,7 +102,9 @@
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IDL-Qd-vBi">
                                                         <rect key="frame" x="84" y="9.5" width="67" height="31"/>
                                                         <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Button">
+                                                            <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
+                                                        </buttonConfiguration>
                                                         <connections>
                                                             <action selector="touchUpKoreanItemsButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xsf-3L-ujB"/>
                                                         </connections>
@@ -192,17 +194,17 @@
                                                             <rect key="frame" x="60" y="0.0" width="166.5" height="50"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ucp-TA-YJV">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="59" height="30"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" priority="1" constant="30" id="ubW-XG-lwY"/>
                                                                     </constraints>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7R2-lc-nep">
-                                                                    <rect key="frame" x="0.0" y="40.5" width="41.5" height="9.5"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <rect key="frame" x="0.0" y="50" width="35.5" height="0.0"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
@@ -262,12 +264,12 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="GAH-A4-FWD">
                                         <rect key="frame" x="8" y="87" width="341.5" height="281.5"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="5Hd-as-Afy">
-                                                <rect key="frame" x="0.0" y="0.0" width="341.5" height="256"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="bangjja" translatesAutoresizingMaskIntoConstraints="NO" id="5Hd-as-Afy">
+                                                <rect key="frame" x="0.0" y="0.0" width="341.5" height="259.5"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
-                                                <rect key="frame" x="150" y="261" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NFu-iN-ane">
+                                                <rect key="frame" x="153" y="264.5" width="35.5" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -17,23 +17,24 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="deo-Mu-dzb">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="deo-Mu-dzb">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="406.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="clC-gd-j8i">
+                                        <rect key="frame" x="0.0" y="0.0" width="235" height="406.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="chQ-n8-6Jz">
-                                                <rect key="frame" x="177.5" y="0.0" width="59" height="30"/>
+                                                <rect key="frame" x="88" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="Wvk-Nr-QCu">
-                                                <rect key="frame" x="135" y="38" width="144" height="200"/>
+                                                <rect key="frame" x="45.5" y="38" width="144" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="hVc-hj-akY">
-                                                <rect key="frame" x="166" y="246" width="82" height="20.5"/>
+                                                <rect key="frame" x="76.5" y="246" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soz-LU-IgH">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -50,7 +51,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="mJS-EG-9vB">
-                                                <rect key="frame" x="166" y="274.5" width="82" height="20.5"/>
+                                                <rect key="frame" x="76.5" y="274.5" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSg-WL-2Je">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -67,7 +68,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="D0J-Go-gXt">
-                                                <rect key="frame" x="166" y="303" width="82" height="20.5"/>
+                                                <rect key="frame" x="76.5" y="303" width="82" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KTa-NU-WdQ">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -84,20 +85,16 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7dg-3s-icx">
-                                                <rect key="frame" x="189.5" y="331.5" width="35.5" height="17"/>
+                                                <rect key="frame" x="100" y="331.5" width="35.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="34" translatesAutoresizingMaskIntoConstraints="NO" id="gZX-uJ-irE">
-                                                <rect key="frame" x="89.5" y="356.5" width="235" height="50"/>
+                                                <rect key="frame" x="0.0" y="356.5" width="235" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZaG-bK-6GN">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="50" id="8k2-xC-5YY"/>
-                                                            <constraint firstAttribute="height" constant="50" id="nEL-yI-KR9"/>
-                                                        </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IDL-Qd-vBi">
                                                         <rect key="frame" x="84" y="9.5" width="67" height="31"/>
@@ -111,35 +108,18 @@
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="jLf-WQ-wyj">
                                                         <rect key="frame" x="185" y="0.0" width="50" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="7PT-yS-3Zp"/>
-                                                            <constraint firstAttribute="width" constant="50" id="tTW-8K-rfQ"/>
-                                                        </constraints>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="clC-gd-j8i" firstAttribute="width" secondItem="72w-T2-ApN" secondAttribute="width" id="Hgr-VM-4hy"/>
-                                    <constraint firstItem="clC-gd-j8i" firstAttribute="bottom" secondItem="Kgq-wt-yRv" secondAttribute="bottom" id="Khq-lm-wMz"/>
-                                    <constraint firstItem="clC-gd-j8i" firstAttribute="trailing" secondItem="Kgq-wt-yRv" secondAttribute="trailing" id="LsH-dR-AsY"/>
-                                    <constraint firstItem="clC-gd-j8i" firstAttribute="leading" secondItem="Kgq-wt-yRv" secondAttribute="leading" id="pMT-wb-RR0"/>
-                                    <constraint firstItem="clC-gd-j8i" firstAttribute="top" secondItem="Kgq-wt-yRv" secondAttribute="top" id="vO5-7M-IBH"/>
-                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="Kgq-wt-yRv"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="72w-T2-ApN"/>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="deo-Mu-dzb" secondAttribute="trailing" id="3BC-hW-UDN"/>
-                            <constraint firstItem="deo-Mu-dzb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Cxs-l9-5eX"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="deo-Mu-dzb" secondAttribute="bottom" id="TXU-XR-ygb"/>
-                            <constraint firstItem="deo-Mu-dzb" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="pr2-Gw-kQi"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="nQV-bp-DT1"/>
                     <connections>

--- a/README.md
+++ b/README.md
@@ -1,56 +1,198 @@
-# 만국박람회 프로젝트 저장소
+# 만국박람회
 
-## 타임라인
-- 프로젝트 기간: 20220411 ~ 20220422(2주)
+>프로젝트 기간 2022-04-11 ~ 2022-04-22
+>
+>팀원 : [쿼카](https://github.com/Quokkaaa), [Tiana](https://github.com/Kim-TaeHyun-A) / 리뷰어 : [올라프](https://github.com/1Consumption)
 
-## UML
-![](https://i.imgur.com/Ar8FyKP.png)
-
-## 팀원 및 리뷰어
-팀원: [Tiana](https://github.com/Kim-TaeHyun-A), [쿼카](https://github.com/Quokkaaa), 리뷰어: [Tony](https://github.com/Monsteel)
 
 ## 개발환경 및 라이브러리
 [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
-[![xcode](https://img.shields.io/badge/Xcode-13.3-blue)]()
+[![xcode](https://img.shields.io/badge/Xcode-13.3.1-blue)]()
 
-## 그라운드룰
-- 점심시간 12시 ~ 2시
-- 저녁시간 7시 - 8시
+# 학습한 키워드
+`Dedable` `orientation`
 
-[Tiana]
-- 안되는 시간 없음
+## PR 바로가기
+[STEP 1 PR](https://github.com/yagom-academy/ios-exposition-universelle/pull/137)
 
-[쿼카]
-- 안되는시간 
-    - 22일 이사가야돼서 금요일은 빼고 프로젝트를 생각해볼 수 있을까요 ?
+[STEP 2 PR](https://github.com/yagom-academy/ios-exposition-universelle/pull/147)
 
-## git flow
+[STEP 3 PR](https://github.com/yagom-academy/ios-exposition-universelle/pull/158)
 
-: 브랜치 전략 중 하나.
-브랜치 생성, 머지 등 흐름 파악.
-checkout, merge, tag 사용되는 깃 명령어 많지 않아 단순
-1개월 이상 긴 개발 시 사용
+# STEP1
 
-1. master : 앱 출시 브랜치, release가 병합됨
+<img src="https://i.imgur.com/dlBbe9t.png" width="600">
 
-2. develop : 다음 출시 버전 개발, feature가 기능 완료하면 develop에 합쳐짐, 배포 시 master에 합칠 때 develop에도 합침(이후 버전 개발을 위해)
+1.  encode할 필요가 없다고 판단되어 각 모델은 Decodable만 채택합니다.
 
-3. feature(s) : 단일 기능 개발, develop에서 브랜치 따서 기능 개발, feature-기능 : 브랜치 이름
+2.  testcase에서 XCTAssertEqual() 메서드를 사용해서 타입이 json data를 잘 decode하는지 확인
 
-4. release(s) : 다음 버전 배포 준비(버전명, 심사 실패 시버그 수정), develop에서 새 버전 배포하기 위해 생성
+```swift
+extension ParisExpo: Equatable {
+     public static func == (lhs: ParisExpo, rhs: ParisExpo) -> Bool {
+         return lhs.title == rhs.title && lhs.description == rhs.description && lhs.duration == rhs.duration && lhs.visitors == rhs.visitors && lhs.location == rhs.location
+     }
+ }
+```
+Equatable은 테스트를 위한 코드에서만 필요합니다. 따하서, 테스트 파일에서 import한 타입의 기능을 확장하는 방식으로 구현했습니다.
 
-5. hotfix(s) : 배포한 앱에서 발생한 급한 버그 수정, master에서 브랜치 생성 후 master로 바로 합침, 버전과 빌드 번호도 여기서 수정 후 배포
-cf. (s) → 여러 개 만들 수 있는 브랜치들
+3. 공식문서 예제에는 프로퍼티들이 var로 설정되어 있었으나 만국박람회 프로젝트에서는 수정할 필요가 없을 것 같아 let으로 선언했습니다.
 
 
-## STEP1 핵심경험
-- Codable을 채택하여 JSON 데이터와 매칭할 모델 타입 구현
-- 스네이크 케이스 또는 축약형인 JSON 키 값을 스위프트의 네이밍에 맞게 변환
 
-## Step 2 핵심경험
-- 테이블뷰의 Delegate와 Data Source의 역할의 이해
-- 테이블뷰의 셀의 재사용 이해
-- 테이블뷰의 전반적인 동작 방식의 이해
-- 주어진 JSON 데이터를 파싱하여 테이블뷰에 표시
-- 내비게이션 컨트롤러를 활용한 화면 전환
-- 뷰 컨트롤러 사이의 데이터 전달
+# STEP2
+1. 메서드로 기능분리
+- Cell에 값을 넘겨줄때 메서드로 기능분리
+```swift
+[before]
+        cell.titleLabel.text = koreanItems[indexPath.row].name
+        cell.descriptionLabel.text = koreanItems[indexPath.row].shortDesciption
+        cell.mainImageView.image = UIImage(named: koreanItems[indexPath.row].imageName)
+
+[after]
+    func assignKoreanItemValue(with item: KoreanHistoricalItem) {
+         titleLabel.text = item.name
+         descriptionLabel.text = item.shortDesciption
+         mainImageView.image = UIImage(named: item.imageName)
+     }
+
+[호출]
+  cell.assignKoreanItemValue(with: koreanItems[indexPath.row])
+```
+
+뷰 컨트롤러에서 cell 의 프로퍼티를 세팅하는 것이 아닌 메서드에서 값을 설정할 수 있도록 변경했습니다.
+
+* 델리게이트 세팅을 위한 메서드
+```swift
+    private func configurateDelegateProperties() {
+         koreanItemsTableView.delegate = self
+         koreanItemsTableView.dataSource = self
+     }
+```
+
+* 에러 알림창 띄우는 메서드
+유저 친화적인 멘트 보이도록 수정했습니다.
+```swift
+private func showFailureAlert() {
+         let alertController = UIAlertController(title: nil, message: "적절한 데이터를 불러올 수 없습니다.", preferredStyle: .alert)
+         let confirmButton = UIAlertAction(title: "ok", style: .default)
+         alertController.addAction(confirmButton)
+         present(alertController, animated: true)
+}
+```
+
+
+2. View역할에 대한 고민
+VC내에서는 View에게 값을 전달만 할 수 있도록 역할 분리했습니다.
+view의 역할은 모델에서 데이터를 가져와서 보여주는 것만 하고 사용자의 interaction만 진행합니다.
+
+```swift
+[Before]
+    private func initializeParisExpoData() {
+        guard let data = try? ParisExpo.decode(from: FileName.parisExpo) else {
+            return
+        }
+        parisExpoData = data
+    }
+```
+위 코드가 VC내에 있어서 Filename을 불러와서 값을 디코드 해주었는데 이는 모델에 역할이기에 리펙토링을 해주었습니다.
+
+```swift
+[After]
+enum AssetData {
+    static func assignParisExpo() throws -> ParisExpo {
+        return try ParserManager<ParisExpo>.parse(fileName: FileName.parisExpo)
+    }
+    
+    static func assignKoreanItems() throws -> [KoreanHistoricalItem] {
+        return try ParserManager<[KoreanHistoricalItem]>.parse(fileName: FileName.items)
+    }
+}
+
+extension ParisExpoViewController {
+    private func initializeParisExpoData() {
+        do {
+            parisExpoData = try AssetData.assignParisExpo()
+        } catch {
+            showFailureAlert(message: AlertMessage.notFoundData)
+        }
+    }
+}
+```
+
+3. 파일분리
+Utils그룹 폴더 내 Error, Consant, Extension 그룹 폴더를 만들고 MVC, Application그룹 폴더 만들어 파일분리를 했습니다.
+
+4. UITableViewCell을 반환하는 tableview메서드의 error처리
+
+```swift
+// viewDidLoad내에서 실행 => 한번만 실행해도 되기 떄문
+tableView.register(UITableViewCell.self, forCellReuseIdentifier: "empty cell")
+showFailureAlert()
+```
+
+5. 매직넘버를 enum으로 관리
+
+
+6. 네이밍
+	- upload라는 네이밍은 서버에 전달하는 느낌이라 비동기적 성격을 띄는 것 같아서 Configure같은 것으로 대체했습니다.
+
+7. Storyboard VS code 택1
+     * 스토리보드에서 구현한 뷰의 세팅을 두 곳(인스펙터와 코드)에서 모두 진행할 경우 다른 개발자가 설정된 속성값 확인이 번거로울 것 같아서 정적인 속성값 설정은 스토리보드에서 진행했습니다.
+
+
+# STEP3
+- autolayout 설정
+
+- 모든 화면에 Dynamic Type 적용
+
+- 모든 텍스트가 잘리거나 줄임표(...)처리가 되지않도록 함
+
+- 메서드 단일 책임분리
+
+# TROUBLE SHOOTING
+- 세로고정이 되어야하는데 화면 세로고정이 안됬던 문제 해결
+
+firstView -> secondView -> 가로화면 -> firstView = 화면이 세로고정이 바로 안됨
+
+![](https://i.imgur.com/zNT47Bo.gif)
+
+[Before]
+
+```swift
+if let _ = window?.rootViewController?.navigationController?.topViewController 
+as? ParisExpoViewController
+```
+
+* debug biew hierarchy를 사용해보았습니다.
+
+![](https://i.imgur.com/PXurCyT.png)
+* UINavigationController의 top controller 주소를 확인했습니다.
+
+![](https://i.imgur.com/vTbHaeS.png)
+* 시뮬레이터에서 첫 화면이 나왔을 때, 첫 화면의 뷰 컨트롤러의 주소값이 navagiation controller의 top controller의 주소값과 같은 것을 디버깅으로 확인했습니다.
+
+![](https://i.imgur.com/ajggAea.png)
+* UINavigationController의 top controller 주소를 확인했습니다.
+
+![](https://i.imgur.com/Gj6iQ50.png)
+* 시뮬레이터에서 두번째 화면이 나왔을 때, 두번째의 뷰 컨트롤러의 주소값이 navagiation controller의 top controller의 주소값과 같은 것을 디버깅으로 확인했습니다.
+
+![](https://i.imgur.com/FrYQjpg.png)
+* debug memory graph를 확인해보면 rootView는 navigationController라는걸 확인할 수 있다.
+
+* rootViewController가 navigationController인 것을 확인하고 타입 캐스팅을 통해 최상위에 접근합니다. 타입 캐스팅으로 첫번째 뷰 인지 확인했습니다.
+
+```swift
+[After]
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if let navigationController: UINavigationController = window?.rootViewController as? UINavigationController,
+           let _ = navigationController.topViewController as? ParisExpoViewController
+             {
+            return .portrait
+        }
+        return .all
+    }
+```
+* 위 코드에서는 젤 상단의 뷰 컨트롤러의 타입을 확인하고 지원하는 orientation을 설정합니다.
+


### PR DESCRIPTION
@1Consumption 
울라프! ⛄ 
마지막 STEP3 PR 잘부탁드립니다.🙇‍♀️🙇‍♂️

# 고민한 점
1. decode 타입 생성
    * 캡슐화된 메서드에 접근하기 위한 인스턴스 생성은 불필요해 보였기에 타입 메서드로 구현했습니다. case가 없는 enum으로 인스턴스 생성이 힘들도록 구현했습니다.
    * ParserManager에서는 기존에는 KoreanHistoricalItem 모델과 ParisExpo 모델 타입에 중복으로 구현된 부분을 제거하고자 제네릭으로 타입을 구현했습니다.
    * Asset 타입의 타입 메서드로 뷰 컨트롤러에서는 뷰의 역할(= model에서 데이터를 꺼내서 보여주고 user와 interaction하는 것)에 충실할 수 있도록 했습니다.


2. 첫번째 화면 세로로 고정
    * 처음에는 UINavigationController를 확장해서 구현했는데 기기가 가로일 때 세로로 화면이 나오지 않는 문제가 생겨서 실패했습니다.
    ```swift
    extension UINavigationController {
    override open var shouldAutorotate: Bool {
        get {
            if let _ = topViewController as? ParisExpoViewController {
                return false
            }
            return true
            }
        }
    }
    ```
    * UIAppDelegate에 Bool 변수로 플래그를 선언했습니다.
    * 특정 윈도우의 뷰 컨트롤러들의 orientation 설정에 사용되는 `application(_:supportedInterfaceOrientationsFor:)` 메서드를 사용해서 `UIInterfaceOrientationMask`를 설정했습니다.
    * 플래그를 사용않고 아래처럼 젤 상단의 뷰 컨트롤러에 접근하고 싶었지만 잘 되지 않네요.🤔
    `if let _ = window?.rootViewController?.navigationController?.topViewController as? ParisExpoViewController`



3. AutoLayout
    * stakView에서 alignment와 distribution을 설정할 때 중앙 정렬을 하고 싶은 경우에는 Center로, 왼쪽으로 정렬하고 싶을 땐 leading, 가득 채울 땐 fill로 설정했습니다.
    * intrisic content size는 고유 컨텐츠 사이즈로, 버튼이나 레이블의 경우 내부 텍스트를 통해 사이즈 추측이 가능하여 오토 레이아웃 설정 시 높이 설정이 필요 없었습니다.
    * 테이블 뷰의 cell의 오토레이아웃 설정 시 처음에는 cell과 내부 stack의 상하좌우를 맞췄으나 제대로 설정되지 않아서 content view에 연결해서 해결했습니다.
    * 스크롤 뷰의 스크롤바를 오른쪽에 붙이며 좌우 간격을 띄우기 위해서 스크롤 뷰 내부에 위치한 스택뷰의 너비를 띄우고자 하는 간격만큼 작게 설정하는 것으로 해결했습니다.

4. 하드 코딩 지양

5. 단일 책임을 가지는 메서드가 되도록 분리

6. Dynamic Type
    * 버튼의 레이블 텍스트를 스토리보드에서 dynamic type으로 설정하고 싶었지만 xcode의 버그인지 저희가 제대로 적용시키지 못한 것인지 실패했습니다.
    * 따라서, 코드에서 `UIFont.preferredFont(forTextStyle: .callout)`를 통해 스타일을 지정하였고 제대로 적용된 것을 확인했습니다.
    * autoshrink를 스토리보드에서 적용시켜서 사용자가 글자 크기를 크게 설정해도 어느정도 이상은 커지지 않도록 막았습니다.
    ![](https://i.imgur.com/0bZyvTq.png)

7. 버튼 텍스트 오류
    * 버튼의 텍스트 레이블을 코드로 작성했을 때 제대로 출력되지 않아서 스토리보드에서 세팅했습니다.

8. 네이밍