### PR TITLE
 만국박람회 [STEP3] derrickkim0109, BaekGom

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -13,11 +13,11 @@
 		8A8D49A6285B1FF300B9E7D6 /* EntryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8D49A5285B1FF300B9E7D6 /* EntryDetailView.swift */; };
 		8A8D49A9285C610B00B9E7D6 /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8D49A8285C610B00B9E7D6 /* Int+Extensions.swift */; };
 		8A8D49AB285C615400B9E7D6 /* UILabel+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8D49AA285C615400B9E7D6 /* UILabel+Extensions.swift */; };
-		8AA59366285AFA1100494FE9 /* ExpositionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA59365285AFA1100494FE9 /* ExpositionTableViewCell.swift */; };
+		8AA59366285AFA1100494FE9 /* EntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA59365285AFA1100494FE9 /* EntryTableViewCell.swift */; };
 		905C43E82857046E00BB84E3 /* EntryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905C43E72857046E00BB84E3 /* EntryEntity.swift */; };
 		905C43F328576CC800BB84E3 /* ExpositionPostEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905C43F228576CC800BB84E3 /* ExpositionPostEntity.swift */; };
 		909123082858212900854F1B /* ExpositionPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909123072858212900854F1B /* ExpositionPost.swift */; };
-		90E080BB2859C23200950E42 /* ExpositionTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E080BA2859C23200950E42 /* ExpositionTableViewController.swift */; };
+		90E080BB2859C23200950E42 /* EntryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E080BA2859C23200950E42 /* EntryTableViewController.swift */; };
 		90E08105285ACB5900950E42 /* ExpositionPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E08104285ACB5900950E42 /* ExpositionPostView.swift */; };
 		90E0810D285B5CAF00950E42 /* JsonError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E0810C285B5CAF00950E42 /* JsonError.swift */; };
 		90EB84E3285D9EF600AAB6F5 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EB84E2285D9EF600AAB6F5 /* UIViewController+Extensions.swift */; };
@@ -47,11 +47,11 @@
 		8A8D49A5285B1FF300B9E7D6 /* EntryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailView.swift; sourceTree = "<group>"; };
 		8A8D49A8285C610B00B9E7D6 /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 		8A8D49AA285C615400B9E7D6 /* UILabel+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extensions.swift"; sourceTree = "<group>"; };
-		8AA59365285AFA1100494FE9 /* ExpositionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionTableViewCell.swift; sourceTree = "<group>"; };
+		8AA59365285AFA1100494FE9 /* EntryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTableViewCell.swift; sourceTree = "<group>"; };
 		905C43E72857046E00BB84E3 /* EntryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryEntity.swift; sourceTree = "<group>"; };
 		905C43F228576CC800BB84E3 /* ExpositionPostEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpositionPostEntity.swift; sourceTree = "<group>"; };
 		909123072858212900854F1B /* ExpositionPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionPost.swift; sourceTree = "<group>"; };
-		90E080BA2859C23200950E42 /* ExpositionTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionTableViewController.swift; sourceTree = "<group>"; };
+		90E080BA2859C23200950E42 /* EntryTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTableViewController.swift; sourceTree = "<group>"; };
 		90E08104285ACB5900950E42 /* ExpositionPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionPostView.swift; sourceTree = "<group>"; };
 		90E0810C285B5CAF00950E42 /* JsonError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonError.swift; sourceTree = "<group>"; };
 		90EB84E2285D9EF600AAB6F5 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
@@ -105,7 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				90E08104285ACB5900950E42 /* ExpositionPostView.swift */,
-				8AA59365285AFA1100494FE9 /* ExpositionTableViewCell.swift */,
+				8AA59365285AFA1100494FE9 /* EntryTableViewCell.swift */,
 				8A8D49A5285B1FF300B9E7D6 /* EntryDetailView.swift */,
 			);
 			path = View;
@@ -128,7 +128,7 @@
 			isa = PBXGroup;
 			children = (
 				C79FF4B82589F401005FB0FD /* ExpositionPostViewController.swift */,
-				90E080BA2859C23200950E42 /* ExpositionTableViewController.swift */,
+				90E080BA2859C23200950E42 /* EntryTableViewController.swift */,
 				8A8D49A3285B1FAF00B9E7D6 /* EntryDetailViewController.swift */,
 			);
 			path = Controller;
@@ -306,8 +306,8 @@
 				8A8D49A6285B1FF300B9E7D6 /* EntryDetailView.swift in Sources */,
 				90EB84E3285D9EF600AAB6F5 /* UIViewController+Extensions.swift in Sources */,
 				8A8D49A9285C610B00B9E7D6 /* Int+Extensions.swift in Sources */,
-				90E080BB2859C23200950E42 /* ExpositionTableViewController.swift in Sources */,
-				8AA59366285AFA1100494FE9 /* ExpositionTableViewCell.swift in Sources */,
+				90E080BB2859C23200950E42 /* EntryTableViewController.swift in Sources */,
+				8AA59366285AFA1100494FE9 /* EntryTableViewCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		8AA59366285AFA1100494FE9 /* EntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA59365285AFA1100494FE9 /* EntryTableViewCell.swift */; };
 		905C43E82857046E00BB84E3 /* EntryEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905C43E72857046E00BB84E3 /* EntryEntity.swift */; };
 		905C43F328576CC800BB84E3 /* ExpositionPostEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905C43F228576CC800BB84E3 /* ExpositionPostEntity.swift */; };
