### PR TITLE
만국박람회 [STEP3] 사파리, papri

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 				9B0AFABA2808675900A9177C /* ItemTableViewController.swift */,
 				9B0AFABE2808768F00A9177C /* ItemDetailViewController.swift */,
 				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
+				9B2D0734280EC8DC00704B2E /* TableViewCell.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -113,7 +114,6 @@
 			children = (
 				C79FF4BA2589F401005FB0FD /* Main.storyboard */,
 				C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */,
-				9B2D0734280EC8DC00704B2E /* TableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		675E7672280517AA0039896B /* Heritage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675E7671280517AA0039896B /* Heritage.swift */; };
 		9B0AFABB2808675900A9177C /* ItemTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0AFABA2808675900A9177C /* ItemTableViewController.swift */; };
 		9B0AFABF2808768F00A9177C /* ItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0AFABE2808768F00A9177C /* ItemDetailViewController.swift */; };
+		9B2D0735280EC8DC00704B2E /* TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B2D0734280EC8DC00704B2E /* TableViewCell.swift */; };
 		9B53AF9A2805145F00C4DB93 /* Expo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B53AF992805145F00C4DB93 /* Expo.swift */; };
 		9B77746D2807BE11006F668A /* exposition_universelle_1900.json in Resources */ = {isa = PBXBuildFile; fileRef = 9B77746C2807BE11006F668A /* exposition_universelle_1900.json */; };
 		9B77746F2807BE1E006F668A /* items.json in Resources */ = {isa = PBXBuildFile; fileRef = 9B77746E2807BE1E006F668A /* items.json */; };
@@ -48,6 +49,7 @@
 		675E767728051C8F0039896B /* ModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B0AFABA2808675900A9177C /* ItemTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemTableViewController.swift; sourceTree = "<group>"; };
 		9B0AFABE2808768F00A9177C /* ItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailViewController.swift; sourceTree = "<group>"; };
+		9B2D0734280EC8DC00704B2E /* TableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewCell.swift; sourceTree = "<group>"; };
 		9B53AF992805145F00C4DB93 /* Expo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expo.swift; sourceTree = "<group>"; };
 		9B77746C2807BE11006F668A /* exposition_universelle_1900.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = exposition_universelle_1900.json; sourceTree = "<group>"; };
 		9B77746E2807BE1E006F668A /* items.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = items.json; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 			children = (
 				C79FF4BA2589F401005FB0FD /* Main.storyboard */,
 				C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */,
+				9B2D0734280EC8DC00704B2E /* TableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				9B0AFABB2808675900A9177C /* ItemTableViewController.swift in Sources */,
 				9B0AFABF2808768F00A9177C /* ItemDetailViewController.swift in Sources */,
+				9B2D0735280EC8DC00704B2E /* TableViewCell.swift in Sources */,
 				6724BE4B2807BFA700363C89 /* DecodableExtension.swift in Sources */,
 				9B53AF9A2805145F00C4DB93 /* Expo.swift in Sources */,
 				675E7672280517AA0039896B /* Heritage.swift in Sources */,

--- a/Expo1900/Expo1900/Controller/AppDelegate.swift
+++ b/Expo1900/Expo1900/Controller/AppDelegate.swift
@@ -8,8 +8,7 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
+    var changeOrientation = true
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -28,6 +27,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        guard changeOrientation else { return [.portrait] }
+        
+        return [.all]
     }
 
 

--- a/Expo1900/Expo1900/Controller/AppDelegate.swift
+++ b/Expo1900/Expo1900/Controller/AppDelegate.swift
@@ -8,7 +8,7 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var changeOrientation = true
+    var isPortrait = true
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -30,7 +30,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        guard changeOrientation else { return [.portrait] }
+        if isPortrait {
+            return [.portrait]
+        }
         
         return [.all]
     }

--- a/Expo1900/Expo1900/Controller/ItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/ItemDetailViewController.swift
@@ -9,7 +9,6 @@ import UIKit
 
 final class ItemDetailViewController: UIViewController {
     private let item: Heritage
-    
     @IBOutlet private weak var itemImageView: UIImageView!
     @IBOutlet private weak var ItemDescriptionLabel: UILabel!
     
@@ -27,7 +26,10 @@ final class ItemDetailViewController: UIViewController {
         super.viewDidLoad()
         setUpView()
     }
-    
+}
+ 
+// MARK: - Method
+private extension ItemDetailViewController {
     private func setUpView() {
         title = item.title
         itemImageView.image = UIImage(named: item.imageName)

--- a/Expo1900/Expo1900/Controller/ItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ItemTableViewController.swift
@@ -8,19 +8,19 @@
 import UIKit
 
 final class ItemTableViewController: UITableViewController {
-    
-    private let cellIdentifier = "itemCell"
-    private let subViewVCIdentifier = "ItemDetailVC"
-
     @IBOutlet weak var itemsTableView: UITableView!
     private let itemsList: [Heritage]? = [Heritage].parsingJson(name: "items")
+    private let cellIdentifier = "itemCell"
+    private let subViewVCIdentifier = "ItemDetailVC"
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.navigationController?.isNavigationBarHidden = false
     }
+}
 
-    // MARK: - Table view data source
+// MARK: - Table view data source
+extension ItemTableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return itemsList?.count ?? 0
     }
