### PR TITLE
만국박람회 [STEP 3] Kay, 나이든별

### DIFF
--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
+    var restrictOrientation = UIInterfaceOrientationMask.all
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -30,6 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return restrictOrientation
+    }
 }
 

--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -9,29 +9,21 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var restrictOrientation = UIInterfaceOrientationMask.all
+    var allowedScreenPosition = UIInterfaceOrientationMask.all
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
 
-    // MARK: UISceneSession Lifecycle
-
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        return restrictOrientation
+        return allowedScreenPosition
     }
 }
 

--- a/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
@@ -61,10 +61,10 @@ extension ExpositionPosterViewController {
             return
         }
         
-        titleLabel.text = poster.title.replacingOccurrences(of: "(", with: "\n(")
-        visitorsLabel.text = poster.visitorContents
-        locationLabel.text = poster.locationContents
-        durationLabel.text = poster.durationContents
+        titleLabel.text = poster.formattedTitle
+        visitorsLabel.text = poster.formattedVisitor
+        locationLabel.text = poster.formattedLocation
+        durationLabel.text = poster.formattedDuration
         descriptionLabel.text = poster.description
         
         posterImageView.image = UIImage(named: AssetFileName.poster)

--- a/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
@@ -61,7 +61,7 @@ extension ExpositionPosterViewController {
             return
         }
         
-        titleLabel.text = poster.title
+        titleLabel.text = poster.title.replacingOccurrences(of: "(", with: "\n(")
         visitorsLabel.text = poster.visitorContents
         locationLabel.text = poster.locationContents
         durationLabel.text = poster.durationContents

--- a/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
@@ -27,15 +27,34 @@ extension ExpositionPosterViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        
         self.navigationController?.isNavigationBarHidden = true
+        lockRotation()
     }
         
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        
         self.navigationController?.isNavigationBarHidden = false
+        releaseRotation()
     }
     
-
+    private func lockRotation() {
+        guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
+            return
+        }
+        
+        delegate.restrictOrientation = .portrait
+    }
+    
+    private func releaseRotation() {
+        guard let delegate = UIApplication.shared.delegate as? AppDelegate else {
+            return
+        }
+        
+        delegate.restrictOrientation = .all
+    }
+    
     private func configurePosterView() {
         guard let asset = NSDataAsset.init(name: AssetFileName.expositionUniverselle),
               let poster = try? JSONDecoder().decode(ExpositionPoster.self, from: asset.data) else {

--- a/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
@@ -28,14 +28,14 @@ extension ExpositionPosterViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.navigationController?.isNavigationBarHidden = true
+        navigationController?.isNavigationBarHidden = true
         lockRotation()
     }
         
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
-        self.navigationController?.isNavigationBarHidden = false
+        navigationController?.isNavigationBarHidden = false
         releaseRotation()
     }
     