+		9089FCED2860AAE500700A70 /* ReuseIdentifying.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9089FCEC2860AAE500700A70 /* ReuseIdentifying.swift */; };
 		909123082858212900854F1B /* ExpositionPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909123072858212900854F1B /* ExpositionPost.swift */; };
 		90E080BB2859C23200950E42 /* EntryTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E080BA2859C23200950E42 /* EntryTableViewController.swift */; };
 		90E08105285ACB5900950E42 /* ExpositionPostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90E08104285ACB5900950E42 /* ExpositionPostView.swift */; };
@@ -50,6 +51,7 @@
 		8AA59365285AFA1100494FE9 /* EntryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTableViewCell.swift; sourceTree = "<group>"; };
 		905C43E72857046E00BB84E3 /* EntryEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryEntity.swift; sourceTree = "<group>"; };
 		905C43F228576CC800BB84E3 /* ExpositionPostEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExpositionPostEntity.swift; sourceTree = "<group>"; };
+		9089FCEC2860AAE500700A70 /* ReuseIdentifying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReuseIdentifying.swift; sourceTree = "<group>"; };
 		909123072858212900854F1B /* ExpositionPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionPost.swift; sourceTree = "<group>"; };
 		90E080BA2859C23200950E42 /* EntryTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTableViewController.swift; sourceTree = "<group>"; };
 		90E08104285ACB5900950E42 /* ExpositionPostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionPostView.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 				8A894FA728582C6000A4F6FD /* JsonParser.swift */,
 				90E0810C285B5CAF00950E42 /* JsonError.swift */,
 				90EB84E4285DA43B00AAB6F5 /* JSONFile.swift */,
+				9089FCEC2860AAE500700A70 /* ReuseIdentifying.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -292,6 +295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				905C43E82857046E00BB84E3 /* EntryEntity.swift in Sources */,
+				9089FCED2860AAE500700A70 /* ReuseIdentifying.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionPostViewController.swift in Sources */,
 				905C43F328576CC800BB84E3 /* ExpositionPostEntity.swift in Sources */,
 				90EB84E5285DA43B00AAB6F5 /* JSONFile.swift in Sources */,

--- a/Expo1900/Expo1900/Application/AppDelegate.swift
+++ b/Expo1900/Expo1900/Application/AppDelegate.swift
@@ -24,10 +24,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        if isActivatedOnlyPortrait {
-            return [.portrait]
-        } else {
-            return [.all]
-        }
+        return isActivatedOnlyPortrait ? .portrait : .all
     }
 }

--- a/Expo1900/Expo1900/Application/AppDelegate.swift
+++ b/Expo1900/Expo1900/Application/AppDelegate.swift
@@ -8,6 +8,8 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    var isActivatedOnlyPortrait = true
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         return true
     }