@@ -34,7 +34,10 @@ final class ItemTableViewController: UITableViewController {
         
         return itemCell
     }
-    
+}
+
+// MARK: - Table view delegate
+extension ItemTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let item = itemsList?[indexPath.row] else { return }
         guard let subViewController = self.storyboard?.instantiateViewController(identifier: subViewVCIdentifier, creator: { coder in ItemDetailViewController(item: item, coder: coder) }) else { return }

--- a/Expo1900/Expo1900/Controller/ItemTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/ItemTableViewController.swift
@@ -26,13 +26,11 @@ final class ItemTableViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let itemCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
-        var content = itemCell.defaultContentConfiguration()
+        guard let itemCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? TableViewCell else { return UITableViewCell() }
         
-        content.text = itemsList?[indexPath.row].title
-        content.secondaryText = itemsList?[indexPath.row].shortDescription
-        content.image = UIImage(named: itemsList?[indexPath.row].imageName ?? "swift")
-        itemCell.contentConfiguration = content
+        itemCell.itemTitleLebel.text = itemsList?[indexPath.row].title
+        itemCell.itemImageView.image = UIImage(named: itemsList?[indexPath.row].imageName ?? "swift")
+        itemCell.itemShortDescriptionLabel.text = itemsList?[indexPath.row].shortDescription
         
         return itemCell
     }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -15,7 +15,7 @@ final class MainViewController: UIViewController {
     @IBOutlet private weak var decriptionLabel: UILabel!
     @IBOutlet weak var subViewShowButton: UIButton!
     
-    
+    let uiAppDelegate = UIApplication.shared.delegate
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,8 +23,20 @@ final class MainViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        guard let appDelegate = uiAppDelegate as? AppDelegate else { return }
+
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
+        appDelegate.changeOrientation = false
+        let value = UIDeviceOrientation.portrait.rawValue
+        UIDevice.current.setValue(value, forKey: "orientation")
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        guard let appDelegate = uiAppDelegate as? AppDelegate else { return }
+        
+        super.viewWillDisappear(animated)
+        appDelegate.changeOrientation = true
     }
     
     private func setUpView() {

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -29,20 +29,14 @@ final class MainViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        guard let appDelegate = uiAppDelegate as? AppDelegate else { return }
-
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
-        appDelegate.changeOrientation = false
-        let value = UIDeviceOrientation.portrait.rawValue
-        UIDevice.current.setValue(value, forKey: "orientation")
+        fixViewOrientation(true)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
-        guard let appDelegate = uiAppDelegate as? AppDelegate else { return }
-        
         super.viewWillDisappear(animated)
-        appDelegate.changeOrientation = true
+        fixViewOrientation(false)
     }
 }
 
