### PR TITLE
만국 박람회 [Step3] 우롱차, marisol

### DIFF
--- a/Expo1900/DetailViewController.swift
+++ b/Expo1900/DetailViewController.swift
@@ -11,8 +11,8 @@ final class DetailViewController: UIViewController {
 
     @IBOutlet private weak var heritageImage: UIImageView!
     @IBOutlet private weak var heritageDescription: UILabel!
-    static let identifier = String(describing: DetailViewController.self)
     
+    static let identifier = String(describing: DetailViewController.self)
     var item: Item?
     
     override func viewDidLoad() {

--- a/Expo1900/DetailViewController.swift
+++ b/Expo1900/DetailViewController.swift
@@ -7,12 +7,11 @@
 
 import UIKit
 
-final class DetailViewController: UIViewController {
+final class DetailViewController: UIViewController, ViewControllerIdentifier {
 
     @IBOutlet private weak var heritageImage: UIImageView!
     @IBOutlet private weak var heritageDescription: UILabel!
     
-    static let identifier = String(describing: DetailViewController.self)
     var item: Item?
     
     override func viewDidLoad() {

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -17,10 +17,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ONN-CF-NGc">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ONN-CF-NGc">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FYW-Tb-bqs" userLabel="Contents View">
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FYW-Tb-bqs" userLabel="Contents View">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="458"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ktN-8w-RtL" userLabel="Title">
@@ -56,69 +56,66 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="djd-j3-WkS">
-                                                <rect key="frame" x="10" y="368" width="394" height="80"/>
-                                                <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="flag" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1C9-y5-Oh5">
-                                                        <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="80" id="9MK-mo-wAe"/>
-                                                            <constraint firstAttribute="width" constant="80" id="urM-uI-fBR"/>
-                                                        </constraints>
-                                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        </preferredSymbolConfiguration>
-                                                    </imageView>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IR1-f9-VTF">
-                                                        <rect key="frame" x="80" y="0.0" width="234" height="80"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                                        <state key="normal" title="한국의 출품작 보러가기">
-                                                            <color key="titleColor" systemColor="linkColor"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="showListButtonIsTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mZB-P8-neQ"/>
-                                                        </connections>
-                                                    </button>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="flag" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4ow-8h-abQ">
-                                                        <rect key="frame" x="314" y="0.0" width="80" height="80"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="80" id="f59-Oj-cPR"/>
-                                                            <constraint firstAttribute="height" constant="80" id="zrj-jY-TrR"/>
-                                                        </constraints>
-                                                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        </preferredSymbolConfiguration>
-                                                    </imageView>
-                                                </subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalCompressionResistancePriority="250" ambiguous="YES" image="flag" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1C9-y5-Oh5" userLabel="Left Flag">
+                                                <rect key="frame" x="10" y="368" width="80" height="80"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" secondItem="IR1-f9-VTF" secondAttribute="height" id="fiA-pC-K2g"/>
+                                                    <constraint firstAttribute="width" relation="lessThanOrEqual" secondItem="FYW-Tb-bqs" secondAttribute="width" multiplier="0.15" id="6B8-sD-lkf"/>
+                                                    <constraint firstAttribute="width" secondItem="1C9-y5-Oh5" secondAttribute="height" multiplier="1.2" id="IHN-aX-c10"/>
                                                 </constraints>
-                                            </stackView>
+                                                <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                </preferredSymbolConfiguration>
+                                            </imageView>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IR1-f9-VTF">
+                                                <rect key="frame" x="90" y="368" width="234" height="80"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                                <state key="normal" title="한국의 출품작 보러가기"/>
+                                                <connections>
+                                                    <action selector="showListButtonIsTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mZB-P8-neQ"/>
+                                                </connections>
+                                            </button>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" ambiguous="YES" image="flag" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4ow-8h-abQ" userLabel="Right Flag">
+                                                <rect key="frame" x="324" y="368" width="80" height="80"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="1C9-y5-Oh5" secondAttribute="width" multiplier="1:1" id="Cz4-g9-ugQ"/>
+                                                    <constraint firstAttribute="height" secondItem="1C9-y5-Oh5" secondAttribute="height" multiplier="1:1" id="fyA-GU-can"/>
+                                                </constraints>
+                                                <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font">
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                </preferredSymbolConfiguration>
+                                            </imageView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
+                                            <constraint firstItem="1C9-y5-Oh5" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="2t5-zl-Lha"/>
                                             <constraint firstAttribute="width" id="49f-8k-zYC"/>
                                             <constraint firstAttribute="trailing" secondItem="7Le-wY-w8Z" secondAttribute="trailing" constant="10" id="4EO-mv-QT7"/>
                                             <constraint firstItem="7Le-wY-w8Z" firstAttribute="top" secondItem="1R4-Z4-ZTG" secondAttribute="bottom" constant="10" id="4Sk-zf-8po"/>
                                             <constraint firstItem="7Le-wY-w8Z" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="5Us-Qx-Y9U"/>
+                                            <constraint firstAttribute="trailing" secondItem="4ow-8h-abQ" secondAttribute="trailing" constant="10" id="9HK-mf-fsE"/>
                                             <constraint firstAttribute="trailing" secondItem="PPf-Yg-MKq" secondAttribute="trailing" constant="10" id="BBE-3n-nye"/>
-                                            <constraint firstAttribute="trailing" secondItem="djd-j3-WkS" secondAttribute="trailing" constant="10" id="CBP-8x-cXq"/>
-                                            <constraint firstItem="djd-j3-WkS" firstAttribute="top" secondItem="7Le-wY-w8Z" secondAttribute="bottom" constant="10" id="GrX-tG-rpB"/>
+                                            <constraint firstAttribute="bottom" secondItem="IR1-f9-VTF" secondAttribute="bottom" constant="10" id="BwC-89-FV9"/>
                                             <constraint firstAttribute="trailing" secondItem="ktN-8w-RtL" secondAttribute="trailing" constant="10" id="H3g-yz-1gq"/>
+                                            <constraint firstItem="1C9-y5-Oh5" firstAttribute="top" secondItem="7Le-wY-w8Z" secondAttribute="bottom" constant="10" id="HQd-lw-Deo"/>
                                             <constraint firstAttribute="trailing" secondItem="1R4-Z4-ZTG" secondAttribute="trailing" constant="10" id="PmW-NH-yTT"/>
+                                            <constraint firstItem="4ow-8h-abQ" firstAttribute="leading" secondItem="IR1-f9-VTF" secondAttribute="trailing" id="SXH-fp-qjf"/>
                                             <constraint firstItem="1R4-Z4-ZTG" firstAttribute="top" secondItem="PPf-Yg-MKq" secondAttribute="bottom" constant="10" id="T3b-Ka-pDj"/>
-                                            <constraint firstItem="djd-j3-WkS" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="UZG-XP-ecp"/>
                                             <constraint firstItem="b27-L0-HqB" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="Uku-pF-xMQ"/>
+                                            <constraint firstItem="IR1-f9-VTF" firstAttribute="leading" secondItem="1C9-y5-Oh5" secondAttribute="trailing" id="VPT-6K-Ryy"/>
+                                            <constraint firstItem="IR1-f9-VTF" firstAttribute="top" secondItem="7Le-wY-w8Z" secondAttribute="bottom" constant="10" id="WW4-vA-XDI"/>
+                                            <constraint firstItem="4ow-8h-abQ" firstAttribute="top" secondItem="7Le-wY-w8Z" secondAttribute="bottom" constant="10" id="XzU-OK-4bW"/>
                                             <constraint firstItem="8Tj-we-nDF" firstAttribute="centerX" secondItem="FYW-Tb-bqs" secondAttribute="centerX" id="kyL-py-TzM"/>
                                             <constraint firstItem="ktN-8w-RtL" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="mXT-Yj-OEa"/>
                                             <constraint firstItem="1R4-Z4-ZTG" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="muz-Ic-nVz"/>
                                             <constraint firstItem="b27-L0-HqB" firstAttribute="top" secondItem="8Tj-we-nDF" secondAttribute="bottom" constant="10" id="nha-LL-r9h"/>
+                                            <constraint firstItem="IR1-f9-VTF" firstAttribute="centerX" secondItem="FYW-Tb-bqs" secondAttribute="centerX" id="od7-km-gsI"/>
                                             <constraint firstItem="8Tj-we-nDF" firstAttribute="top" secondItem="ktN-8w-RtL" secondAttribute="bottom" constant="10" id="qa6-6w-Zth"/>
                                             <constraint firstItem="ktN-8w-RtL" firstAttribute="top" secondItem="FYW-Tb-bqs" secondAttribute="top" constant="10" id="qcQ-Lu-Lcg"/>
                                             <constraint firstItem="PPf-Yg-MKq" firstAttribute="top" secondItem="b27-L0-HqB" secondAttribute="bottom" constant="10" id="rSK-He-j5B"/>
+                                            <constraint firstAttribute="bottom" secondItem="1C9-y5-Oh5" secondAttribute="bottom" constant="10" id="rw4-6a-nD5"/>
                                             <constraint firstAttribute="trailing" secondItem="b27-L0-HqB" secondAttribute="trailing" constant="10" id="uU2-7f-J4u"/>
-                                            <constraint firstAttribute="bottom" secondItem="djd-j3-WkS" secondAttribute="bottom" constant="10" id="w0p-PL-Efj"/>
+                                            <constraint firstAttribute="bottom" secondItem="4ow-8h-abQ" secondAttribute="bottom" constant="10" id="zZS-qC-egU"/>
                                             <constraint firstItem="PPf-Yg-MKq" firstAttribute="leading" secondItem="FYW-Tb-bqs" secondAttribute="leading" constant="10" id="zlE-SO-0c3"/>
                                         </constraints>
                                         <variation key="default">
@@ -152,7 +149,6 @@
                     <connections>
                         <outlet property="descriptionLabel" destination="7Le-wY-w8Z" id="Fua-EA-7De"/>
                         <outlet property="durationLabel" destination="1R4-Z4-ZTG" id="HUY-Ef-I4X"/>
-                        <outlet property="koreanItemsButton" destination="IR1-f9-VTF" id="f5U-aj-KLf"/>
                         <outlet property="locationLabel" destination="PPf-Yg-MKq" id="jDy-Bj-l09"/>
                         <outlet property="posterImage" destination="8Tj-we-nDF" id="3lH-gA-DFY"/>
                         <outlet property="titleLabel" destination="ktN-8w-RtL" id="je5-MT-jzo"/>
@@ -330,9 +326,6 @@
     <resources>
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="144" height="200"/>
-        <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -244,6 +244,10 @@
                                 </connections>
                             </tableViewCell>
                         </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="hSF-IZ-cdm" id="8w1-3E-oHK"/>
+                            <outlet property="delegate" destination="hSF-IZ-cdm" id="KJy-v5-08b"/>
+                        </connections>
                     </tableView>
                     <navigationItem key="navigationItem" id="4bb-jP-Q3b"/>
                     <connections>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -205,16 +205,16 @@
                                             </constraints>
                                         </imageView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="gri-nQ-E4y">
-                                            <rect key="frame" x="140" y="31" width="225.5" height="47"/>
+                                            <rect key="frame" x="140" y="31" width="245.5" height="47"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Fy-Hz-cpU" userLabel="Title">
-                                                    <rect key="frame" x="0.0" y="0.0" width="225.5" height="30"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="245.5" height="30"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" text="Short Description" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NXu-BJ-MQW" userLabel="Short Description">
-                                                    <rect key="frame" x="0.0" y="30" width="225.5" height="17"/>
+                                                    <rect key="frame" x="0.0" y="30" width="245.5" height="17"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -224,7 +224,7 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="04u-1Q-nDY" secondAttribute="bottom" constant="10" id="00U-Kw-aYK"/>
-                                        <constraint firstAttribute="trailing" secondItem="gri-nQ-E4y" secondAttribute="trailing" constant="20" id="Jws-ee-7P2"/>
+                                        <constraint firstAttribute="trailing" secondItem="gri-nQ-E4y" secondAttribute="trailing" id="Jws-ee-7P2"/>
                                         <constraint firstItem="04u-1Q-nDY" firstAttribute="leading" secondItem="r7k-yG-zWm" secondAttribute="leading" constant="10" id="Mfb-jw-gPT"/>
                                         <constraint firstItem="gri-nQ-E4y" firstAttribute="top" secondItem="r7k-yG-zWm" secondAttribute="top" constant="10" id="Swf-wC-HFo"/>
                                         <constraint firstItem="gri-nQ-E4y" firstAttribute="centerY" secondItem="r7k-yG-zWm" secondAttribute="centerY" id="fEO-dB-UM4"/>

--- a/Expo1900/Expo1900Tests/Expo1900Tests.swift
+++ b/Expo1900/Expo1900Tests/Expo1900Tests.swift
@@ -22,18 +22,28 @@ class Expo1900Tests: XCTestCase {
         // given
         let jsonManager = JsonManager()
         // when
-        let expositionInfo = try? jsonManager.decodedExpositionInfo()
+        var expositionInfo: ExpositionInfo
         // then
-        XCTAssertNotNil(expositionInfo)
+        do {
+            try expositionInfo = jsonManager.decodedResult()
+            XCTAssertNotNil(expositionInfo)
+        } catch {
+            XCTFail()
+        }
     }
     
     func test_getDecodedItems의리턴값이_nil이아니다() throws {
         // given
         let jsonManager = JsonManager()
         // when
-        let item = try? jsonManager.decodedItems()
+        var item: [Item]
         // then
-        XCTAssertNotNil(item)
+        do {
+            try item = jsonManager.decodedResult()
+            XCTAssertNotNil(item)
+        } catch {
+            XCTFail()
+        }
     }
     
     func test_noFileError() throws {
@@ -42,7 +52,7 @@ class Expo1900Tests: XCTestCase {
         var result: ExpoError?
         // when
         do {
-            _ = try jsonManager.decodedItems()
+            let items: [Item] = try jsonManager.decodedResult()
         } catch {
             result = error as? ExpoError
         }
@@ -56,7 +66,7 @@ class Expo1900Tests: XCTestCase {
         var result: ExpoError?
         // when
         do {
-            _ = try jsonManager.decodedExpositionInfo()
+            let expositionInfo: ExpositionInfo = try jsonManager.decodedResult()
         } catch {
             result = error as? ExpoError
         }

--- a/Expo1900/Expo1900Tests/Expo1900Tests.swift
+++ b/Expo1900/Expo1900Tests/Expo1900Tests.swift
@@ -27,7 +27,6 @@ class Expo1900Tests: XCTestCase {
             // then
             XCTAssertNotNil(expositionInfo)
         } catch {
-
             XCTFail()
         }
     }
@@ -70,7 +69,6 @@ class Expo1900Tests: XCTestCase {
            let result = error as? ExpoError
            // then
            XCTAssertEqual(result, ExpoError.decodingError)
-        
         }
     }
 }

--- a/Expo1900/Expo1900Tests/Expo1900Tests.swift
+++ b/Expo1900/Expo1900Tests/Expo1900Tests.swift
@@ -21,13 +21,13 @@ class Expo1900Tests: XCTestCase {
     func test_getDecodedExpositionInfo의리턴값이_nil이아니다() throws {
         // given
         let jsonManager = JsonManager()
-        // when
-        var expositionInfo: ExpositionInfo
-        // then
         do {
-            try expositionInfo = jsonManager.decodedResult()
+            // when
+            let expositionInfo: ExpositionInfo = try jsonManager.decodedResult()
+            // then
             XCTAssertNotNil(expositionInfo)
         } catch {
+
             XCTFail()
         }
     }
@@ -35,11 +35,11 @@ class Expo1900Tests: XCTestCase {
     func test_getDecodedItems의리턴값이_nil이아니다() throws {
         // given
         let jsonManager = JsonManager()
-        // when
-        var item: [Item]
-        // then
+        
         do {
-            try item = jsonManager.decodedResult()
+            // when
+            let item: [Item] = try jsonManager.decodedResult()
+            // then
             XCTAssertNotNil(item)
         } catch {
             XCTFail()
@@ -49,30 +49,28 @@ class Expo1900Tests: XCTestCase {
     func test_noFileError() throws {
         // given
         let jsonManager = MockJsonManager()
-        var result: ExpoError?
-        // when
+    
         do {
-            let items: [Item] = try jsonManager.decodedResult()
+            // when
+            let _: [Item] = try jsonManager.decodedResult()
         } catch {
-            result = error as? ExpoError
+            let result = error as? ExpoError
+            // then
+            XCTAssertEqual(result, ExpoError.noFileError)
         }
-        // then
-        XCTAssertEqual(result, ExpoError.noFileError)
     }
     
     func test_decodingError() throws {
         // given
         let jsonManager = MockJsonManager()
-        var result: ExpoError?
-        // when
         do {
-            let expositionInfo: ExpositionInfo = try jsonManager.decodedResult()
+            // when
+            let _: ExpositionInfo = try jsonManager.decodedResult()
         } catch {
-            result = error as? ExpoError
+           let result = error as? ExpoError
+           // then
+           XCTAssertEqual(result, ExpoError.decodingError)
+        
         }
-        // then
-        XCTAssertEqual(result, ExpoError.decodingError)
     }
 }
-
-

--- a/Expo1900/Expo1900Tests/MockJsonManager.swift
+++ b/Expo1900/Expo1900Tests/MockJsonManager.swift
@@ -10,10 +10,30 @@ import UIKit
 
 struct MockJsonManager: JsonManagerable {
     func decodedResult() throws -> [Item] {
-        throw ExpoError.noFileError
+        let jsonDecoder = JSONDecoder()
+
+        guard let itemData = NSDataAsset(name: "wrongName") else {
+            throw ExpoError.noFileError
+        }
+
+        guard let items = try? jsonDecoder.decode([Item].self, from: itemData.data) else {
+            throw ExpoError.decodingError
+        }
+
+        return items
     }
     
     func decodedResult() throws -> ExpositionInfo {
-        throw ExpoError.decodingError
+        let jsonDecoder = JSONDecoder()
+
+                guard let expositionInfoData = NSDataAsset(name: DataFileName.items) else {
+                    throw ExpoError.noFileError
+                }
+
+                guard let expositionInfo = try? jsonDecoder.decode(ExpositionInfo.self, from: expositionInfoData.data) else {
+                    throw ExpoError.decodingError
+                }
+
+                return expositionInfo
     }
 }

--- a/Expo1900/Expo1900Tests/MockJsonManager.swift
+++ b/Expo1900/Expo1900Tests/MockJsonManager.swift
@@ -11,29 +11,29 @@ import UIKit
 struct MockJsonManager: JsonManagerable {
     func decodedResult() throws -> [Item] {
         let jsonDecoder = JSONDecoder()
-
+        
         guard let itemData = NSDataAsset(name: "wrongName") else {
             throw ExpoError.noFileError
         }
-
+        
         guard let items = try? jsonDecoder.decode([Item].self, from: itemData.data) else {
             throw ExpoError.decodingError
         }
-
+        
         return items
     }
     
     func decodedResult() throws -> ExpositionInfo {
         let jsonDecoder = JSONDecoder()
-
-                guard let expositionInfoData = NSDataAsset(name: DataFileName.items) else {
-                    throw ExpoError.noFileError
-                }
-
-                guard let expositionInfo = try? jsonDecoder.decode(ExpositionInfo.self, from: expositionInfoData.data) else {
-                    throw ExpoError.decodingError
-                }
-
-                return expositionInfo
+        
+        guard let expositionInfoData = NSDataAsset(name: DataFileName.items) else {
+            throw ExpoError.noFileError
+        }
+        
+        guard let expositionInfo = try? jsonDecoder.decode(ExpositionInfo.self, from: expositionInfoData.data) else {
+            throw ExpoError.decodingError
+        }
+        
+        return expositionInfo
     }
 }

--- a/Expo1900/Expo1900Tests/MockJsonManager.swift
+++ b/Expo1900/Expo1900Tests/MockJsonManager.swift
@@ -9,31 +9,11 @@ import UIKit
 @testable import Expo1900
 
 struct MockJsonManager: JsonManagerable {
-    func decodedItems() throws -> [Item] {
-        let jsonDecoder = JSONDecoder()
-         
-        guard let itemData = NSDataAsset(name: "wrongName") else {
-            throw ExpoError.noFileError
-        }
-        
-        guard let items = try? jsonDecoder.decode([Item].self, from: itemData.data) else {
-            throw ExpoError.decodingError
-        }
-        
-        return items
+    func decodedResult() throws -> [Item] {
+        throw ExpoError.noFileError
     }
     
-    func decodedExpositionInfo() throws -> ExpositionInfo {
-        let jsonDecoder = JSONDecoder()
-        
-        guard let expositionInfoData = NSDataAsset(name: DataFileName.items) else {
-            throw ExpoError.noFileError
-        }
-  
-        guard let expositionInfo = try? jsonDecoder.decode(ExpositionInfo.self, from: expositionInfoData.data) else {
-            throw ExpoError.decodingError
-        }
-        
-        return expositionInfo
+    func decodedResult() throws -> ExpositionInfo {
+        throw ExpoError.decodingError
     }
 }

--- a/Expo1900/HeritageListCell.swift
+++ b/Expo1900/HeritageListCell.swift
@@ -12,6 +12,7 @@ final class HeritageListCell: UITableViewCell {
     @IBOutlet private weak var heritageImage: UIImageView!
     @IBOutlet private weak var heritageTitleLabel: UILabel!
     @IBOutlet private weak var heritageShortDescriptionLabel: UILabel!
+    
     static let identifier = String(describing: HeritageListCell.self)
         
     func setContentOfCell(item: Item) {

--- a/Expo1900/HeritageListCell.swift
+++ b/Expo1900/HeritageListCell.swift
@@ -7,14 +7,12 @@
 
 import UIKit
 
-final class HeritageListCell: UITableViewCell {
+final class HeritageListCell: UITableViewCell, ViewControllerIdentifier {
 
     @IBOutlet private weak var heritageImage: UIImageView!
     @IBOutlet private weak var heritageTitleLabel: UILabel!
     @IBOutlet private weak var heritageShortDescriptionLabel: UILabel!
     
-    static let identifier = String(describing: HeritageListCell.self)
-        
     func setContentOfCell(item: Item) {
         heritageImage.image = UIImage(named: item.imageName)
         heritageTitleLabel.text = item.name

--- a/Expo1900/HeritageListViewController.swift
+++ b/Expo1900/HeritageListViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class HeritageListViewController: UIViewController, GenerateErrorAlertProtocol {
 
     @IBOutlet private weak var heritageListTableView: UITableView!
+    
     private var items: [Item] = []
     static let identifier = String(describing: HeritageListViewController.self)
     
@@ -63,6 +64,7 @@ extension HeritageListViewController: UITableViewDelegate {
 extension HeritageListViewController {
     private func loadItems() -> [Item]? {
         let jsonManager: JsonManagerable = JsonManager()
+        
         do {
             let heritageInfo: [Item] = try jsonManager.decodedResult()
             return heritageInfo

--- a/Expo1900/HeritageListViewController.swift
+++ b/Expo1900/HeritageListViewController.swift
@@ -7,12 +7,11 @@
 
 import UIKit
 
-final class HeritageListViewController: UIViewController, GenerateErrorAlertProtocol {
+final class HeritageListViewController: UIViewController, GenerateErrorAlertProtocol, ViewControllerIdentifier {
 
     @IBOutlet private weak var heritageListTableView: UITableView!
     
     private var items: [Item] = []
-    static let identifier = String(describing: HeritageListViewController.self)
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/HeritageListViewController.swift
+++ b/Expo1900/HeritageListViewController.swift
@@ -79,8 +79,6 @@ extension HeritageListViewController {
         items = loadItems() ?? []
         navigationController?.navigationBar.topItem?.title = "메인"
         title = "한국의 출품작"
-        heritageListTableView.dataSource = self
-        heritageListTableView.delegate = self
     }
 }
 

--- a/Expo1900/MainViewController.swift
+++ b/Expo1900/MainViewController.swift
@@ -14,9 +14,8 @@ final class MainViewController: UIViewController, GenerateErrorAlertProtocol {
     @IBOutlet private weak var locationLabel: UILabel!
     @IBOutlet private weak var durationLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
-    @IBOutlet private weak var koreanItemsButton: UIButton!
     
-    let appDelegate = UIApplication.shared.delegate as? AppDelegate
+    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/MainViewController.swift
+++ b/Expo1900/MainViewController.swift
@@ -21,11 +21,6 @@ final class MainViewController: UIViewController, GenerateErrorAlertProtocol {
     override func viewDidLoad() {
         super.viewDidLoad()
         setTextOfMainView()
-        koreanItemsButton.titleLabel?.font = .preferredFont(forTextStyle: .footnote)
-        koreanItemsButton.titleLabel?.adjustsFontForContentSizeCategory = true
-        koreanItemsButton.titleLabel?.adjustsFontSizeToFitWidth = true
-        koreanItemsButton.titleLabel?.sizeToFit()
-        koreanItemsButton.setNeedsUpdateConstraints()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Expo1900/ViewControllerIdentifier.swift
+++ b/Expo1900/ViewControllerIdentifier.swift
@@ -1,0 +1,18 @@
+//
+//  ViewControllerIdentifier.swift
+//  Expo1900
+//
+//  Created by 곽우종 on 2022/04/22.
+//
+
+import Foundation
+
+protocol ViewControllerIdentifier {
+    static var identifier: String { get }
+}
+
+extension ViewControllerIdentifier {
+    static var identifier: String {
+        return String(describing: self.self)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,5 +2,86 @@
 
 ### 만국박람회 프로젝트 저장소
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+핵심경험
+
+## Codable을 채택하여 JSON 데이터와 매칭할 모델 타입 구현
+Codable(Encodable + Decodable)채택했으나 Encodable이 필요하지 않다고 판단(Json을 디코딩만 함으로)하여 Encodable만 채택하도록 변경
+
+## JSON 파일의 구조에 맞춰 모델 타입 구현
+스네이크 케이스 또는 축약형인 JSON 키 값을 스위프트의 네이밍에 맞게 변환
+-> Decodable 채택한 구조체(클래스) 안에서 private enum  CodingKeys: String, CodingKey 구현, JSON 파일내 객체의 이름과 실제 객체의 이름이 다를경우 사용한다. (스네이크 케이스: image_name, 처럼 _ 으로 띄어쓰기 구분)
+
+## 테이블뷰의 Delegate와 Data Source의 역할의 이해
+-> Delegate : 테이블뷰를 눌렀을때 처리하는 친구(안눌러도 볼 수 있으므로 안구현하는 경우도 있다.)
+-> DataSource : 테이블뷰의 내용물을 담당하는 친구, 세션을 몇개를 쓸지, 세션당 몇개를 보여줄지를 담당하며 Cell을 커스텀 하여 원하는것만 보여줄 수 도 있다.
+하지만 이제 테이블 뷰에서 -> 컬렉션 뷰로 넘어가는 추세인듯하다.
+(https://iamcho2.github.io/2021/07/25/UICollectionView-or-UITableView-for-list)
+
+## 테이블뷰의 셀의 재사용 이해
+-> TableView.dequeueReusableCell 이 친구를 이용하여 셀을 꺼낸다. 셀은 재사용 될 수도 있기 때문에 이전에 셀에 조작을 가했다면 초기화를 해줘야 될 수도 있다.
+
+## 테이블뷰의 전반적인 동작 방식의 이해
+-> 재사용 가능한 셀이 있으면 재사용하고 없으면 생성한다. 그리고 DataSource, delegate 의 역할을 파악한다.
+
+## 주어진 JSON 데이터를 파싱하여 테이블뷰에 표시
+-> Json 디코딩한 것들을 DataSource에 담는다. 이때 indexPath의 위치정보를 가져온다.
+
+## 내비게이션 컨트롤러를 활용한 화면 전환
+-> navigationController?.pushViewController(다음 뷰, animated: true) 로 전환한다. 이때 다음 뷰를 전에서 생성해줘야 한다. storyboard?.instantiateViewController(withIdentifier: 뷰이름) 으로 뷰를 생성하였다. 이때 init으로 생성할 수도 있는대 그 부분은 좀 복잡하다. 위의 방법이 편하긴하다.
+
+## 뷰 컨트롤러 사이의 데이터 전달
+-> 다음 뷰를 생성할때 프로퍼티로 전달한다.  프로퍼티를 private으로 주고 싶다면 생성자를 사용한다.
+
+## 오토 레이아웃을 적용하여 다양한 기기에 대응
+-> 오토레이아웃 적용은 많이 해보는 수밖에 없다.
+
+## Word Wrapping / Line Wrapping / Line Break 방식의 이해
+-> 버튼, label 에서  line break option의 속성, character wrap: 개별 문자 단위로 줄바꿈, word Wrap: 단어 기준으로 줄바꿈, 
+
+## 접근성(Accessibility)의 개념과 필요성 이해
+손쉬운 사용 Voic over에서 text, value, hint 를 줄 수 있다. text: 이것이 뭔지, value: 값, hint: 어떻게 사용하는지 보통 나와있다고 한다.
+
+## Dynamic Types를 통해 텍스트 접근성 향상
+손쉬운사용 -> 글꼴 자동 크기 조절 해준다.
+
+---
+
+## 프로젝트 리뷰
+
+import foundation, uikit 이 필요없는 경우도 있다. 그럼으로 필요없는경우라면 사용하지 말것.
+
+네이밍에서 get으로 시작하는걸 쓰지 말것(단순 생성 메소드는 동사형 없이도 사용하곤 한다.) 마치 DispatchQueue.global() 처럼
+
+근거 링크: (https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CodingGuidelines/Articles/NamingMethods.html)
+
+중요한, 관리해야 되는 String 은 enum으로 관리하도록 하자.
+
+return 문을 한줄에 쓰는건 지양하자(개인차긴함)
+
+처음에 의미없이 기본적으로 생성되는 함수가 필요 없으면 지우도록 하자.
+
+self를 쓰는 기준 : 이름이 같을때로 하자!
+
+함수의 기능 분리를 잘하자!
+
+tableview의 numberOfSections의 기본값은 1 이다. 그럼으로 필요없으면 구현안해도 된다.
+
+배열을 사용할때 index를 벗어나면 앱이 터짐으로 다음과 같이 사용하는 방법도 좋다.
+```
+extension Array {
+    public subscript(safe index: Int) -> Element? {
+        return indices ~= index ? self[index] : nil
+    }
+}
+```
+
+뷰컨트롤러의 본인 스스로 이름을 반환하는 법 String(describing: self) 를 사용한다. extension으로 하면 사용하기 편할듯
+
+class에 상속 안할꺼면 final을 사용한다.
+
+tableView의 datasource, delegate는 스토리보드에서 설정할 수 있다.
+
+화면 고정
+
+appdelegate 플래그 주는거 말고 UIInterfaceOrientationMask를 사용하여 화면 고정을 관리할 수 있다.
 


### PR DESCRIPTION
@lina0322
안녕하세요 엘림!
벌써 마지막 step이네요!
이번 스텝도 잘 부탁드립니다.

# 오토레이아웃 삽질 리스트
1. 스크롤뷰
스크롤뷰안에 컨텐츠 뷰(View)를 오토레이아웃 설정에서 FrameLayout을 기준으로 상하좌우를 맞춰서 정말 오래 삽질했습니다.
2. 접근 방법
뷰 제작시 모든 요소를 추가하고 일일히 consantrait을 주려고 하니 정말... 복잡해서 다 지우고 처음부터 다시 하나씩 할당하였습니다.

# 고민한점 & 해결방법

### 1. 어떻게 첫번째 화면만 세로로 고정할 수 있을까?
- 화면 방향을 세로로 고정하기 위해 app delegate에서  flag를 만들어주고, `func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMAsk` 메서드를 통해 flag가 true일 경우 모든 방향을 지원, false일 경우 세로만 지원하도록 했습니다.
- 첫번째 화면에서만 세로로 고정하기 위해 `viewWillAppear에서` flag를 false로 설정하고, 첫번째 화면의 `viewWillDisappear에서` flag를 true로 설정하였습니다.

# 조언을 구하고 싶은 부분

### 1. 버튼의 Dynamic Type 적용

Xcode 13 이후에는 UIButton에 기본적으로 Dynamic Type이 적용되어 있고, Custom 타입의 Style이 Default인 버튼일 경우, Font를 수정해주어야하고
그 외에 System Type 버튼의 경우, Style을 Plain으로 수정하면 자동으로 Dynamic Type이 적용된다고 배웠습니다.

그런데 위 두 방법으로 dynamic type을 적용하면, button의 top constraint가 description label 의 bottom + 10, button의 bottom contraint가 contents view 의 bottom + 10으로 주었는데도 계속 이미지와 같이 버튼UI가 잘려습니다ㅠㅠ 그래서 우선은 button에는 dynamic type을 적용을 못했고, font size를 고정해두었습니다. 

view hierarchy로 확인해보니, button의 titleLabel은 늘어나는데, button 자체의 영역은 안 늘어나서 발생하는 문제같기도 한데 맞을까요? 맞다면 button 자체의 영역도 어떻게 같이 늘릴 수 있을지 궁금합니다.

![](https://i.imgur.com/tKvWC0I.png)