@@ -18,6 +20,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-
+        
+    }
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if isActivatedOnlyPortrait {
+            return [.portrait]
+        } else {
+            return [.all]
+        }
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -9,7 +9,17 @@ import UIKit
 
 final class EntryDetailViewController: UIViewController {
     private var expositionDetailView: EntryDetailView?
-    var entryEntity: EntryEntity?
+    private let entryEntityData: EntryEntity
+    
+    init(data: EntryEntity) {
+        self.entryEntityData = data
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,9 +31,7 @@ final class EntryDetailViewController: UIViewController {
 
 extension EntryDetailViewController {
     private func configureUI() {
-        if let entryEntity = entryEntity {
-            expositionDetailView = EntryDetailView(self.view, data: entryEntity)
-            self.title = entryEntity.name
-        }
+        expositionDetailView = EntryDetailView(self.view, data: entryEntityData)
+        self.title = entryEntityData.name
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -23,8 +23,12 @@ final class EntryDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.activateOnlyPortraitOrientation(false)
         configureUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.activateOnlyPortraitOrientation(false)
     }
 }
 

--- a/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryDetailViewController.swift
@@ -23,6 +23,7 @@ final class EntryDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.activateOnlyPortraitOrientation(false)
         configureUI()
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -34,7 +34,7 @@ extension EntryTableViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = self.expositionTableView.dequeueReusableCell(withIdentifier: "EntryTableViewCell", for: indexPath) as? EntryTableViewCell else {
+        guard let cell = self.expositionTableView.dequeueReusableCell(withIdentifier: EntryTableViewCell.reuseIdentifier, for: indexPath) as? EntryTableViewCell else {
             return UITableViewCell()
         }
         cell.accessoryType = .disclosureIndicator
@@ -78,7 +78,7 @@ extension EntryTableViewController {
             expositionTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         
-        expositionTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: "EntryTableViewCell")
+        expositionTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: EntryTableViewCell.reuseIdentifier)
         
         fetchData() 
     }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -18,7 +18,7 @@ final class EntryTableViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        self.activateOnlyPortraitOrientation(false)
         configureUI()
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -18,8 +18,12 @@ final class EntryTableViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.activateOnlyPortraitOrientation(false)
         configureUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.activateOnlyPortraitOrientation(false)
     }
 }
 

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -70,16 +70,17 @@ extension EntryTableViewController {
         
         self.navigationController?.navigationBar.isHidden = false
         self.title = "한국의 출품작"
+        view.backgroundColor = .white
         self.view.addSubview(entryTableView)
         
         entryTableView.estimatedRowHeight = 100
         entryTableView.rowHeight = UITableView.automaticDimension
         
         NSLayoutConstraint.activate([
-            entryTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            entryTableView.topAnchor.constraint(equalTo: view.topAnchor),
-            entryTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            entryTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            entryTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            entryTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            entryTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            entryTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
         ])
         
         entryTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: EntryTableViewCell.reuseIdentifier)

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class EntryTableViewController: UIViewController {
-    private let expositionTableView: UITableView = {
+    private let entryTableView: UITableView = {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
         return tableView
@@ -38,7 +38,7 @@ extension EntryTableViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = self.expositionTableView.dequeueReusableCell(withIdentifier: EntryTableViewCell.reuseIdentifier, for: indexPath) as? EntryTableViewCell else {
+        guard let cell = self.entryTableView.dequeueReusableCell(withIdentifier: EntryTableViewCell.reuseIdentifier, for: indexPath) as? EntryTableViewCell else {
             return UITableViewCell()
         }
         cell.accessoryType = .disclosureIndicator
@@ -65,24 +65,24 @@ extension EntryTableViewController: UITableViewDelegate, UITableViewDataSource {
 
 extension EntryTableViewController {
     private func configureUI() {
-        expositionTableView.delegate = self
-        expositionTableView.dataSource = self
+        entryTableView.delegate = self
+        entryTableView.dataSource = self
         
         self.navigationController?.navigationBar.isHidden = false
         self.title = "한국의 출품작"
-        self.view.addSubview(expositionTableView)
+        self.view.addSubview(entryTableView)
         
-        expositionTableView.estimatedRowHeight = 100
-        expositionTableView.rowHeight = UITableView.automaticDimension
+        entryTableView.estimatedRowHeight = 100
+        entryTableView.rowHeight = UITableView.automaticDimension
         
         NSLayoutConstraint.activate([
-            expositionTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            expositionTableView.topAnchor.constraint(equalTo: view.topAnchor),
-            expositionTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            expositionTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            entryTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            entryTableView.topAnchor.constraint(equalTo: view.topAnchor),
+            entryTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            entryTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         
-        expositionTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: EntryTableViewCell.reuseIdentifier)
+        entryTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: EntryTableViewCell.reuseIdentifier)
         
         fetchData() 
     }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -90,7 +90,21 @@ extension EntryTableViewController {
         case .success(let data):
             entryEntity = data
         case .failure(let error):
-            self.showConfirmAlert(message: error.message)
+            self.showErrorAlert(message: error.message)
         }
+    }
+    
+    func showErrorAlert(message: String) {
+        let alertController = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: "뒤로가기", style: .default) { _ in
+            self.navigationController?.popViewController(animated: true)
+        }
+        
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        
+        alertController.addAction(alertAction)
+        alertController.addAction(cancelAction)
+
+        self.present(alertController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -104,21 +104,7 @@ extension EntryTableViewController {
         case .success(let data):
             entryEntity = data
         case .failure(let error):
-            self.showErrorAlert(message: error.message)
+            self.showConfirmAlert(title: "뒤로가기", message: error.message, alertStyle: .revert)
         }
-    }
-    
-    func showErrorAlert(message: String) {
-        let alertController = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: "뒤로가기", style: .default) { _ in
-            self.navigationController?.popViewController(animated: true)
-        }
-        
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-        
-        alertController.addAction(alertAction)
-        alertController.addAction(cancelAction)
-
-        self.present(alertController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -48,9 +48,11 @@ extension EntryTableViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: false)
-        
-        let entryDetailViewController = EntryDetailViewController()
-        entryDetailViewController.entryEntity = entryEntity?[indexPath.row]
+
+        guard let data = entryEntity?[indexPath.row] else {
+            return
+        }
+        let entryDetailViewController = EntryDetailViewController(data: data)
         self.navigationController?.pushViewController(entryDetailViewController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ExpositionTableViewController.swift
+//  EntryTableViewController.swift
 //  Expo1900
 //
 //  Created by Derrick kim on 2022/06/15.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class ExpositionTableViewController: UIViewController {
+final class EntryTableViewController: UIViewController {
     private let expositionTableView: UITableView = {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
@@ -25,7 +25,7 @@ final class ExpositionTableViewController: UIViewController {
 
 // - MARK: TableView Settings
 
-extension ExpositionTableViewController: UITableViewDelegate, UITableViewDataSource {
+extension EntryTableViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if let entryEntity = entryEntity {
             return entryEntity.count
@@ -34,7 +34,7 @@ extension ExpositionTableViewController: UITableViewDelegate, UITableViewDataSou
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = self.expositionTableView.dequeueReusableCell(withIdentifier: "ExpositionTableViewCell", for: indexPath) as? ExpositionTableViewCell else {
+        guard let cell = self.expositionTableView.dequeueReusableCell(withIdentifier: "EntryTableViewCell", for: indexPath) as? EntryTableViewCell else {
             return UITableViewCell()
         }
         cell.accessoryType = .disclosureIndicator
@@ -57,7 +57,7 @@ extension ExpositionTableViewController: UITableViewDelegate, UITableViewDataSou
 
 // - MARK: View Settings
 
-extension ExpositionTableViewController {
+extension EntryTableViewController {
     private func configureUI() {
         expositionTableView.delegate = self
         expositionTableView.dataSource = self
@@ -76,7 +76,7 @@ extension ExpositionTableViewController {
             expositionTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
         
-        expositionTableView.register(ExpositionTableViewCell.self, forCellReuseIdentifier: "ExpositionTableViewCell")
+        expositionTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: "EntryTableViewCell")
         
         fetchData() 
     }

--- a/Expo1900/Expo1900/Controller/EntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewController.swift
@@ -73,19 +73,26 @@ extension EntryTableViewController {
         view.backgroundColor = .white
         self.view.addSubview(entryTableView)
         
-        entryTableView.estimatedRowHeight = 100
-        entryTableView.rowHeight = UITableView.automaticDimension
+        entryTableView.insetsLayoutMarginsFromSafeArea = false
+        entryTableView.contentInsetAdjustmentBehavior = .never
+                
+        entryTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: EntryTableViewCell.reuseIdentifier)
+        setConstraint()
+        
+        fetchData()
+    }
+    
+    func setConstraint() {
+        guard let safeArea = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first?.safeAreaInsets else {
+            return
+        }
         
         NSLayoutConstraint.activate([
-            entryTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            entryTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             entryTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            entryTableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            entryTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            entryTableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -max(20.0, safeArea.bottom)),
+            entryTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
-        
-        entryTableView.register(EntryTableViewCell.self, forCellReuseIdentifier: EntryTableViewCell.reuseIdentifier)
-        
-        fetchData() 
     }
     
     private func fetchData() {

--- a/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
@@ -11,12 +11,16 @@ final class ExpositionPostViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.activateOnlyPortraitOrientation(true)
         configureUI()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        self.activateOnlyPortraitOrientation(true)
+        
+        let orientation = UIInterfaceOrientation.portrait.rawValue
+        UIDevice.current.setValue(orientation, forKey: "orientation")
+        
         self.title = "메인"
         self.navigationController?.navigationBar.isHidden = true
     }

--- a/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
@@ -11,6 +11,7 @@ final class ExpositionPostViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.activateOnlyPortraitOrientation(true)
         configureUI()
     }
     

--- a/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
@@ -45,18 +45,9 @@ extension ExpositionPostViewController {
         case .success(let data):
             return data
         case .failure(let error):
-            self.showErrorAlert(message: error.message)
+            self.showConfirmAlert(title: "확인", message: error.message, alertStyle: .confirm)
         }
         
         return fetchData()
-    }
-    
-    func showErrorAlert(message: String) {
-        let alertController = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: "확인", style: .default, handler: nil)
-        
-        alertController.addAction(cancelAction)
-
-        self.present(alertController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
@@ -40,9 +40,18 @@ extension ExpositionPostViewController {
         case .success(let data):
             return data
         case .failure(let error):
-            self.showConfirmAlert(message: error.message)
+            self.showErrorAlert(message: error.message)
         }
         
         return fetchData()
+    }
+    
+    func showErrorAlert(message: String) {
+        let alertController = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: "확인", style: .default, handler: nil)
+        
+        alertController.addAction(cancelAction)
+
+        self.present(alertController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionPostViewController.swift
@@ -18,9 +18,9 @@ final class ExpositionPostViewController: UIViewController {
         super.viewWillAppear(animated)
         self.activateOnlyPortraitOrientation(true)
         
-        let orientation = UIInterfaceOrientation.portrait.rawValue
-        UIDevice.current.setValue(orientation, forKey: "orientation")
-        
+        let portraitOrientation = UIInterfaceOrientation.portrait.rawValue
+        UIDevice.current.setValue(portraitOrientation, forKey: "orientation")
+
         self.title = "메인"
         self.navigationController?.navigationBar.isHidden = true
     }

--- a/Expo1900/Expo1900/Extensions/UILabel+Extensions.swift
+++ b/Expo1900/Expo1900/Extensions/UILabel+Extensions.swift
@@ -9,10 +9,12 @@ import Foundation
 import UIKit
 
 extension UILabel {
-    func setTitleStyle() {
-        let font = UIFont.preferredFont(forTextStyle: .title3)
+    func setTitle(by seperator: Character, for style: UIFont.TextStyle) {
+        let font = UIFont.preferredFont(forTextStyle: style)
         let fullText = self.text ?? ""
-        let targetString = fullText.split(separator: ":").map{ String($0) }[0]
+        
+        let targetString = fullText.split(separator: seperator).map{ String($0) }[0]
+        
         let range = (fullText as NSString).range(of: targetString)
         let attributedString = NSMutableAttributedString(string: fullText)
         attributedString.addAttribute(.font, value: font, range: range)

--- a/Expo1900/Expo1900/Extensions/UILabel+Extensions.swift
+++ b/Expo1900/Expo1900/Extensions/UILabel+Extensions.swift
@@ -5,7 +5,6 @@
 //  Created by Baek on 2022/06/17.
 //
 
-import Foundation
 import UIKit
 
 extension UILabel {
@@ -13,7 +12,9 @@ extension UILabel {
         let font = UIFont.preferredFont(forTextStyle: style)
         let fullText = self.text ?? ""
         
-        let targetString = fullText.split(separator: seperator).map{ String($0) }[0]
+        guard let targetString = fullText.split(separator: seperator).map({ String($0) }).first else {
+            return
+        }
         
         let range = (fullText as NSString).range(of: targetString)
         let attributedString = NSMutableAttributedString(string: fullText)

--- a/Expo1900/Expo1900/Extensions/UIViewController+Extensions.swift
+++ b/Expo1900/Expo1900/Extensions/UIViewController+Extensions.swift
@@ -14,4 +14,25 @@ extension UIViewController {
         }
         delegate.isActivatedOnlyPortrait = isActivated
     }
+    
+    func showConfirmAlert(title: String, message: String, alertStyle: AlertStyle) {
+        let alertController = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+        
+        if alertStyle == .revert {
+            let revertAction = UIAlertAction(title: title, style: .default) { _ in
+                self.navigationController?.popViewController(animated: true)
+            }
+            alertController.addAction(revertAction)
+        } else {
+            let confirmAction = UIAlertAction(title: title, style: .default, handler: nil)
+            alertController.addAction(confirmAction)
+        }
+        
+        self.present(alertController, animated: true)
+    }
+}
+
+enum AlertStyle {
+    case confirm
+    case revert
 }

--- a/Expo1900/Expo1900/Extensions/UIViewController+Extensions.swift
+++ b/Expo1900/Expo1900/Extensions/UIViewController+Extensions.swift
@@ -8,10 +8,5 @@
 import UIKit
 
 extension UIViewController {
-    func showConfirmAlert(message: String) {
-        let alertController = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: "", style: .default, handler: nil)
-        alertController.addAction(alertAction)
-        self.present(alertController, animated: true)
-    }
+    
 }

--- a/Expo1900/Expo1900/Extensions/UIViewController+Extensions.swift
+++ b/Expo1900/Expo1900/Extensions/UIViewController+Extensions.swift
@@ -8,5 +8,10 @@
 import UIKit
 
 extension UIViewController {
-    
+    func activateOnlyPortraitOrientation(_ isActivated: Bool) {
+        guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
+            return
+        }
+        delegate.isActivatedOnlyPortrait = isActivated
+    }
 }

--- a/Expo1900/Expo1900/Model/ReuseIdentifying.swift
+++ b/Expo1900/Expo1900/Model/ReuseIdentifying.swift
@@ -1,0 +1,16 @@
+//
+//  ReuseIdentifying.swift
+//  Expo1900
+//
+//  Created by Derrick kim on 2022/06/20.
+//
+
+protocol ReuseIdentifying {
+    static var reuseIdentifier: String { get }
+}
+
+extension ReuseIdentifying {
+    static var reuseIdentifier: String {
+        return String(describing: Self.self)
+    }
+}

--- a/Expo1900/Expo1900/View/EntryDetailView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailView.swift
@@ -40,6 +40,9 @@ final class EntryDetailView: UIView {
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     

--- a/Expo1900/Expo1900/View/EntryDetailView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailView.swift
@@ -68,26 +68,23 @@ private extension EntryDetailView {
     }
     
     func setUpUIConstraints(from rootView: UIView) {
-        let contentLayoutGuide = contentScrollView.contentLayoutGuide
-        let frameLayoutGuide = contentScrollView.frameLayoutGuide
-        
-        NSLayoutConstraint.activate([
-            contentScrollView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
-            contentScrollView.topAnchor.constraint(equalTo: rootView.topAnchor),
-            contentScrollView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
-            contentScrollView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
-            
-            verticalStackView.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
-            verticalStackView.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
-            verticalStackView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
-            verticalStackView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor, constant: -10),
-            verticalStackView.widthAnchor.constraint(equalTo: frameLayoutGuide.widthAnchor),
+            NSLayoutConstraint.activate([
+                contentScrollView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
+                contentScrollView.topAnchor.constraint(equalTo: rootView.topAnchor),
+                contentScrollView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
+                contentScrollView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
 
-            descriptionLabel.topAnchor.constraint(equalTo: entryImage.bottomAnchor, constant: 10),
-            descriptionLabel.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor, constant: 10),
-            descriptionLabel.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor, constant: -10),
-        ])
-    }
+                verticalStackView.leadingAnchor.constraint(equalTo: contentScrollView.leadingAnchor),
+                verticalStackView.trailingAnchor.constraint(equalTo: contentScrollView.trailingAnchor),
+                verticalStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor),
+                verticalStackView.bottomAnchor.constraint(equalTo: contentScrollView.bottomAnchor, constant: -10),
+                verticalStackView.widthAnchor.constraint(equalTo: contentScrollView.widthAnchor),
+
+                descriptionLabel.topAnchor.constraint(equalTo: entryImage.bottomAnchor, constant: 10),
+                descriptionLabel.leadingAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+                descriptionLabel.trailingAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            ])
+        }
     
     func setDefaultValue(with data: EntryEntity) {
         self.entryImage.image = data.image

--- a/Expo1900/Expo1900/View/EntryDetailView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailView.swift
@@ -84,8 +84,8 @@ private extension EntryDetailView {
             verticalStackView.widthAnchor.constraint(equalTo: frameLayoutGuide.widthAnchor),
 
             descriptionLabel.topAnchor.constraint(equalTo: entryImage.bottomAnchor, constant: 10),
-            descriptionLabel.leadingAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.leadingAnchor, constant: 10),
-            descriptionLabel.trailingAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            descriptionLabel.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor, constant: 10),
+            descriptionLabel.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor, constant: -10),
         ])
     }
     

--- a/Expo1900/Expo1900/View/EntryDetailView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailView.swift
@@ -30,14 +30,14 @@ final class EntryDetailView: UIView {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.widthAnchor.constraint(lessThanOrEqualToConstant: 100).isActive = true
-        imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 100).isActive = true
+        imageView.widthAnchor.constraint(lessThanOrEqualToConstant: 200).isActive = true
+        imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 200).isActive = true
         return imageView
     }()
     
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .caption2)
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
@@ -80,12 +80,12 @@ private extension EntryDetailView {
             verticalStackView.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
             verticalStackView.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
             verticalStackView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
-            verticalStackView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor),
+            verticalStackView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor, constant: -10),
             verticalStackView.widthAnchor.constraint(equalTo: frameLayoutGuide.widthAnchor),
 
             descriptionLabel.topAnchor.constraint(equalTo: entryImage.bottomAnchor, constant: 10),
-            descriptionLabel.leadingAnchor.constraint(equalTo: verticalStackView.leadingAnchor, constant: 10),
-            descriptionLabel.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -10),
+            descriptionLabel.leadingAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+            descriptionLabel.trailingAnchor.constraint(equalTo: rootView.safeAreaLayoutGuide.trailingAnchor, constant: -10),
         ])
     }
     