@@ -78,6 +78,6 @@ extension ExpositionPosterViewController {
         guard let KoreanEntryTableViewContoller = self.storyboard?.instantiateViewController(withIdentifier: KoreanEntryTableViewController.identifier) as? KoreanEntryTableViewController else {
             return
         }
-        self.navigationController?.pushViewController(KoreanEntryTableViewContoller, animated: true)
+        navigationController?.pushViewController(KoreanEntryTableViewContoller, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpositionPosterViewController.swift
@@ -44,7 +44,7 @@ extension ExpositionPosterViewController {
             return
         }
         
-        delegate.restrictOrientation = .portrait
+        delegate.allowedScreenPosition = .portrait
     }
     
     private func releaseRotation() {
@@ -52,7 +52,7 @@ extension ExpositionPosterViewController {
             return
         }
         
-        delegate.restrictOrientation = .all
+        delegate.allowedScreenPosition = .all
     }
     
     private func configurePosterView() {

--- a/Expo1900/Expo1900/Controllers/KoreanEntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanEntryTableViewController.swift
@@ -49,6 +49,6 @@ extension KoreanEntryTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let selectedEntryViewController = self.storyboard?.instantiateViewController(withIdentifier: SelectedEntryViewController.identifier) as? SelectedEntryViewController else { return }
         selectedEntryViewController.entry = entries[indexPath.row]
-        self.navigationController?.pushViewController(selectedEntryViewController, animated: true)
+        navigationController?.pushViewController(selectedEntryViewController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controllers/KoreanEntryTableViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanEntryTableViewController.swift
@@ -15,10 +15,10 @@ extension KoreanEntryTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setupTableViewData()
+        setupEntries()
     }
 
-    private func setupTableViewData() {
+    private func setupEntries() {
         guard let asset = NSDataAsset.init(name: AssetFileName.items),
               let entries = try? JSONDecoder().decode([ExpositionEntry].self, from: asset.data) else {
             return

--- a/Expo1900/Expo1900/Controllers/SelectedEntryViewController.swift
+++ b/Expo1900/Expo1900/Controllers/SelectedEntryViewController.swift
@@ -18,12 +18,20 @@ extension SelectedEntryViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        configureView()
+        configureData()
+        configureNavigationBar()
     }
 
-    private func configureView() {
+    private func configureData() {
         navigationItem.title = entry?.name
         selectedEntryImageView.image = entry?.thumbnail
         selectedEntryDescriptionLabel.text = entry?.description
+    }
+    
+    private func configureNavigationBar() {
+        let navigationBarAppearance = UINavigationBarAppearance()
+        navigationController?.navigationBar.isTranslucent = true
+        navigationController?.navigationBar.scrollEdgeAppearance = navigationBarAppearance
+        navigationController?.navigationBar.standardAppearance = navigationBarAppearance
     }
 }

--- a/Expo1900/Expo1900/Models/ExpositionPoster.swift
+++ b/Expo1900/Expo1900/Models/ExpositionPoster.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct ExpositionPoster: Decodable {
     let title: String
     let description: String
@@ -6,9 +8,11 @@ struct ExpositionPoster: Decodable {
     private let location: String
     private let duration: String
     
-    // TODO: 방문객 숫자에 numberFormatter 적용하기
     var visitorContents: String {
-        return "방문객 : \(visitors) 명"
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        let visitorInFormat = formatter.string(from: NSNumber(value: visitors)) ?? "0"
+        return "방문객 : \(visitorInFormat) 명"
     }
     
     var locationContents: String {

--- a/Expo1900/Expo1900/Models/ExpositionPoster.swift
+++ b/Expo1900/Expo1900/Models/ExpositionPoster.swift
@@ -1,25 +1,29 @@
 import Foundation
 
 struct ExpositionPoster: Decodable {
-    let title: String
     let description: String
     
+    private let title: String
     private let visitors: Int
     private let location: String
     private let duration: String
     
-    var visitorContents: String {
+    var formattedTitle: String {
+        return title.replacingOccurrences(of: "(", with: "\n(")
+    }
+    
+    var formattedVisitor: String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         let visitorInFormat = formatter.string(from: NSNumber(value: visitors)) ?? "0"
         return "방문객 : \(visitorInFormat) 명"
     }
     
-    var locationContents: String {
+    var formattedLocation: String {
         return "개최지 : \(location)"
     }
     
-    var durationContents: String {
+    var formattedDuration: String {
         return "개최 기간 : \(duration)"
     }
 }

--- a/Expo1900/Expo1900/SceneDelegate.swift
+++ b/Expo1900/Expo1900/SceneDelegate.swift
@@ -10,40 +10,29 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let _ = (scene as? UIWindowScene) else { return }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+        
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
+
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
+
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
+
     }
 
 

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -36,32 +36,32 @@
                                                     <constraint firstAttribute="height" constant="150" id="krd-DB-Fyw"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Btn-6A-Y95">
-                                                <rect key="frame" x="186.5" y="210" width="41.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Btn-6A-Y95">
+                                                <rect key="frame" x="8" y="210" width="398" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmb-AA-7jt">
-                                                <rect key="frame" x="186.5" y="240.5" width="41.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmb-AA-7jt">
+                                                <rect key="frame" x="8" y="240.5" width="398" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75g-hg-U2k">
-                                                <rect key="frame" x="186.5" y="271" width="41.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75g-hg-U2k">
+                                                <rect key="frame" x="8" y="271" width="398" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2js-f5-My6">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2js-f5-My6">
                                                 <rect key="frame" x="8" y="301.5" width="398" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Zwu-Pi-6WW">
-                                                <rect key="frame" x="60.5" y="328.5" width="293" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Zwu-Pi-6WW">
+                                                <rect key="frame" x="40" y="328.5" width="334" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qwh-tn-I5L">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -71,7 +71,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k1r-oD-GB6">
-                                                        <rect key="frame" x="70" y="9.5" width="153" height="31"/>
+                                                        <rect key="frame" x="90.5" y="9.5" width="153" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
@@ -79,7 +79,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rNC-Ey-Ajz">
-                                                        <rect key="frame" x="243" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="284" y="0.0" width="50" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="50" id="X2u-pf-fBQ"/>
                                                             <constraint firstAttribute="width" secondItem="rNC-Ey-Ajz" secondAttribute="height" multiplier="1:1" id="ko8-XT-sUc"/>
@@ -95,11 +95,16 @@
                                         <constraints>
                                             <constraint firstItem="vmb-AA-7jt" firstAttribute="top" secondItem="Btn-6A-Y95" secondAttribute="bottom" constant="10" id="0Wz-3D-fCc"/>
                                             <constraint firstItem="2js-f5-My6" firstAttribute="top" secondItem="75g-hg-U2k" secondAttribute="bottom" constant="10" id="5Pq-gl-QQc"/>
+                                            <constraint firstItem="Zwu-Pi-6WW" firstAttribute="leading" secondItem="EbA-6E-tPm" secondAttribute="leading" constant="40" id="5us-gp-4bX"/>
+                                            <constraint firstAttribute="trailing" secondItem="75g-hg-U2k" secondAttribute="trailing" constant="8" id="5zm-q4-7h0"/>
+                                            <constraint firstAttribute="trailing" secondItem="vmb-AA-7jt" secondAttribute="trailing" constant="8" id="7fI-7e-nsX"/>
                                             <constraint firstItem="Btn-6A-Y95" firstAttribute="centerX" secondItem="EbA-6E-tPm" secondAttribute="centerX" id="94H-2N-JtS"/>
+                                            <constraint firstItem="75g-hg-U2k" firstAttribute="leading" secondItem="EbA-6E-tPm" secondAttribute="leading" constant="8" id="9TU-Ea-nC5"/>
                                             <constraint firstItem="Zwu-Pi-6WW" firstAttribute="top" secondItem="2js-f5-My6" secondAttribute="bottom" constant="10" id="9za-bB-3jw"/>
                                             <constraint firstItem="75g-hg-U2k" firstAttribute="top" secondItem="vmb-AA-7jt" secondAttribute="bottom" constant="10" id="BWw-x8-Eu7"/>
                                             <constraint firstItem="vmb-AA-7jt" firstAttribute="centerX" secondItem="EbA-6E-tPm" secondAttribute="centerX" id="DRB-r6-m5e"/>
                                             <constraint firstItem="75g-hg-U2k" firstAttribute="centerX" secondItem="EbA-6E-tPm" secondAttribute="centerX" id="E6L-G3-W0l"/>
+                                            <constraint firstAttribute="trailing" secondItem="Btn-6A-Y95" secondAttribute="trailing" constant="8" id="G0R-bs-Vdy"/>
                                             <constraint firstItem="2js-f5-My6" firstAttribute="leading" secondItem="EbA-6E-tPm" secondAttribute="leading" constant="8" id="MmE-rf-aSi"/>
                                             <constraint firstAttribute="trailing" secondItem="9du-86-Zqp" secondAttribute="trailing" constant="8" id="Mxp-F5-Agy"/>
                                             <constraint firstItem="Btn-6A-Y95" firstAttribute="top" secondItem="5eP-1L-ZFo" secondAttribute="bottom" constant="10" id="O3U-jk-bQG"/>
@@ -107,11 +112,14 @@
                                             <constraint firstItem="5eP-1L-ZFo" firstAttribute="top" secondItem="9du-86-Zqp" secondAttribute="bottom" constant="10" id="Q42-Br-tgn"/>
                                             <constraint firstItem="9du-86-Zqp" firstAttribute="top" secondItem="EbA-6E-tPm" secondAttribute="top" constant="10" id="WaB-6y-5UE"/>
                                             <constraint firstItem="9du-86-Zqp" firstAttribute="centerX" secondItem="EbA-6E-tPm" secondAttribute="centerX" id="XYY-Uw-NCk"/>
+                                            <constraint firstItem="Btn-6A-Y95" firstAttribute="leading" secondItem="EbA-6E-tPm" secondAttribute="leading" constant="8" id="cnB-vz-kJp"/>
                                             <constraint firstItem="9du-86-Zqp" firstAttribute="leading" secondItem="EbA-6E-tPm" secondAttribute="leading" constant="8" id="eHe-6G-7BT"/>
+                                            <constraint firstAttribute="trailing" secondItem="Zwu-Pi-6WW" secondAttribute="trailing" constant="40" id="ec2-52-ALA"/>
                                             <constraint firstItem="2js-f5-My6" firstAttribute="centerX" secondItem="EbA-6E-tPm" secondAttribute="centerX" id="gqI-0p-pfw"/>
                                             <constraint firstItem="5eP-1L-ZFo" firstAttribute="centerX" secondItem="EbA-6E-tPm" secondAttribute="centerX" id="j9m-yK-5Fk"/>
                                             <constraint firstAttribute="bottom" secondItem="Zwu-Pi-6WW" secondAttribute="bottom" constant="10" id="o1D-v2-KhM"/>
                                             <constraint firstAttribute="trailing" secondItem="2js-f5-My6" secondAttribute="trailing" constant="8" id="w8g-Dk-PDn"/>
+                                            <constraint firstItem="vmb-AA-7jt" firstAttribute="leading" secondItem="EbA-6E-tPm" secondAttribute="leading" constant="8" id="x2T-hD-mNa"/>
                                         </constraints>
                                     </view>
                                 </subviews>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -21,47 +21,47 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EbA-6E-tPm" userLabel="Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="387"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="388.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9du-86-Zqp">
-                                                <rect key="frame" x="8" y="10" width="398" height="27.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="23"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9du-86-Zqp">
+                                                <rect key="frame" x="8" y="10" width="398" height="30"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5eP-1L-ZFo">
-                                                <rect key="frame" x="132" y="47.5" width="150" height="150"/>
+                                                <rect key="frame" x="132" y="50" width="150" height="150"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="150" id="62j-9K-AMN"/>
                                                     <constraint firstAttribute="height" constant="150" id="krd-DB-Fyw"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Btn-6A-Y95">
-                                                <rect key="frame" x="186.5" y="207.5" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Btn-6A-Y95">
+                                                <rect key="frame" x="186.5" y="210" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmb-AA-7jt">
-                                                <rect key="frame" x="186.5" y="238" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vmb-AA-7jt">
+                                                <rect key="frame" x="186.5" y="240.5" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75g-hg-U2k">
-                                                <rect key="frame" x="186.5" y="268.5" width="41.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="75g-hg-U2k">
+                                                <rect key="frame" x="186.5" y="271" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2js-f5-My6">
-                                                <rect key="frame" x="8" y="299" width="398" height="18"/>
-                                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="15"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2js-f5-My6">
+                                                <rect key="frame" x="8" y="301.5" width="398" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Zwu-Pi-6WW">
-                                                <rect key="frame" x="60.5" y="327" width="293" height="50"/>
+                                                <rect key="frame" x="60.5" y="328.5" width="293" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qwh-tn-I5L">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -228,7 +228,7 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TLY-3U-Jby">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="238.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="235"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="BG1-Qn-mcR">
                                                 <rect key="frame" x="119.5" y="20" width="175" height="175"/>
@@ -237,9 +237,9 @@
                                                     <constraint firstAttribute="width" constant="175" id="hAS-3E-wgm"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3vb-d0-uaO">
-                                                <rect key="frame" x="15" y="210" width="384" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3vb-d0-uaO">
+                                                <rect key="frame" x="15" y="210" width="384" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -11,6 +11,7 @@ final class KoreanEntryTableViewCell: UITableViewCell, ReuseIdentifying {
     private lazy var entryImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
         return imageView
     }()
     private lazy var titleLabel: UILabel = {
@@ -23,12 +24,13 @@ final class KoreanEntryTableViewCell: UITableViewCell, ReuseIdentifying {
         let shortDescriptionLabel = UILabel()
         shortDescriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         shortDescriptionLabel.numberOfLines = 0
+        shortDescriptionLabel.lineBreakMode = .byWordWrapping
         return shortDescriptionLabel
     }()
     private lazy var descriptionStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.spacing = 8
+        stackView.spacing = 5
         stackView.axis = .vertical
         return stackView
     }()
@@ -52,18 +54,20 @@ extension KoreanEntryTableViewCell {
     
     private func setupLayout() {
         NSLayoutConstraint.activate([
-            entryImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
-            entryImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: 8),
+            entryImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            entryImageView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 8),
+            entryImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8),
             entryImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
             entryImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
             entryImageView.widthAnchor.constraint(equalTo: entryImageView.heightAnchor)
         ])
         
         NSLayoutConstraint.activate([
+            descriptionStackView.centerYAnchor.constraint(equalTo: entryImageView.centerYAnchor),
+            descriptionStackView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 8),
+            descriptionStackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -8),
             descriptionStackView.leadingAnchor.constraint(equalTo: entryImageView.trailingAnchor, constant: 8),
-            descriptionStackView.topAnchor.constraint(equalTo: entryImageView.topAnchor),
-            descriptionStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            descriptionStackView.bottomAnchor.constraint(equalTo: entryImageView.bottomAnchor)
+            descriptionStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
     }
 }

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -40,7 +40,7 @@ extension KoreanEntryTableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        self.accessoryType = .disclosureIndicator
+        accessoryType = .disclosureIndicator
         setupAttribute()
         setupLayout()
     }

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -19,6 +19,7 @@ final class KoreanEntryTableViewCell: UITableViewCell, ReuseIdentifying {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.font = UIFont.preferredFont(forTextStyle: .title2)
         titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.adjustsFontSizeToFitWidth = true
         return titleLabel
     }()
     private lazy var shortDescriptionLabel: UILabel = {

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -26,7 +26,7 @@ final class KoreanEntryTableViewCell: UITableViewCell, ReuseIdentifying {
         let shortDescriptionLabel = UILabel()
         shortDescriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         shortDescriptionLabel.numberOfLines = 0
-        shortDescriptionLabel.lineBreakMode = .byWordWrapping
+        shortDescriptionLabel.lineBreakStrategy = .hangulWordPriority
         shortDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .body)
         shortDescriptionLabel.adjustsFontForContentSizeCategory = true
         return shortDescriptionLabel
@@ -44,7 +44,6 @@ extension KoreanEntryTableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        accessoryType = .disclosureIndicator
         setupAttribute()
         setupLayout()
     }
@@ -55,6 +54,8 @@ extension KoreanEntryTableViewCell {
         descriptionStackView.addArrangedSubview(titleLabel)
         descriptionStackView.addArrangedSubview(shortDescriptionLabel)
         contentView.addSubview(descriptionStackView)
+        
+        accessoryType = .disclosureIndicator
     }
     
     private func setupLayout() {

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -53,7 +53,7 @@ extension KoreanEntryTableViewCell {
     private func setupLayout() {
         NSLayoutConstraint.activate([
             entryImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
-            entryImageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 8),
+            entryImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: 8),
             entryImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 8),
             entryImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
             entryImageView.widthAnchor.constraint(equalTo: entryImageView.heightAnchor)

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -17,7 +17,8 @@ final class KoreanEntryTableViewCell: UITableViewCell, ReuseIdentifying {
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.font = UIFont.systemFont(ofSize: 24)
+        titleLabel.font = UIFont.preferredFont(forTextStyle: .title2)
+        titleLabel.adjustsFontForContentSizeCategory = true
         return titleLabel
     }()
     private lazy var shortDescriptionLabel: UILabel = {
@@ -25,6 +26,8 @@ final class KoreanEntryTableViewCell: UITableViewCell, ReuseIdentifying {
         shortDescriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         shortDescriptionLabel.numberOfLines = 0
         shortDescriptionLabel.lineBreakMode = .byWordWrapping
+        shortDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        shortDescriptionLabel.adjustsFontForContentSizeCategory = true
         return shortDescriptionLabel
     }()
     private lazy var descriptionStackView: UIStackView = {

--- a/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreanEntryTableViewCell.swift
@@ -40,6 +40,7 @@ extension KoreanEntryTableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
+        self.accessoryType = .disclosureIndicator
         setupAttribute()
         setupLayout()
     }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
     * 화 : 포스터 모델 및 출품작 모델 구현
     * 수 : 피드백 받은 부분에 따라 출품작 모델 보완 및 보강 - 이미지를 불러오는 프로퍼티 추가
     * 목 : 포스터 뷰 구현, 한국의 출품작 테이블 뷰 구현
-    * 금 : 한국의 출품작 테이블 뷰 셀 구현, 한국의 출품작 상세 뷰 구현 (진행중) 
+    * 금 : 한국의 출품작 테이블 뷰 셀 구현, 한국의 출품작 상세 뷰 구현
 
 * 둘째주 타임라인 (2022.06.20 ~ 2022.06.24)
     * 월 : TableViewCell 코드 수정
@@ -62,7 +62,7 @@
 
 | 포스터 | 한국의 출품작 목록 | 선택한 출품작의 상세 정보 |
 |:------:|:--------:|:--------:|
-| ![](https://i.imgur.com/AYcodBH.gif) | ![](https://i.imgur.com/U9EACM3.gif) | ![](https://i.imgur.com/WtTIBjy.gif) |
+| ![poster](https://user-images.githubusercontent.com/102375432/175782486-b64e1419-4f37-48ca-ae98-8f3948003606.gif) | ![list](https://user-images.githubusercontent.com/102375432/175782489-920cf380-879b-4517-bc4a-27ae8f9480a4.gif) | ![selection](https://user-images.githubusercontent.com/102375432/175782490-8b260e47-489e-47d1-a1db-25c0363ebcf6.gif) |
 
 ---
 
@@ -85,24 +85,24 @@
 * 트러블 슈팅
     * 테이블 뷰 커스텀 셀을 만들 때 내부적으로 셀 컨텐츠 뷰를 계속 리사이징해서 제약사항이 충돌했던 것에 대한 고민
         * 스토리보드 위에서 프로토타입 셀을 먼저 커스터마이징하고 테이블 뷰 셀 클래스를 짜려고 해서 생겼던 문제. 
-        * 커스텀 테이블 뷰 셀에 대한 정보 즉, 들어가야 할 이미지 뷰나 레이블 등의 **프로퍼티와 UI 제약사항을 테이블 뷰 클래스에서 먼저 설정**해준 다음, 해당 클래스를 스토리보드의 프로토타입 셀을 담당하는 클래스로 지정해줌으로써 해결 (진행중) 
+        * 커스텀 테이블 뷰 셀에 대한 정보 즉, 들어가야 할 이미지 뷰나 레이블 등의 **프로퍼티와 UI 제약사항을 테이블 뷰 클래스에서 먼저 설정**해준 다음, 해당 클래스를 스토리보드의 프로토타입 셀을 담당하는 클래스로 지정해줌으로써 **해결**
     * 뷰 간의 데이터 이동에 대한 고민
-        *  identifier를 통해 데이터를 넘겨줄 뷰 컨트롤러를 인지하고 이용해 새로운 뷰 컨트롤러의 프로퍼티에 JSONDecoder로 파싱한 값을 통째로 넘겨준다(진행중)
+        *  identifier를 통해 데이터를 넘겨줄 뷰 컨트롤러를 인지하고 이용해 새로운 뷰 컨트롤러의 프로퍼티에 JSONDecoder로 파싱한 값을 통째로 넘겨줌으로써 **해결**
     * Back Bar Button Item을 어떻게 설정할지에 대한 고민
         * 이전 뷰 컨트롤러로 돌아가고자 할 때, Back Button을 만들고자 했으나, 해당 버튼의 타이틀이 원하는 대로 설정되지 않았던 문제
-        * (진행중)
+        * Navigation Controller에서 따로 Back Button의 이름을 정해줄 수 있었던 것 발견함으로써 **해결**
+        * 포스터 뷰 컨트롤러의 내비게이션 바는 숨김 처리
     * 로컬 Asset으로부터 어떻게 데이터를 불러와야 할지에 대한 고민
         * 가져와야 할 두 가지 데이터 - 이미지, JSON
         * Assets 폴더에 이미 있는 데이터를 불러오는 상황
         * 이미지를 가져올 때는 **`UIImage(named:)` 메서드 활용**
         * JSON 데이터를 가져올 때는, 먼저 **`NSDataAsset.init(name:)`을 활용해 `NSDataAsset` 인스턴스를 가져온 다음, 해당 인스턴스의 `.data` 프로퍼티에 있는 `Data` 자료형을 가져와서 `JSONDecoder.decode<T>(_ type: T.type, from data: Data) throws where T: Decodable` 메서드에 넣어서 디코딩**하여, 원하는 모델에 맞춰진 자료를 생성
     * 첫 화면을 세로로 고정하는 문제에 대한 고민
-        * UIApplication의 타입 프로퍼티를 활용해 AppDelegate에 접근이 가능하게 하고  AppDelegate에서는 UIInterfaceOrientationMask 구조체를 타입으로 가지는 restrictOrientation 프로퍼티를 만들어 주어 결국엔 필요한 화면에서 view가 나타날때와 사라질때 각각 .portrait과 .all을 적용 시켜 주어 문제를 해결했습니다.
-
+        * UIApplication의 타입 프로퍼티를 활용해 AppDelegate에 접근이 가능하게 하고  AppDelegate에서는 UIInterfaceOrientationMask 구조체를 타입으로 가지는 restrictOrientation 프로퍼티를 만들어 주어 결국엔 필요한 화면에서 view가 나타날때와 사라질때 각각 .portrait과 .all을 적용 시켜 주어 문제를 **해결**
     * 어느곳에 Numberformatter 코드를 구현해야 하는지 고민
-        * 처음엔 메서드로 만들어 주려고 했으나 많이 쓰이지 않는 부분을 감안해 연산프로퍼티를 만들어 가독성과 효율을 동시에 잡았습니다.
+        * 처음엔 메서드로 만들어 주려고 했으나 많이 쓰이지 않는 부분을 감안해 포스터 모델 안의 연산 프로퍼티로 제작
     * 마지막 작품 상세 페이지에서 네이게이션 바 부분이 불투명하게 나오지 않는점 고민
-        * navigationBar.isTranslucent 를 true로 설정 해주고 UINavigationBarAppearance 타입의 인스턴스를 만들고 navigationBar.scrollEdgeAppearance 와 navigationBar.standardAppearance에 대입해주었습니다.
+        * navigationBar.isTranslucent 를 true로 설정 해주고 UINavigationBarAppearance 타입의 인스턴스를 만들고 navigationBar.scrollEdgeAppearance 와 navigationBar.standardAppearance에 대입하여 **해결**
 
 ---
 
@@ -120,5 +120,5 @@
 
 ---
 
-최종 업데이트 : 6/24
+최종 업데이트 : 6/26
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,87 @@
 # 만국박람회 README
 
-* 제목: 만국박람회
+## 목차:
+- [개요](https://hackmd.io/se5jwqftTvi_J5qiK3o0LQ#%EA%B0%9C%EC%9A%94)
+- [타임라인](https://hackmd.io/se5jwqftTvi_J5qiK3o0LQ#%ED%83%80%EC%9E%84%EB%9D%BC%EC%9D%B8)
+- [구동 영상](https://hackmd.io/se5jwqftTvi_J5qiK3o0LQ#%EC%B2%AB-%ED%99%94%EB%A9%B4-%EC%84%B8%EB%A1%9C-%EC%84%A4%EC%A0%95)
+- [실행 화면에 대한 설명](https://hackmd.io/se5jwqftTvi_J5qiK3o0LQ#%EC%8B%A4%ED%96%89-%ED%99%94%EB%A9%B4%EC%97%90-%EB%8C%80%ED%95%9C-%EC%84%A4%EB%AA%85)
+- [트러블 슈팅](https://hackmd.io/se5jwqftTvi_J5qiK3o0LQ#%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85)
+- [참고 링크](https://hackmd.io/se5jwqftTvi_J5qiK3o0LQ#%EC%B0%B8%EA%B3%A0-%EB%A7%81%ED%81%AC)
+---
+
+## 개요
+* 프로젝트명: 만국박람회
 
 * 소개: 1900년 파리 만국박람회와 그 배경, 그리고 참가국으로써의 한국(당시 대한제국)의 주변을 둘러싼 역사적 상황, 그리고 한국의 출품작에 대해 다루고 설명하는 앱
 
 * 팀원
-    * 나이든별, KayAhn
-    * 사진 및 담당 역할 향후 추가 예정
+    | 나이든별 | KayAhn |
+    |:--------:|:------:|
+    |  ![](https://i.imgur.com/fLzA5CS.jpg) | ![](https://i.imgur.com/iMppyyH.jpg)|
 
 ---
-
-* 타임라인
+## 타임라인
+* 첫째주 타임라인 (2022.06.13 ~ 2022.06.17)
     * 월 : 프로젝트 사전 준비. 필요한 사항에 대한 공부.
     * 화 : 포스터 모델 및 출품작 모델 구현
     * 수 : 피드백 받은 부분에 따라 출품작 모델 보완 및 보강 - 이미지를 불러오는 프로퍼티 추가
     * 목 : 포스터 뷰 구현, 한국의 출품작 테이블 뷰 구현
     * 금 : 한국의 출품작 테이블 뷰 셀 구현, 한국의 출품작 상세 뷰 구현 (진행중) 
 
+* 둘째주 타임라인 (2022.06.20 ~ 2022.06.24)
+    * 월 : TableViewCell 코드 수정
+    * 화 : 
+        * 포스터 프로퍼티를 모델에서 가공하도록 수정
+        * identifier 관리 방법 수정
+        * cell setting method를 뷰 컨트롤러에서 직접하지 않고 클래스의 메서드를 이용해 구성하도록 수정
+    * 수 : 전체적인 Step2 수정 및 re-Request
+    * 목 : 
+        * 첫 화면만 세로로 고정.
+        * 컨텐츠가 잘 나오도록 테이블뷰 셀 오토-레이아웃 추가 및 수정.
+        * 포스터 모델 수정.
+        * 관람객 NumberFormatter 추가
+        * 문자열 포매팅 연산 프로퍼티 네이밍 통일
+        * 작품 상세 네비게이션바를 기능 요구서와 동일하게 수정.
+        * Word Wrapping 추가.
+        * Dynamic Type 적용.
+    * 금 : Step3 PR
 ---
 
+## 프로젝트 구조
 * 시각화된 프로젝트 구조(다이어그램 등)
-    * 현재 해결중인 이슈 해결 완료하는 대로 추가 예정
+    * TBA
 
 ---
 
+## 구동 영상
+|           포스터 화면 (세로 고정)         |
+|:------------------------------------:|
+| ![](https://i.imgur.com/mj3G93O.gif) |
+
+
+
+| 포스터 | 한국의 출품작 목록 | 선택한 출품작의 상세 정보 |
+|:------:|:--------:|:--------:|
+| ![](https://i.imgur.com/AYcodBH.gif) | ![](https://i.imgur.com/U9EACM3.gif) | ![](https://i.imgur.com/WtTIBjy.gif) |
+
+---
+
+## 실행 화면에 대한 설명
 * 실행 화면(기능 설명)
     * 인트로 화면: 1900년 파리 만국박람회와 참가국으로써의 한국(당시 대한제국)을 소개
     * 한국의 출품작 화면: 한국의 출품작 목록 표시
     * 한국의 출품작 상세 화면: 각각의 출품작에 대한 상세 설명
 * 사용 기술:
     * TableViewDelegate, TableViewDataSource를 이용한 테이블 구성
-    * 내비게이션 컨트롤러를 활용한 화면 전환
+    * instantiateViewController 메서드를 활용한 화면 전환
     * Decodable 프로토콜을 사용해 JSON 데이터 파싱하여 테이블뷰에 표시
+    * Numberformatter 적용
+    * Word Wrapping을 사용해 긴 문장을 단어 단위로 슬라이싱
+    * Dynamic Type 적용
 
 ---
 
+## 트러블 슈팅
 * 트러블 슈팅
     * 테이블 뷰 커스텀 셀을 만들 때 내부적으로 셀 컨텐츠 뷰를 계속 리사이징해서 제약사항이 충돌했던 것에 대한 고민
         * 스토리보드 위에서 프로토타입 셀을 먼저 커스터마이징하고 테이블 뷰 셀 클래스를 짜려고 해서 생겼던 문제. 
@@ -45,13 +92,21 @@
         * 이전 뷰 컨트롤러로 돌아가고자 할 때, Back Button을 만들고자 했으나, 해당 버튼의 타이틀이 원하는 대로 설정되지 않았던 문제
         * (진행중)
     * 로컬 Asset으로부터 어떻게 데이터를 불러와야 할지에 대한 고민
-        * 두 가지 가져와야 할 데이터 - 이미지, JSON
+        * 가져와야 할 두 가지 데이터 - 이미지, JSON
         * Assets 폴더에 이미 있는 데이터를 불러오는 상황
         * 이미지를 가져올 때는 **`UIImage(named:)` 메서드 활용**
         * JSON 데이터를 가져올 때는, 먼저 **`NSDataAsset.init(name:)`을 활용해 `NSDataAsset` 인스턴스를 가져온 다음, 해당 인스턴스의 `.data` 프로퍼티에 있는 `Data` 자료형을 가져와서 `JSONDecoder.decode<T>(_ type: T.type, from data: Data) throws where T: Decodable` 메서드에 넣어서 디코딩**하여, 원하는 모델에 맞춰진 자료를 생성
+    * 첫 화면을 세로로 고정하는 문제에 대한 고민
+        * UIApplication의 타입 프로퍼티를 활용해 AppDelegate에 접근이 가능하게 하고  AppDelegate에서는 UIInterfaceOrientationMask 구조체를 타입으로 가지는 restrictOrientation 프로퍼티를 만들어 주어 결국엔 필요한 화면에서 view가 나타날때와 사라질때 각각 .portrait과 .all을 적용 시켜 주어 문제를 해결했습니다.
+
+    * 어느곳에 Numberformatter 코드를 구현해야 하는지 고민
+        * 처음엔 메서드로 만들어 주려고 했으나 많이 쓰이지 않는 부분을 감안해 연산프로퍼티를 만들어 가독성과 효율을 동시에 잡았습니다.
+    * 마지막 작품 상세 페이지에서 네이게이션 바 부분이 불투명하게 나오지 않는점 고민
+        * navigationBar.isTranslucent 를 true로 설정 해주고 UINavigationBarAppearance 타입의 인스턴스를 만들고 navigationBar.scrollEdgeAppearance 와 navigationBar.standardAppearance에 대입해주었습니다.
 
 ---
 
+## 참고 링크
 * 참고 링크
     * https://yagom.net/courses/autolayout/lessons/working-with-self-sizing-table-view-cells/topic/self-sizing-table-view-cell-practice/
     * https://www.wtfautolayout.com/
@@ -59,7 +114,11 @@
     * https://developer.apple.com/documentation/uikit/nsdataasset
     * https://developer.apple.com/documentation/uikit/uiimage/1624146-init
     * https://developer.apple.com/forums/thread/92434
+    * https://stackoverflow.com/questions/38969419/ios-how-to-enable-and-disable-rotation-on-each-uiviewcontroller
+    * https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically
+    * https://stackoverflow.com/questions/70575637/avoid-navigation-bar-becoming-visible-when-theres-scrollable-content-beneath-it
 
 ---
 
-최종 업데이트 : 6/17
+최종 업데이트 : 6/24
+


### PR DESCRIPTION
안녕하세요 @jryoun1  !
만국 박람회 마지막 Pull - Request 보내드립니다. 마지막 PR도 잘 부탁드립니다!🙇🏻‍♂️

### 작업한 내용

- 첫 화면만 세로로 고정.
- 컨텐츠가 잘 나오도록 테이블뷰 셀 오토-레이아웃 추가 및 수정.
- 포스터 모델 수정.
    - 관람객 NumberFormatter 추가
    - 문자열 포매팅 연산 프로퍼티 네이밍 통일
- 작품 상세 네비게이션바를 기능 요구서와 동일하게 수정.
- Word Wrapping 추가.
- Dynamic Type 적용.

### 고민한 점 및 조언을 얻고 싶은 점
- 이번 프로젝트에서 오토레이아웃에 많은 시간을 할애 하였습니다. 조금 더 연습 하고 싶은데 좋은 방법이 있을까요?
- 이전 PR 피드백 마지막 부분에서 `self`의 사용에 대해 기준이 있는지 여쭤봐 주셨습니다. 합의 하에 일단은, 중복된 네이밍으로 인해 혼동의 여지가 있는 경우에만 `self`를 활용했고 나머지는 모두 지워 주었는데요, 이 부분에 대해 가지고 계신 기준에 대해 여쭤보고 싶습니다.

### 참조한 사이트
https://stackoverflow.com/questions/38969419/ios-how-to-enable-and-disable-rotation-on-each-uiviewcontroller
https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically
https://stackoverflow.com/questions/70575637/avoid-navigation-bar-becoming-visible-when-theres-scrollable-content-beneath-it