@@ -67,6 +61,17 @@ private extension MainViewController {
         visitorsLabel.changePartFont(part: .visitor)
         locationLabel.changePartFont(part: .location)
         durationLabel.changePartFont(part: .duration)
+    }
+    
+    func fixViewOrientation(_ fixed: Bool) {
+        guard let appDelegate = uiAppDelegate as? AppDelegate else { return }
+        
+        appDelegate.isPortrait = fixed
+        
+        if fixed {
+            let value = UIDeviceOrientation.portrait.rawValue
+            UIDevice.current.setValue(value, forKey: "orientation")
+        }
     }
 }
 

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -55,6 +55,7 @@ private extension MainViewController {
         changeFont()
         decriptionLabel.text = expoInfomation.description
         subViewShowButton.setTitle("한국의 출품작 보러가기", for: .normal)
+        subViewShowButton.maximumContentSizeCategory = .accessibilityMedium
     }
     
     func changeFont() {

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -6,6 +6,12 @@
 
 import UIKit
 
+private extension String {
+    static var visitor: String { "방문객" }
+    static var location: String { "개최지" }
+    static var duration: String { "개최기간" }
+}
+
 final class MainViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var posterImageView: UIImageView!
@@ -38,14 +44,18 @@ final class MainViewController: UIViewController {
         super.viewWillDisappear(animated)
         appDelegate.changeOrientation = true
     }
+}
+
+// MARK: - Method
+private extension MainViewController {
     
-    private func setUpView() {
+    func setUpView() {
         guard let expoInfomation = Expo.parsingJson(name: "exposition_universelle_1900") else { return }
         guard let separationIndex = expoInfomation.title.firstIndex(of: "(") else { return }
-                
+        
         titleLabel.text = String(expoInfomation.title[..<separationIndex]) + "\n" + String(expoInfomation.title[separationIndex...])
         posterImageView.image = UIImage(named: "poster")
-        visitorsLabel.text = .visitor + " : \(expoInfomation.visitors.changedFormat())"
+        visitorsLabel.text = .visitor + " : \(expoInfomation.formattedVisitors)"
         locationLabel.text = .location + " : \(expoInfomation.location)"
         durationLabel.text = .duration + " : \(expoInfomation.duration)"
         changeFont()
@@ -53,24 +63,14 @@ final class MainViewController: UIViewController {
         subViewShowButton.setTitle("한국의 출품작 보러가기", for: .normal)
     }
     
-    private func changeFont() {
+    func changeFont() {
         visitorsLabel.changePartFont(part: .visitor)
         locationLabel.changePartFont(part: .location)
         durationLabel.changePartFont(part: .duration)
     }
 }
 
-private extension Int {
-    func changedFormat() -> String {
-        let numberFormatter = NumberFormatter()
-        
-        numberFormatter.numberStyle = .decimal
-    
-        return numberFormatter.string(from: self as NSNumber) ?? "FormatError"
-    }
-}
-
-
+// MARK: - UILabel AddAttribute
 private extension UILabel {
     func changePartFont(part: String) {
         guard let text = self.text else { return }
@@ -81,10 +81,4 @@ private extension UILabel {
         
         self.attributedText = mutableText
     }
-}
-
-private extension String {
-    static var visitor: String { "방문객" }
-    static var location: String { "개최지" }
-    static var duration: String { "개최기간" }
 }

--- a/Expo1900/Expo1900/Controller/TableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/TableViewCell.swift
@@ -11,7 +11,4 @@ class TableViewCell: UITableViewCell {
     @IBOutlet weak var itemImageView: UIImageView!
     @IBOutlet weak var itemTitleLebel: UILabel!
     @IBOutlet weak var itemShortDescriptionLabel: UILabel!
-    
-    
-
 }

--- a/Expo1900/Expo1900/Model/Expo.swift
+++ b/Expo1900/Expo1900/Model/Expo.swift
@@ -13,4 +13,18 @@ struct Expo: Codable {
     let location: String
     let duration: String
     let description: String
+    
+    var formattedVisitors: String {
+        visitors.changedFormat() + " 명"
+    }
+}
+
+private extension Int {
+    func changedFormat() -> String {
+        let numberFormatter = NumberFormatter()
+        
+        numberFormatter.numberStyle = .decimal
+    
+        return numberFormatter.string(from: self as NSNumber) ?? "FormatError"
+    }
 }

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="36S-AP-sYU">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -14,56 +14,56 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xQp-Rh-aF9">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VnY-1N-fcF">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="237"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="428" height="237"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4A-MM-akj">
-                                                <rect key="frame" x="177.5" y="0.0" width="59" height="30"/>
+                                                <rect key="frame" x="184.66666666666666" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cim-gb-wz1">
-                                                <rect key="frame" x="83.5" y="38" width="247.5" height="50"/>
+                                                <rect key="frame" x="90.666666666666686" y="38" width="247" height="50"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ir1-a4-UF8">
-                                                <rect key="frame" x="186.5" y="96" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="193.33333333333334" y="96" width="41.333333333333343" height="20.333333333333329"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XYP-nZ-44a">
-                                                <rect key="frame" x="186.5" y="124.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="193.33333333333334" y="124.33333333333333" width="41.333333333333343" height="20.333333333333329"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WLw-4i-saT">
-                                                <rect key="frame" x="186.5" y="153" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="193.33333333333334" y="152.66666666666666" width="41.333333333333343" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-Pb-ZF1">
-                                                <rect key="frame" x="20" y="181.5" width="374" height="20.5"/>
+                                                <rect key="frame" x="20" y="181" width="388" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wq5-Sj-YKE">
-                                                <rect key="frame" x="41.5" y="210" width="331" height="27"/>
+                                                <rect key="frame" x="42.666666666666657" y="209.33333333333334" width="342.66666666666674" height="27.666666666666657"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="rKX-A0-a4A">
-                                                        <rect key="frame" x="0.0" y="0.0" width="132" height="27"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="138" height="27.666666666666668"/>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xGC-aC-0lG">
-                                                        <rect key="frame" x="132" y="0.0" width="67" height="27"/>
+                                                        <rect key="frame" x="138" y="0.0" width="67" height="27.666666666666668"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                                         <connections>
@@ -71,7 +71,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="vf2-FS-Yoa">
-                                                        <rect key="frame" x="199" y="0.0" width="132" height="27"/>
+                                                        <rect key="frame" x="205" y="0.0" width="137.66666666666663" height="27.666666666666668"/>
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
@@ -126,37 +126,37 @@
             <objects>
                 <tableViewController id="h7u-TM-1Hf" customClass="ItemTableViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="tbu-Wi-rVe">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="95" id="e7o-rk-cG4" customClass="TableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="95"/>
+                                <rect key="frame" x="0.0" y="44.666666030883789" width="428" height="95"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e7o-rk-cG4" id="qQj-ZV-s2l">
-                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="95"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="398.33333333333331" height="95"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ybs-Tq-IT1">
-                                            <rect key="frame" x="10" y="10" width="364.5" height="75"/>
+                                            <rect key="frame" x="10" y="10" width="378.33333333333331" height="75"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uNi-Hv-nBH">
-                                                    <rect key="frame" x="0.0" y="0.0" width="91" height="75"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="94.666666666666671" height="75"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="uNi-Hv-nBH" secondAttribute="height" multiplier="1:1" id="vbX-Og-w7a"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Ud9-Rm-0hN">
-                                                    <rect key="frame" x="99" y="12.5" width="265.5" height="50.5"/>
+                                                    <rect key="frame" x="102.66666666666666" y="12.333333333333332" width="275.66666666666674" height="50.333333333333343"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
-                                                            <rect key="frame" x="0.0" y="0.0" width="265.5" height="30"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
+                                                            <rect key="frame" x="0.0" y="0.0" width="275.66666666666669" height="30"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
-                                                            <rect key="frame" x="0.0" y="30" width="265.5" height="20.5"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
+                                                            <rect key="frame" x="0.0" y="30.000000000000007" width="275.66666666666669" height="20.333333333333336"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -202,25 +202,33 @@
             <objects>
                 <viewController storyboardIdentifier="ItemDetailVC" id="CQy-M9-gUC" customClass="ItemDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="LFI-J8-OtA">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4EI-Fz-iuy">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4EI-Fz-iuy">
+                                <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="600-iK-aCc">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="214.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="600-iK-aCc">
+                                        <rect key="frame" x="0.0" y="0.0" width="428" height="242.33333333333334"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KhM-w3-X7y">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="194"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KhM-w3-X7y">
+                                                <rect key="frame" x="107" y="0.0" width="214" height="214"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="KhM-w3-X7y" secondAttribute="height" multiplier="1:1" id="FrM-cy-PWC"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="130" id="LO6-BO-gNA"/>
+                                                </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J7l-pm-6Nb">
-                                                <rect key="frame" x="0.0" y="194" width="414" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J7l-pm-6Nb">
+                                                <rect key="frame" x="20" y="222" width="388" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="J7l-pm-6Nb" secondAttribute="trailing" constant="20" id="YgH-JH-P43"/>
+                                            <constraint firstItem="J7l-pm-6Nb" firstAttribute="leading" secondItem="600-iK-aCc" secondAttribute="leading" constant="20" id="lr0-Ef-VqA"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -239,6 +247,7 @@
                         <constraints>
                             <constraint firstItem="4EI-Fz-iuy" firstAttribute="trailing" secondItem="RbD-oN-6BJ" secondAttribute="trailing" id="F6R-zG-X0X"/>
                             <constraint firstItem="4EI-Fz-iuy" firstAttribute="top" secondItem="RbD-oN-6BJ" secondAttribute="top" id="LaO-xr-pde"/>
+                            <constraint firstItem="KhM-w3-X7y" firstAttribute="height" secondItem="RbD-oN-6BJ" secondAttribute="height" multiplier="0.252358" priority="500" id="d1a-bG-KhY"/>
                             <constraint firstItem="RbD-oN-6BJ" firstAttribute="bottom" secondItem="4EI-Fz-iuy" secondAttribute="bottom" id="eME-Uz-1Xn"/>
                             <constraint firstItem="4EI-Fz-iuy" firstAttribute="leading" secondItem="RbD-oN-6BJ" secondAttribute="leading" id="u6t-3e-F5w"/>
                         </constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -19,8 +19,8 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xQp-Rh-aF9">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VnY-1N-fcF">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="189"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VnY-1N-fcF">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="237"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4A-MM-akj">
                                                 <rect key="frame" x="177.5" y="0.0" width="59" height="30"/>
@@ -29,34 +29,34 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cim-gb-wz1">
-                                                <rect key="frame" x="16" y="30" width="382" height="50"/>
+                                                <rect key="frame" x="83.5" y="38" width="247.5" height="50"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ir1-a4-UF8">
-                                                <rect key="frame" x="186.5" y="80" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="96" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XYP-nZ-44a">
-                                                <rect key="frame" x="186.5" y="100.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="124.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WLw-4i-saT">
-                                                <rect key="frame" x="186.5" y="121" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="153" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-Pb-ZF1">
-                                                <rect key="frame" x="186.5" y="141.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="20" y="181.5" width="374" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wq5-Sj-YKE">
-                                                <rect key="frame" x="41.5" y="162" width="331" height="27"/>
+                                                <rect key="frame" x="41.5" y="210" width="331" height="27"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="rKX-A0-a4A">
                                                         <rect key="frame" x="0.0" y="0.0" width="132" height="27"/>
@@ -96,8 +96,10 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="CYL-nX-K5P"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="E5l-Pb-ZF1" secondAttribute="trailing" constant="20" id="JQc-5j-er1"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="Tc0-Kq-N0V"/>
                             <constraint firstItem="wq5-Sj-YKE" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="80%" id="a3d-wx-mDK"/>
+                            <constraint firstItem="E5l-Pb-ZF1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="i1h-9E-fCc"/>
                             <constraint firstItem="wq5-Sj-YKE" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="0.03" id="lRR-mW-rOp"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="tCv-f3-nhd"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="ugu-LP-Mjv"/>
@@ -127,13 +129,45 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" id="e7o-rk-cG4">
-                                <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="95" id="e7o-rk-cG4" customClass="TableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="44.5" width="414" height="95"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="e7o-rk-cG4" id="qQj-ZV-s2l">
-                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="384.5" height="95"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ybs-Tq-IT1">
+                                            <rect key="frame" x="20" y="11" width="114.5" height="66"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uNi-Hv-nBH">
+                                                    <rect key="frame" x="0.0" y="0.0" width="73" height="66"/>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ud9-Rm-0hN">
+                                                    <rect key="frame" x="73" y="0.0" width="41.5" height="66"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
+                                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="45.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
+                                                            <rect key="frame" x="0.0" y="45.5" width="41.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="itemImageView" destination="uNi-Hv-nBH" id="Ski-lX-iQY"/>
+                                    <outlet property="itemShortDescriptionLabel" destination="SVR-hu-1bC" id="g0m-hu-EIL"/>
+                                    <outlet property="itemTitleLebel" destination="ESa-8R-bOm" id="T4q-5X-e1R"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -148,7 +182,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SHb-3x-gMW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1383" y="140"/>
+            <point key="canvasLocation" x="1382.608695652174" y="139.95535714285714"/>
         </scene>
         <!--Item Detail View Controller-->
         <scene sceneID="VHY-xp-DqN">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -85,7 +85,7 @@
                                 <constraints>
                                     <constraint firstItem="VnY-1N-fcF" firstAttribute="top" secondItem="Vy3-OE-iWP" secondAttribute="top" id="W3t-Hl-wBH"/>
                                     <constraint firstItem="VnY-1N-fcF" firstAttribute="leading" secondItem="Vy3-OE-iWP" secondAttribute="leading" id="Woj-gt-q6D"/>
-                                    <constraint firstItem="VnY-1N-fcF" firstAttribute="trailing" secondItem="Vy3-OE-iWP" secondAttribute="trailing" constant="414" id="fEa-NN-LBR"/>
+                                    <constraint firstItem="VnY-1N-fcF" firstAttribute="trailing" secondItem="Vy3-OE-iWP" secondAttribute="trailing" id="fEa-NN-LBR"/>
                                     <constraint firstItem="VnY-1N-fcF" firstAttribute="width" secondItem="xQp-Rh-aF9" secondAttribute="width" id="jGf-ha-va7"/>
                                     <constraint firstItem="Vy3-OE-iWP" firstAttribute="bottom" secondItem="VnY-1N-fcF" secondAttribute="bottom" id="rhB-PV-DZf"/>
                                 </constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VnY-1N-fcF">
-                                        <rect key="frame" x="0.0" y="0.0" width="428" height="223.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="428" height="238.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4A-MM-akj">
                                                 <rect key="frame" x="184.66666666666666" y="0.0" width="59" height="30"/>
@@ -57,13 +57,16 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wq5-Sj-YKE">
-                                                <rect key="frame" x="42.666666666666657" y="196" width="342.66666666666674" height="27.666666666666657"/>
+                                                <rect key="frame" x="42.666666666666657" y="196" width="342.66666666666674" height="42.666666666666657"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="rKX-A0-a4A">
-                                                        <rect key="frame" x="0.0" y="0.0" width="138" height="27.666666666666668"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="43" height="42.666666666666664"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="rKX-A0-a4A" secondAttribute="height" multiplier="1:1" id="qKn-9O-0WE"/>
+                                                        </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xGC-aC-0lG">
-                                                        <rect key="frame" x="138" y="0.0" width="67" height="27.666666666666668"/>
+                                                        <rect key="frame" x="43" y="0.0" width="256.66666666666669" height="42.666666666666664"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                                         <connections>
@@ -71,12 +74,14 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="vf2-FS-Yoa">
-                                                        <rect key="frame" x="205" y="0.0" width="137.66666666666663" height="27.666666666666668"/>
+                                                        <rect key="frame" x="299.66666666666663" y="0.0" width="43" height="42.666666666666664"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="vf2-FS-Yoa" secondAttribute="height" multiplier="1:1" id="AY8-iK-QHc"/>
+                                                        </constraints>
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="vf2-FS-Yoa" firstAttribute="width" secondItem="rKX-A0-a4A" secondAttribute="width" id="GoG-y1-84t"/>
-                                                    <constraint firstItem="vf2-FS-Yoa" firstAttribute="height" secondItem="rKX-A0-a4A" secondAttribute="height" id="SMS-2u-QZX"/>
+                                                    <constraint firstItem="xGC-aC-0lG" firstAttribute="height" secondItem="wq5-Sj-YKE" secondAttribute="height" id="OPU-qS-fh6"/>
                                                 </constraints>
                                             </stackView>
                                         </subviews>
@@ -87,7 +92,7 @@
                                     <constraint firstItem="VnY-1N-fcF" firstAttribute="leading" secondItem="Vy3-OE-iWP" secondAttribute="leading" id="Woj-gt-q6D"/>
                                     <constraint firstItem="VnY-1N-fcF" firstAttribute="trailing" secondItem="Vy3-OE-iWP" secondAttribute="trailing" id="fEa-NN-LBR"/>
                                     <constraint firstItem="VnY-1N-fcF" firstAttribute="width" secondItem="xQp-Rh-aF9" secondAttribute="width" id="jGf-ha-va7"/>
-                                    <constraint firstItem="Vy3-OE-iWP" firstAttribute="bottom" secondItem="VnY-1N-fcF" secondAttribute="bottom" id="rhB-PV-DZf"/>
+                                    <constraint firstItem="Vy3-OE-iWP" firstAttribute="bottom" secondItem="VnY-1N-fcF" secondAttribute="bottom" constant="16" id="rhB-PV-DZf"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="Vy3-OE-iWP"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="CfU-Yu-dHk"/>
@@ -96,14 +101,15 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="rKX-A0-a4A" firstAttribute="width" secondItem="6Tk-OE-BBY" secondAttribute="width" multiplier="0.1" id="2HT-Uv-glz"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="CYL-nX-K5P"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="E5l-Pb-ZF1" secondAttribute="trailing" constant="20" id="JQc-5j-er1"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="Tc0-Kq-N0V"/>
                             <constraint firstItem="wq5-Sj-YKE" firstAttribute="width" secondItem="8bC-Xf-vdC" secondAttribute="width" multiplier="80%" id="a3d-wx-mDK"/>
                             <constraint firstItem="E5l-Pb-ZF1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="i1h-9E-fCc"/>
-                            <constraint firstItem="wq5-Sj-YKE" firstAttribute="height" secondItem="8bC-Xf-vdC" secondAttribute="height" multiplier="0.03" id="lRR-mW-rOp"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="tCv-f3-nhd"/>
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="ugu-LP-Mjv"/>
+                            <constraint firstItem="vf2-FS-Yoa" firstAttribute="width" secondItem="6Tk-OE-BBY" secondAttribute="width" multiplier="0.1" id="zMc-5f-RBK"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="메인" id="B63-Ff-Kc2"/>
@@ -209,17 +215,17 @@
                                 <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="600-iK-aCc">
-                                        <rect key="frame" x="0.0" y="0.0" width="428" height="239"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="428" height="345"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KhM-w3-X7y">
-                                                <rect key="frame" x="107" y="0.0" width="214" height="214"/>
+                                                <rect key="frame" x="54" y="0.0" width="320" height="320"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="KhM-w3-X7y" secondAttribute="height" multiplier="1:1" id="FrM-cy-PWC"/>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="130" id="LO6-BO-gNA"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J7l-pm-6Nb">
-                                                <rect key="frame" x="20" y="222" width="388" height="17"/>
+                                                <rect key="frame" x="20" y="328" width="388" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Main View Controller-->
+        <!--메인-->
         <scene sceneID="tne-QT-ifu">
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
@@ -21,9 +21,9 @@
                                 <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VnY-1N-fcF">
-                                        <rect key="frame" x="0.0" y="0.0" width="428" height="237"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="428" height="223.66666666666666"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4A-MM-akj">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="e4A-MM-akj">
                                                 <rect key="frame" x="184.66666666666666" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
@@ -32,32 +32,32 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Cim-gb-wz1">
                                                 <rect key="frame" x="90.666666666666686" y="38" width="247" height="50"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ir1-a4-UF8">
-                                                <rect key="frame" x="193.33333333333334" y="96" width="41.333333333333343" height="20.333333333333329"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ir1-a4-UF8">
+                                                <rect key="frame" x="196.33333333333334" y="96" width="35.333333333333343" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XYP-nZ-44a">
-                                                <rect key="frame" x="193.33333333333334" y="124.33333333333333" width="41.333333333333343" height="20.333333333333329"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XYP-nZ-44a">
+                                                <rect key="frame" x="196.33333333333334" y="121" width="35.333333333333343" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WLw-4i-saT">
-                                                <rect key="frame" x="193.33333333333334" y="152.66666666666666" width="41.333333333333343" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WLw-4i-saT">
+                                                <rect key="frame" x="196.33333333333334" y="146" width="35.333333333333343" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-Pb-ZF1">
-                                                <rect key="frame" x="20" y="181" width="388" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E5l-Pb-ZF1">
+                                                <rect key="frame" x="20" y="171" width="388" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wq5-Sj-YKE">
-                                                <rect key="frame" x="42.666666666666657" y="209.33333333333334" width="342.66666666666674" height="27.666666666666657"/>
+                                                <rect key="frame" x="42.666666666666657" y="196" width="342.66666666666674" height="27.666666666666657"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="rKX-A0-a4A">
                                                         <rect key="frame" x="0.0" y="0.0" width="138" height="27.666666666666668"/>
@@ -106,7 +106,7 @@
                             <constraint firstItem="xQp-Rh-aF9" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="ugu-LP-Mjv"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="B63-Ff-Kc2"/>
+                    <navigationItem key="navigationItem" title="메인" id="B63-Ff-Kc2"/>
                     <connections>
                         <outlet property="decriptionLabel" destination="E5l-Pb-ZF1" id="cVc-Mw-hrq"/>
                         <outlet property="durationLabel" destination="WLw-4i-saT" id="AcC-4L-eTZ"/>
@@ -149,13 +149,13 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Ud9-Rm-0hN">
                                                     <rect key="frame" x="102.66666666666666" y="12.333333333333332" width="275.66666666666674" height="50.333333333333343"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
                                                             <rect key="frame" x="0.0" y="0.0" width="275.66666666666669" height="30"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
                                                             <rect key="frame" x="0.0" y="30.000000000000007" width="275.66666666666669" height="20.333333333333336"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                             <nil key="textColor"/>
@@ -209,7 +209,7 @@
                                 <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="600-iK-aCc">
-                                        <rect key="frame" x="0.0" y="0.0" width="428" height="242.33333333333334"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="428" height="239"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KhM-w3-X7y">
                                                 <rect key="frame" x="107" y="0.0" width="214" height="214"/>
@@ -218,9 +218,9 @@
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="130" id="LO6-BO-gNA"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J7l-pm-6Nb">
-                                                <rect key="frame" x="20" y="222" width="388" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J7l-pm-6Nb">
+                                                <rect key="frame" x="20" y="222" width="388" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -136,32 +137,44 @@
                                     <rect key="frame" x="0.0" y="0.0" width="384.5" height="95"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ybs-Tq-IT1">
-                                            <rect key="frame" x="20" y="11" width="114.5" height="66"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ybs-Tq-IT1">
+                                            <rect key="frame" x="10" y="10" width="364.5" height="75"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uNi-Hv-nBH">
-                                                    <rect key="frame" x="0.0" y="0.0" width="73" height="66"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="uNi-Hv-nBH">
+                                                    <rect key="frame" x="0.0" y="0.0" width="91" height="75"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="uNi-Hv-nBH" secondAttribute="height" multiplier="1:1" id="vbX-Og-w7a"/>
+                                                    </constraints>
                                                 </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ud9-Rm-0hN">
-                                                    <rect key="frame" x="73" y="0.0" width="41.5" height="66"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Ud9-Rm-0hN">
+                                                    <rect key="frame" x="99" y="12.5" width="265.5" height="50.5"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
-                                                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="45.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ESa-8R-bOm">
+                                                            <rect key="frame" x="0.0" y="0.0" width="265.5" height="30"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
-                                                            <rect key="frame" x="0.0" y="45.5" width="41.5" height="20.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SVR-hu-1bC">
+                                                            <rect key="frame" x="0.0" y="30" width="265.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="uNi-Hv-nBH" firstAttribute="width" secondItem="ybs-Tq-IT1" secondAttribute="width" multiplier="1/4" id="yix-iC-mUL"/>
+                                            </constraints>
                                         </stackView>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="ybs-Tq-IT1" firstAttribute="top" secondItem="qQj-ZV-s2l" secondAttribute="top" constant="10" id="A5r-vU-IVM"/>
+                                        <constraint firstAttribute="trailing" secondItem="ybs-Tq-IT1" secondAttribute="trailing" constant="10" id="LPY-gC-f83"/>
+                                        <constraint firstAttribute="bottom" secondItem="ybs-Tq-IT1" secondAttribute="bottom" constant="10" id="ajc-Z3-IaA"/>
+                                        <constraint firstItem="ybs-Tq-IT1" firstAttribute="leading" secondItem="qQj-ZV-s2l" secondAttribute="leading" constant="10" id="pCf-RA-rkB"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="itemImageView" destination="uNi-Hv-nBH" id="Ski-lX-iQY"/>

--- a/Expo1900/Expo1900/View/TableViewCell.swift
+++ b/Expo1900/Expo1900/View/TableViewCell.swift
@@ -1,0 +1,17 @@
+//
+//  TableViewCell.swift
+//  Expo1900
+//
+//  Created by 이시원 on 2022/04/19.
+//
+
+import UIKit
+
+class TableViewCell: UITableViewCell {
+    @IBOutlet weak var itemImageView: UIImageView!
+    @IBOutlet weak var itemTitleLebel: UILabel!
+    @IBOutlet weak var itemShortDescriptionLabel: UILabel!
+    
+    
+
+}

--- a/Expo1900/Expo1900ModelTests/Expo1900ModelTests.swift
+++ b/Expo1900/Expo1900ModelTests/Expo1900ModelTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 class Expo1900ModelTests: XCTestCase {
 
-    func test_Heritage_Type_parsingJson_작동하면_FirstItemTitle_Equal_직지심체요절() {
+    func test_Heritage_Type_json데이터를파싱했을때_모델의데이터와json데이터의내용은동일해야한다() {
         //given
         let firstHeritageItemName = "직지심체요절"
         
@@ -22,7 +22,7 @@ class Expo1900ModelTests: XCTestCase {
         XCTAssertEqual(itemName, firstHeritageItemName)
     }
     
-    func test_Expo_Type_parsingJson_작동하면_ExpoTitle_Equal_파리만국박람회1900() {
+    func test_Expo_Type_json데이터를파싱했을때_모델의데이터와json데이터의내용은동일해야한다() {
         //given
         let expoTitle = "파리 만국박람회 1900(L'Exposition de Paris 1900)"
         


### PR DESCRIPTION
# 만국박람회 STEP3 사파리, 파프리 

안녕하세요 혀나노나 😊@hyunable
STEP3 구현 완료하여 PR 보냅니다
그동안 리뷰 감사드렸습니다! 마지막까지 잘부탁드립니다🥰!


### 고민한 점과 질문 (혀나노나의 의견 부탁드려요😇)

#### 1. 버튼 안 content(text)의 높이에 따라 버튼을 포함하고 있는 stackView의 높이를 늘리고 싶었는데 실패하였습니다

![](https://i.imgur.com/rLhBdmn.png)

위와 같이 컨텐트 사이즈는 늘어났는데, 버튼의 크기와 stackView의 크기는 늘어나지 않았습니다...😓

그래서 Accessibility로 사용자가 일정 크기 이상 사이즈를 키우면 버튼의 Text와 위에 있는 Label Text와 겹치는 일이 발생했습니다. 때문에 일단 버튼의 

```swift
subViewShowButton.maximumContentSizeCategory = .accessibilityMedium
```

위와 같이 제한을 주었습니다. 위 문제를 해결할 수 있는 다른 키워드가 있다면, 공부하고 싶습니다.

---

#### 2. 첫번째 화면만 portrait상태, 즉 세로 고정 상태로 유지하도록 하고, 나머지 화면은 기기의 화면전환상태에 맞춰 화면전환이 이루어지도록 구현하고자 했습니다. 

```swift
class AppDelegate: UIResponder, UIApplicationDelegate {
    var isPortrait = true

    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
        if isPortrait {
            return [.portrait]
        }
        
        return [.all]
    }
}
```
`AppDelegate`에서 다음과 같이 `isPortrait 변수`와 `application()` 함수를 정의하고

```swift
func fixViewOrientation(_ fixed: Bool) {
        guard let appDelegate = uiAppDelegate as? AppDelegate else { return }
        
        appDelegate.isPortrait = fixed
        
        if fixed {
            let value = UIDeviceOrientation.portrait.rawValue
            UIDevice.current.setValue(value, forKey: "orientation")
        }
}
    
```
`MainViewController(첫번째 화면VC)`에 위와같은 함수를 정의해
`viewWillAppear()`에서 `fixViewOrientation(true)`를 수행하고
`viewWillDisappear()`에서 `fixViewOrientation(false)`가 수행되도록 하였습니다.

`viewWillDisappear`에서 화면세로 고정을 풀어줬음에도, 
첫번째 화면에서 기기를 가로로 돌린 상태로 두번째 화면으로 이동하면,
왜 두번째 화면이 자동으로 화면전환이 안되고 portrait상태로 유지되어있는지가 궁금합니다.

 ![](https://i.imgur.com/x0fC4N0.gif)
 
### ❓ 질문

Dynamic Type으로 설정에서 글씨 크기를 키우면 어플의 Label의 크기가 커질 수 있도록 하였는데, 어느정도 크기를 넘어서면 디자인적으로 오히려 너무 보기 불편해졌습니다..🥲 혹시 현업에서는 Dynamic Type으로 설정해 Accessibility를 높이는 것을 어느정도로 고려하는지 궁금해 질문을 남깁니다!