--- a/Expo1900/Expo1900/View/EntryDetailView.swift
+++ b/Expo1900/Expo1900/View/EntryDetailView.swift
@@ -40,6 +40,7 @@ final class EntryDetailView: UIView {
         label.font = UIFont.preferredFont(forTextStyle: .title3)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -62,7 +62,7 @@ final class EntryTableViewCell: UITableViewCell {
 
 // - MARK: View Settings
 
-extension EntryTableViewCell {
+extension EntryTableViewCell: ReuseIdentifying {
     private func addSubView() {
         contentView.addSubview(entryImage)
         contentView.addSubview(verticalStackView)

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -12,8 +12,8 @@ final class EntryTableViewCell: UITableViewCell {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.widthAnchor.constraint(lessThanOrEqualToConstant: 80).isActive = true
-        imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 40).isActive = true
+        imageView.widthAnchor.constraint(lessThanOrEqualToConstant: 90).isActive = true
+        imageView.heightAnchor.constraint(lessThanOrEqualToConstant: 60).isActive = true
         return imageView
     }()
     
@@ -27,7 +27,7 @@ final class EntryTableViewCell: UITableViewCell {
     private let shortDescription: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.preferredFont(forTextStyle: .caption2)
+        label.font = UIFont.preferredFont(forTextStyle: .caption1)
         label.numberOfLines = 0
         return label
     }()

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -1,5 +1,5 @@
 //
-//  ExpositionTableViewCell.swift
+//  EntryTableViewCell.swift
 //  Expo1900
 //
 //  Created by Baek on 2022/06/16.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class ExpositionTableViewCell: UITableViewCell {
+final class EntryTableViewCell: UITableViewCell {
     private let entryImage: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -62,7 +62,7 @@ final class ExpositionTableViewCell: UITableViewCell {
 
 // - MARK: View Settings
 
-extension ExpositionTableViewCell {
+extension EntryTableViewCell {
     private func addSubView() {
         contentView.addSubview(entryImage)
         contentView.addSubview(verticalStackView)

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -21,6 +21,9 @@ final class EntryTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .title1)
+        label.adjustsFontForContentSizeCategory = true
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byWordWrapping
         return label
     }()
     
@@ -28,6 +31,9 @@ final class EntryTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .caption1)
+        label.adjustsFontForContentSizeCategory = true
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         return label
     }()

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -21,6 +21,10 @@ final class EntryTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .title1)
+        label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byWordWrapping
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -29,6 +33,9 @@ final class EntryTableViewCell: UITableViewCell {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .caption1)
         label.numberOfLines = 0
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byWordWrapping
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
         

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -40,7 +40,6 @@ final class ExpositionPostView: UIView {
     private let contentScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.backgroundColor = .white
         return scrollView
     }()
     
@@ -188,8 +187,10 @@ private extension ExpositionPostView {
     }
     
     func setUpBaseUIConstraints(from rootView: UIView) {
-        let contentLayoutGuide = contentScrollView.contentLayoutGuide
-        let frameLayoutGuide = contentScrollView.frameLayoutGuide
+        horizontalStackView.insetsLayoutMarginsFromSafeArea = false
+        contentScrollView.insetsLayoutMarginsFromSafeArea = false
+        verticalStackView.insetsLayoutMarginsFromSafeArea = false
+        contentScrollView.contentInsetAdjustmentBehavior = .never
         
         NSLayoutConstraint.activate([
             self.contentScrollView.topAnchor.constraint(equalTo: rootView.topAnchor),
@@ -197,19 +198,20 @@ private extension ExpositionPostView {
             self.contentScrollView.trailingAnchor.constraint(equalTo: rootView.trailingAnchor),
             self.contentScrollView.bottomAnchor.constraint(equalTo: rootView.bottomAnchor),
             
-            verticalStackView.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
-            verticalStackView.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
-            verticalStackView.topAnchor.constraint(equalTo: contentLayoutGuide.topAnchor),
-            verticalStackView.widthAnchor.constraint(equalTo: frameLayoutGuide.widthAnchor),
+            self.verticalStackView.leadingAnchor.constraint(equalTo: contentScrollView.leadingAnchor),
+            self.verticalStackView.trailingAnchor.constraint(equalTo: contentScrollView.trailingAnchor),
+            self.verticalStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor),
+            self.verticalStackView.widthAnchor.constraint(equalTo: rootView.widthAnchor),
             
-            descriptionLabel.leadingAnchor.constraint(equalTo: verticalStackView.leadingAnchor, constant: 10),
-            descriptionLabel.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -10),
+            self.descriptionLabel.leadingAnchor.constraint(equalTo: verticalStackView.leadingAnchor, constant: 10),
+            self.descriptionLabel.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -10),
             
-            horizontalStackView.leadingAnchor.constraint(equalTo: contentLayoutGuide.leadingAnchor),
-            horizontalStackView.trailingAnchor.constraint(equalTo: contentLayoutGuide.trailingAnchor),
-            horizontalStackView.topAnchor.constraint(equalTo: verticalStackView.bottomAnchor, constant: 10),
-            horizontalStackView.bottomAnchor.constraint(equalTo: contentLayoutGuide.bottomAnchor, constant: 10),
-            horizontalStackView.widthAnchor.constraint(equalTo: frameLayoutGuide.widthAnchor),
+            self.horizontalStackView.topAnchor.constraint(equalTo: verticalStackView.bottomAnchor, constant: 10),
+            self.horizontalStackView.leadingAnchor.constraint(equalTo: contentScrollView.leadingAnchor),
+            self.horizontalStackView.trailingAnchor.constraint(equalTo: contentScrollView.trailingAnchor),
+         
+            self.horizontalStackView.bottomAnchor.constraint(equalTo: contentScrollView.bottomAnchor, constant: -max(20.0, (UIApplication.shared.keyWindow?.safeAreaInsets.bottom)!)),
+            self.horizontalStackView.widthAnchor.constraint(equalTo: rootView.widthAnchor),
         ])
     }
 }

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -199,10 +199,10 @@ private extension ExpositionPostView {
             
             self.verticalStackView.leadingAnchor.constraint(equalTo: contentScrollView.leadingAnchor),
             self.verticalStackView.trailingAnchor.constraint(equalTo: contentScrollView.trailingAnchor),
-            self.verticalStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor),
+            self.verticalStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor, constant: max(20.0, (safeArea.top))),
             self.verticalStackView.widthAnchor.constraint(equalTo: rootView.widthAnchor),
             
-            self.titleLabel.topAnchor.constraint(equalTo: contentScrollView.topAnchor, constant: max(20.0, (safeArea.top))),
+            self.titleLabel.topAnchor.constraint(equalTo: verticalStackView.topAnchor),
             
             self.descriptionLabel.leadingAnchor.constraint(equalTo: verticalStackView.leadingAnchor, constant: 10),
             self.descriptionLabel.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -10),

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -47,6 +47,7 @@ final class ExpositionPostView: UIView {
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .title1)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         label.lineBreakStrategy = .hangulWordPriority
         label.lineBreakMode = .byCharWrapping
@@ -70,6 +71,7 @@ final class ExpositionPostView: UIView {
         label.lineBreakStrategy = .hangulWordPriority
         label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
     }()
@@ -81,6 +83,7 @@ final class ExpositionPostView: UIView {
         label.lineBreakStrategy = .hangulWordPriority
         label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
     }()
@@ -92,6 +95,7 @@ final class ExpositionPostView: UIView {
         label.lineBreakStrategy = .hangulWordPriority
         label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
     }()
@@ -103,6 +107,7 @@ final class ExpositionPostView: UIView {
         label.lineBreakStrategy = .hangulWordPriority
         label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         return label
     }()

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -48,6 +48,8 @@ final class ExpositionPostView: UIView {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .title1)
         label.textAlignment = .center
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label
@@ -65,8 +67,10 @@ final class ExpositionPostView: UIView {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .callout)
         label.textAlignment = .center
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         return label
     }()
     
@@ -74,8 +78,10 @@ final class ExpositionPostView: UIView {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .callout)
         label.textAlignment = .center
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         return label
     }()
     
@@ -83,8 +89,10 @@ final class ExpositionPostView: UIView {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .callout)
         label.textAlignment = .center
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 1
+        label.numberOfLines = 0
         return label
     }()
     
@@ -92,6 +100,8 @@ final class ExpositionPostView: UIView {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
         label.textAlignment = .left
+        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
         return label

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -50,6 +50,7 @@ final class ExpositionPostView: UIView {
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -67,6 +68,7 @@ final class ExpositionPostView: UIView {
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -76,6 +78,7 @@ final class ExpositionPostView: UIView {
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -85,6 +88,7 @@ final class ExpositionPostView: UIView {
         label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 1
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
@@ -94,6 +98,7 @@ final class ExpositionPostView: UIView {
         label.textAlignment = .left
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -40,13 +40,8 @@ final class ExpositionPostView: UIView {
     private let contentScrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.backgroundColor = .white
         return scrollView
-    }()
-    
-    private let contentView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
     }()
     
     private let titleLabel: UILabel = {
@@ -192,6 +187,10 @@ private extension ExpositionPostView {
         verticalStackView.insetsLayoutMarginsFromSafeArea = false
         contentScrollView.contentInsetAdjustmentBehavior = .never
         
+        guard let safeArea = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first?.safeAreaInsets else {
+            return
+        }
+        
         NSLayoutConstraint.activate([
             self.contentScrollView.topAnchor.constraint(equalTo: rootView.topAnchor),
             self.contentScrollView.leadingAnchor.constraint(equalTo: rootView.leadingAnchor),
@@ -203,6 +202,8 @@ private extension ExpositionPostView {
             self.verticalStackView.topAnchor.constraint(equalTo: contentScrollView.topAnchor),
             self.verticalStackView.widthAnchor.constraint(equalTo: rootView.widthAnchor),
             
+            self.titleLabel.topAnchor.constraint(equalTo: contentScrollView.topAnchor, constant: max(20.0, (safeArea.top))),
+            
             self.descriptionLabel.leadingAnchor.constraint(equalTo: verticalStackView.leadingAnchor, constant: 10),
             self.descriptionLabel.trailingAnchor.constraint(equalTo: verticalStackView.trailingAnchor, constant: -10),
             
@@ -210,7 +211,7 @@ private extension ExpositionPostView {
             self.horizontalStackView.leadingAnchor.constraint(equalTo: contentScrollView.leadingAnchor),
             self.horizontalStackView.trailingAnchor.constraint(equalTo: contentScrollView.trailingAnchor),
          
-            self.horizontalStackView.bottomAnchor.constraint(equalTo: contentScrollView.bottomAnchor, constant: -max(20.0, (UIApplication.shared.keyWindow?.safeAreaInsets.bottom)!)),
+            self.horizontalStackView.bottomAnchor.constraint(equalTo: contentScrollView.bottomAnchor, constant: -max(20.0, (safeArea.bottom))),
             self.horizontalStackView.widthAnchor.constraint(equalTo: rootView.widthAnchor),
         ])
     }

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -155,9 +155,9 @@ private extension ExpositionPostView {
         durationLabel.text = data.manufacture(ExpositionPost.duration)
         descriptionLabel.text = data.manufacture(ExpositionPost.description)
 
-        visitorLabel.setTitleStyle()
-        locationLabel.setTitleStyle()
-        durationLabel.setTitleStyle()
+        visitorLabel.setTitle(by: ":", for: .title3)
+        locationLabel.setTitle(by: ":", for: .title3)
+        durationLabel.setTitle(by: ":", for: .title3)
         
         expositionEnterButton.addTarget(self, action: #selector(tappedExpositionEnterButton(_:)), for: .touchUpInside)
     }

--- a/Expo1900/Expo1900/View/ExpositionPostView.swift
+++ b/Expo1900/Expo1900/View/ExpositionPostView.swift
@@ -144,8 +144,8 @@ final class ExpositionPostView: UIView {
 
 private extension ExpositionPostView {
     @objc func tappedExpositionEnterButton(_ sender: UIButton) {
-        let expositionTableViewController = ExpositionTableViewController()
-        rootViewController?.navigationController?.pushViewController(expositionTableViewController, animated: true)
+        let entryTableViewController = EntryTableViewController()
+        rootViewController?.navigationController?.pushViewController(entryTableViewController, animated: true)
     }
     
     func setDefaultValue(with data: ExpositionPostEntity) {


### PR DESCRIPTION
안녕하세요 그린!! 벌써 마지막 PR이네요.. @GREENOVER
아쉽네요.. 또 뵙고 싶은데..!
못뵙겠죠..???

중요하게 고민해 본 부분은 리뷰 노트에 넣어 두었습니다.
감사합니다!!

## 작업 내용 
> Dynamic Type으로 Label 처리, Autolayout

- Dynamic Type
    - lineBreakStrategy로 Label을 한글 글자 우선순위를 주었습니다
    - lineBreakMode를 글자 단위별로 설정 / 단어 단위별로 설정
    - adjustsFontForContentSizeCategory = true 로 Dynamic Type 설정해주었습니다

- Autolayout
    - SafeArea 별로 bottom의 간격을 따로 처리해 주었습니다.

### Dynamic Type
- 손쉬운 사용 -> 텍스트 크기 대응
    - ![](https://i.imgur.com/2XpWGUk.gif)
    - ![](https://i.imgur.com/UdH9Ecu.gif)
    - ![](https://i.imgur.com/Vr5YMdn.gif)

### UI Orientation
- 메인 화면은 **Orientation**이 적용 되지 않습니다.
    - ![](https://i.imgur.com/aCT81Su.gif)
 
- 출품작 리스트, 출품작 상세보기 화면은 **Orientation**이 적용됩니다.
    - ![](https://i.imgur.com/Kl2hzEd.gif)
    - ![](https://i.imgur.com/hf32jc5.gif)
- 화면이 가로,세로 **Orientation** 되어있던 화면이 메인 화면으로 돌아가면 다시 세로로 고정 됩니다.
    - ![](https://i.imgur.com/XmYkhwi.gif)

## 테스트 방법
1. Notch가 있는/없는 디바이스별로 Portrait / Landscape 설정 확인
2. Dynamic Type Label 크기 확인
3. Line 별로 텍스트 처리 확인(... : 생략되지 않는지 확인)

## 리뷰 노트
1. Main 화면(첫 화면)에서 스크롤 맨 마지막에 존재하는 horizontalStackView의 bottom 부분이 디바이스에 notch가 존재하면 bottom (-34: safeArea) notch가 없으면 0으로 설정되어서 stackView가 딱 달라붙어 서로 다르게 보이는 부분을 수정하여야 한다고 생각 하여 max함수를 활용하여 UIApplication으로 현재 bottom에 safeArea가 존재유무에 따라 처리할 수 있도록 하였습니다. 

2. UITableView에서도 첫 화면과 마찬가지로 처리가 되어 테이블 셀의 라인 부분이 보이지 않고 있어 해당 부분을 똑같이 처리하였습니다. 

3. `UIApplication.shared.keyWindow?.safeAreaInsets` 에서 keyWindow는 iOS 13.0부터 deprecated되어 `UIApplication.shared.windows.filter({ $0.isKeyWindow }).first?.safeAreaInsets`로 변경하였습니다.

## 스크린샷
|MainPage - Notch|MainPage - Without Notch| 
|:-:|:-:|
|![1-12promax](https://i.imgur.com/CIxhmBe.png)|![1-8plus](https://i.imgur.com/Zr1I3oQ.png)|
|버튼의 bottom contraint를 safeArea bottom(34pt)에 맞춰서 constant:0으로 설정한다|HomeButton이 존재하는 디바이스는 safeArea bottom이 0이라 -20pt에 맞춰 설정한다|

|EntryTableView - Notch|EntryTableView - Without Notch |
|:-:|:-:|
|![](https://i.imgur.com/xGOmC4i.png)|![](https://i.imgur.com/U7JVcJa.png)|
|버튼의 bottom contraint를 safeArea bottom(34pt)에 맞춰서 constant:0으로 설정한다|HomeButton이 존재하는 디바이스는 safeArea bottom이 0이라 -20pt에 맞춰 설정한다|

|EntryDetail - Notch|EntryDetail - Without Notch |
|:-:|:-:|
|![](https://i.imgur.com/gyFND4U.png)|![](https://i.imgur.com/4WRfQfF.jpg)|

## 이번 프로젝트 핵심경험 안내
 - [x] Word Wrapping / Line Wrapping / Line Break 방식의 이해
 - [x] 접근성(Accessibility)의 개념과 필요성 이해
 - [x] Dynamic Types를 통해 텍스트 접근성 향상
