### PR TITLE
만국박람회 [STEP 3] 민쏜, Judy

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		204057A62857336F00192823 /* Content.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204057A52857336F00192823 /* Content.swift */; };
 		20A2740D285AF1C200836444 /* KoreanContentListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A2740C285AF1C200836444 /* KoreanContentListViewController.swift */; };
+		20E25D6328642EDD00264884 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E25D6228642EDD00264884 /* NavigationController.swift */; };
 		20E629FB285B1704001F845C /* ContentDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E629FA285B1704001F845C /* ContentDetailViewController.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
@@ -24,6 +25,7 @@
 /* Begin PBXFileReference section */
 		204057A52857336F00192823 /* Content.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Content.swift; sourceTree = "<group>"; };
 		20A2740C285AF1C200836444 /* KoreanContentListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanContentListViewController.swift; sourceTree = "<group>"; };
+		20E25D6228642EDD00264884 /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		20E629FA285B1704001F845C /* ContentDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentDetailViewController.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
 				20A2740C285AF1C200836444 /* KoreanContentListViewController.swift */,
 				20E629FA285B1704001F845C /* ContentDetailViewController.swift */,
+				20E25D6228642EDD00264884 /* NavigationController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -202,6 +205,7 @@
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				204057A62857336F00192823 /* Content.swift in Sources */,
 				FDC68BF52859D74700804449 /* Error.swift in Sources */,
+				20E25D6328642EDD00264884 /* NavigationController.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				20E629FB285B1704001F845C /* ContentDetailViewController.swift in Sources */,
 			);
@@ -350,14 +354,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Expo1900/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.Expo1900;
+				PRODUCT_BUNDLE_IDENTIFIER = practice.Expo1900;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
@@ -368,14 +375,17 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Expo1900/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.Expo1900;
+				PRODUCT_BUNDLE_IDENTIFIER = practice.Expo1900;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};

--- a/Expo1900/Expo1900/Sources/AppDelegate.swift
+++ b/Expo1900/Expo1900/Sources/AppDelegate.swift
@@ -8,15 +8,7 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var isVerticalOrientationBlocked = true
     
-    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        if isVerticalOrientationBlocked {
-            return .portrait
-        } else {
-            return .all
-        }
-    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/Expo1900/Expo1900/Sources/AppDelegate.swift
+++ b/Expo1900/Expo1900/Sources/AppDelegate.swift
@@ -8,8 +8,15 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
+    var isVerticalOrientationBlocked = true
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if isVerticalOrientationBlocked {
+            return .portrait
+        } else {
+            return .all
+        }
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/Expo1900/Expo1900/Sources/Controllers/ContentDetailViewController.swift
+++ b/Expo1900/Expo1900/Sources/Controllers/ContentDetailViewController.swift
@@ -17,8 +17,10 @@ final class ContentDetailViewController: UIViewController {
     
     private func setUIComponents() {
         guard let content = content else { return }
-        
+
         descriptionLabel.numberOfLines = 0
+        descriptionLabel.font = .preferredFont(forTextStyle: .body)
+        descriptionLabel.adjustsFontForContentSizeCategory = true
         descriptionLabel.text = content.description
         
         contentImageView.image = UIImage(named: content.imageName)

--- a/Expo1900/Expo1900/Sources/Controllers/KoreanContentListViewController.swift
+++ b/Expo1900/Expo1900/Sources/Controllers/KoreanContentListViewController.swift
@@ -25,7 +25,7 @@ final class KoreanContentListViewController: UIViewController {
         } catch let error as DataHandlingError {
             print(error.description)
         } catch {
-            print("Undexpected error: \(error)")
+            print("Unexpected error: \(error)")
         }
     }
     
@@ -56,6 +56,7 @@ extension KoreanContentListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = contentTableView.dequeueReusableCell(withIdentifier: "contentCell", for: indexPath) as? ContentCell ?? ContentCell()
         
+        cell.selectionStyle = .none
         cell.setup(content: contents[indexPath.row])
 
         return cell

--- a/Expo1900/Expo1900/Sources/Controllers/MainViewController.swift
+++ b/Expo1900/Expo1900/Sources/Controllers/MainViewController.swift
@@ -17,8 +17,6 @@ final class MainViewController: UIViewController {
     @IBOutlet private weak var leftFlagImageView: UIImageView!
     @IBOutlet private weak var presentKoreanContentsButton: UIButton!
     @IBOutlet private weak var rightFlagImageView: UIImageView!
-
-    private let appDelegate = UIApplication.shared.delegate as? AppDelegate ?? AppDelegate()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,15 +25,13 @@ final class MainViewController: UIViewController {
         fetchExpositionData()
     }
     
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return [.portrait]
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
-        appDelegate.isVerticalOrientationBlocked = true
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        appDelegate.isVerticalOrientationBlocked = false
     }
     
     private func fetchExpositionData() {

--- a/Expo1900/Expo1900/Sources/Controllers/MainViewController.swift
+++ b/Expo1900/Expo1900/Sources/Controllers/MainViewController.swift
@@ -53,13 +53,26 @@ final class MainViewController: UIViewController {
     
     private func setupLabels(of exposition: Exposition) {
         descriptionLabel.numberOfLines = 0
+        
         titleLabel.numberOfLines = 0
         titleLabel.font = UIFont.preferredFont(forTextStyle: .title1)
-        
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.text = exposition.title.replacingOccurrences(of: "(", with: "\n(")
+        
+        visitorsLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        visitorsLabel.adjustsFontForContentSizeCategory = true
         visitorsLabel.text = "방문객 :  \(applyNumberFormat(to: exposition.visitors)) 명"
+        
+        locationLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        locationLabel.adjustsFontForContentSizeCategory = true
         locationLabel.text = "개최지 : \(exposition.location)"
+        
+        durationLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        durationLabel.adjustsFontForContentSizeCategory = true
         durationLabel.text = "개최 기간 : \(exposition.duration)"
+        
+        descriptionLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        descriptionLabel.adjustsFontForContentSizeCategory = true
         descriptionLabel.text = exposition.description
     }
     

--- a/Expo1900/Expo1900/Sources/Controllers/MainViewController.swift
+++ b/Expo1900/Expo1900/Sources/Controllers/MainViewController.swift
@@ -18,6 +18,8 @@ final class MainViewController: UIViewController {
     @IBOutlet private weak var presentKoreanContentsButton: UIButton!
     @IBOutlet private weak var rightFlagImageView: UIImageView!
 
+    private let appDelegate = UIApplication.shared.delegate as? AppDelegate ?? AppDelegate()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setupImages()
@@ -28,6 +30,12 @@ final class MainViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
+        appDelegate.isVerticalOrientationBlocked = true
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        appDelegate.isVerticalOrientationBlocked = false
     }
     
     private func fetchExpositionData() {

--- a/Expo1900/Expo1900/Sources/Controllers/NavigationController.swift
+++ b/Expo1900/Expo1900/Sources/Controllers/NavigationController.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+class NavigationController: UINavigationController {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return self.topViewController?.supportedInterfaceOrientations ?? [.all]
+    }
+}

--- a/Expo1900/Expo1900/Sources/Models/ContentCell.swift
+++ b/Expo1900/Expo1900/Sources/Models/ContentCell.swift
@@ -6,12 +6,17 @@ class ContentCell: UITableViewCell {
     @IBOutlet weak var descriptionLabel: UILabel!
     
     func setup(content: Content) {
-        descriptionLabel.numberOfLines = 0
+        titleLabel.numberOfLines = 0
         titleLabel.font = .preferredFont(forTextStyle: .title1)
-        accessoryType = .disclosureIndicator
-        
-        contentImageView.image = UIImage(named: content.imageName)
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.text = content.name
+        
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.font = .preferredFont(forTextStyle: .body)
+        descriptionLabel.adjustsFontForContentSizeCategory = true
         descriptionLabel.text = content.shortDescription
+        
+        accessoryType = .disclosureIndicator
+        contentImageView.image = UIImage(named: content.imageName)
     }
 }

--- a/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
@@ -126,7 +126,7 @@
         <!--Navigation Controller-->
         <scene sceneID="aFJ-zC-ldi">
             <objects>
-                <navigationController id="aOg-tw-4yI" sceneMemberID="viewController">
+                <navigationController id="aOg-tw-4yI" customClass="NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="HFI-21-ac5">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4w7-23-imF">
-                                <rect key="frame" x="16" y="88" width="382" height="808"/>
+                                <rect key="frame" x="16" y="104" width="382" height="768"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ptJ-aw-LYo">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="450.5"/>
@@ -100,9 +100,10 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="4w7-23-imF" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="0wN-kP-uDO"/>
+                            <constraint firstAttribute="bottom" relation="lessThanOrEqual" secondItem="4w7-23-imF" secondAttribute="bottom" constant="24" id="2DY-UL-Pdk"/>
                             <constraint firstItem="4w7-23-imF" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" constant="-16" id="STv-gl-FBc"/>
-                            <constraint firstAttribute="bottom" secondItem="4w7-23-imF" secondAttribute="bottom" id="fdy-Nh-bCm"/>
-                            <constraint firstItem="4w7-23-imF" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="sCU-VJ-eNs"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="4w7-23-imF" secondAttribute="bottom" priority="750" constant="20" id="fdy-Nh-bCm"/>
+                            <constraint firstItem="4w7-23-imF" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="16" id="sCU-VJ-eNs"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="메인" id="kvw-ew-uVP"/>
@@ -232,16 +233,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FEp-IU-GDa">
-                                <rect key="frame" x="16" y="88" width="382" height="774"/>
+                                <rect key="frame" x="16" y="104" width="382" height="768"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="W2o-gT-Wf7">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="334.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="W2o-gT-Wf7">
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="140.5"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Yg-ec-GeM">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="304"/>
+                                                <rect key="frame" x="57.5" y="0.0" width="267" height="100"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="200" id="Jvn-EW-Gl8"/>
+                                                </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="K4e-Sb-fXW">
-                                                <rect key="frame" x="0.0" y="314" width="382" height="20.5"/>
+                                                <rect key="frame" x="170.5" y="120" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -252,6 +256,7 @@
                                 <constraints>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="width" secondItem="FEp-IU-GDa" secondAttribute="width" id="Eya-O4-3FR"/>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="height" secondItem="FEp-IU-GDa" secondAttribute="height" priority="250" id="T7b-2z-Swp"/>
+                                    <constraint firstItem="W2o-gT-Wf7" firstAttribute="top" secondItem="hfB-SO-tn5" secondAttribute="top" constant="16" id="UG3-6G-N9c"/>
                                     <constraint firstAttribute="trailing" secondItem="W2o-gT-Wf7" secondAttribute="trailing" id="kML-4I-YMA"/>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="leading" secondItem="FEp-IU-GDa" secondAttribute="leading" id="l8m-mj-dfS"/>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="top" secondItem="FEp-IU-GDa" secondAttribute="top" id="y4b-Ya-Oyk"/>
@@ -265,9 +270,10 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="4Y6-Jm-NyL" firstAttribute="trailing" secondItem="FEp-IU-GDa" secondAttribute="trailing" constant="16" id="A4p-N5-FQd"/>
-                            <constraint firstItem="4Y6-Jm-NyL" firstAttribute="bottom" secondItem="FEp-IU-GDa" secondAttribute="bottom" id="LZB-iU-E0j"/>
+                            <constraint firstItem="4Y6-Jm-NyL" firstAttribute="bottom" secondItem="FEp-IU-GDa" secondAttribute="bottom" priority="750" constant="20" id="LZB-iU-E0j"/>
+                            <constraint firstAttribute="bottom" relation="lessThanOrEqual" secondItem="FEp-IU-GDa" secondAttribute="bottom" constant="24" id="MVk-q2-yDI"/>
                             <constraint firstItem="FEp-IU-GDa" firstAttribute="leading" secondItem="4Y6-Jm-NyL" secondAttribute="leading" constant="16" id="q0X-Nm-loe"/>
-                            <constraint firstItem="FEp-IU-GDa" firstAttribute="top" secondItem="4Y6-Jm-NyL" secondAttribute="top" id="rUS-gu-1D0"/>
+                            <constraint firstItem="FEp-IU-GDa" firstAttribute="top" secondItem="4Y6-Jm-NyL" secondAttribute="top" constant="16" id="rUS-gu-1D0"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="dWw-5a-XtU"/>

--- a/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="16" y="88" width="382" height="808"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ptJ-aw-LYo">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="430.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="450.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="박람회" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Lf-qO-vCJ">
                                                 <rect key="frame" x="169" y="0.0" width="44.5" height="20.5"/>
@@ -57,17 +57,17 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1JR-hj-lwZ">
-                                                <rect key="frame" x="76.5" y="400.5" width="229" height="30"/>
+                                                <rect key="frame" x="56.5" y="400.5" width="269" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AxW-Qs-gPa">
-                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="30" id="7BP-Ci-SGz"/>
+                                                            <constraint firstAttribute="width" constant="50" id="7BP-Ci-SGz"/>
                                                             <constraint firstAttribute="width" secondItem="AxW-Qs-gPa" secondAttribute="height" multiplier="1:1" id="wRD-Ia-a3s"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bKu-Bl-8dI">
-                                                        <rect key="frame" x="38" y="0.0" width="153" height="30"/>
+                                                        <rect key="frame" x="58" y="0.0" width="153" height="50"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
@@ -75,9 +75,9 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6OX-SG-hvc">
-                                                        <rect key="frame" x="199" y="0.0" width="30" height="30"/>
+                                                        <rect key="frame" x="219" y="0.0" width="50" height="50"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="30" id="5Uz-wt-hRv"/>
+                                                            <constraint firstAttribute="width" constant="50" id="5Uz-wt-hRv"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>

--- a/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Sources/Views/Base.lproj/Main.storyboard
@@ -163,23 +163,22 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bg0-Er-5Ji">
-                                                    <rect key="frame" x="8" y="54" width="80" height="80"/>
+                                                    <rect key="frame" x="8" y="32" width="124" height="124"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="80" id="VxF-r1-PMi"/>
-                                                        <constraint firstAttribute="height" constant="80" id="a2Y-iP-Ybv"/>
+                                                        <constraint firstAttribute="width" secondItem="bg0-Er-5Ji" secondAttribute="height" multiplier="1:1" id="VC1-Ge-oFv"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="olu-O3-DUg">
-                                                    <rect key="frame" x="104" y="16" width="282" height="156"/>
+                                                    <rect key="frame" x="148" y="16" width="238" height="156"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="075-c5-znO">
-                                                            <rect key="frame" x="0.0" y="0.0" width="282" height="20.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="238" height="20.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SHX-oD-Uww">
-                                                            <rect key="frame" x="0.0" y="139" width="282" height="17"/>
+                                                            <rect key="frame" x="0.0" y="139" width="238" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -193,6 +192,7 @@
                                                 <constraint firstItem="olu-O3-DUg" firstAttribute="top" secondItem="6mA-t2-xhi" secondAttribute="top" constant="16" id="2Jk-7b-JT7"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="olu-O3-DUg" secondAttribute="trailing" constant="8" id="FEL-6M-SFQ"/>
                                                 <constraint firstItem="bg0-Er-5Ji" firstAttribute="centerY" secondItem="6mA-t2-xhi" secondAttribute="centerY" id="jXh-Ga-vEF"/>
+                                                <constraint firstItem="bg0-Er-5Ji" firstAttribute="width" secondItem="6mA-t2-xhi" secondAttribute="width" multiplier="30%" id="n5R-Dw-J0G"/>
                                                 <constraint firstAttribute="bottom" secondItem="olu-O3-DUg" secondAttribute="bottom" constant="16" id="vXJ-WX-UPR"/>
                                             </constraints>
                                         </tableViewCellContentView>
@@ -222,7 +222,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gfd-vI-0IS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="107" y="92"/>
+            <point key="canvasLocation" x="105.79710144927537" y="91.741071428571431"/>
         </scene>
         <!--Content Detail View Controller-->
         <scene sceneID="7yZ-Xz-nfB">
@@ -256,7 +256,7 @@
                                 <constraints>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="width" secondItem="FEp-IU-GDa" secondAttribute="width" id="Eya-O4-3FR"/>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="height" secondItem="FEp-IU-GDa" secondAttribute="height" priority="250" id="T7b-2z-Swp"/>
-                                    <constraint firstItem="W2o-gT-Wf7" firstAttribute="top" secondItem="hfB-SO-tn5" secondAttribute="top" constant="16" id="UG3-6G-N9c"/>
+                                    <constraint firstItem="W2o-gT-Wf7" firstAttribute="top" secondItem="FEp-IU-GDa" secondAttribute="top" id="UG3-6G-N9c"/>
                                     <constraint firstAttribute="trailing" secondItem="W2o-gT-Wf7" secondAttribute="trailing" id="kML-4I-YMA"/>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="leading" secondItem="FEp-IU-GDa" secondAttribute="leading" id="l8m-mj-dfS"/>
                                     <constraint firstItem="W2o-gT-Wf7" firstAttribute="top" secondItem="FEp-IU-GDa" secondAttribute="top" id="y4b-Ya-Oyk"/>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 <br>
 
 ## 👨‍👨‍👦‍👦 팀원 및 리뷰어
+| 민쏜 & Judy |
+| :--: |
+|<img src="https://i.imgur.com/LJKXXUG.jpg" width="400">|
+
 - **minsson**🎾 (@minsson) 
 - **Judy**🐰 (@Judy-999) 
 - 리뷰어: **하리보**🧸(@HARIBO)
@@ -34,12 +38,12 @@
 
 |메인화면 1|메인화면 2|
 |:------:|:-----:|
-| ![](https://i.imgur.com/EfQMVbH.png)| ![](https://i.imgur.com/pozoglJ.png)|
+|<img src="https://i.imgur.com/EfQMVbH.png" width="300">| <img src="https://i.imgur.com/pozoglJ.png" width="300">|
 
 
 |한국의 출품작 화면|출품작 상세 화면|
 |:-----------:|:----------:|
-| ![](https://i.imgur.com/Ve8UsMw.png) | ![](https://i.imgur.com/XBsY7a6.png)|
+|<img src="https://i.imgur.com/Ve8UsMw.png" width="300">|<img src="https://i.imgur.com/XBsY7a6.png" width="300">|
 
 
 <br>
@@ -507,7 +511,7 @@ contentTableView.rowHeight = UITableView.automaticDimension
 - 대부분 알맞게 나왔지만 세로로 된 이미지, 특히 **<해금>** 항목은 아래와 같이 이미지의 높이가 비정상적으로 크게 나오는 문제 발생
 
 
-<img src="https://i.imgur.com/T6guLYQ.png" width="50%" height="50%">
+<img src="https://i.imgur.com/T6guLYQ.png" width="300">
 
 <br><br>
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 
 # 만국박람회 프로젝트 🏛
 ## 🪧 목차
-- [📜 프로젝트 내용](#-프로젝트-내용)
 - [👨‍👨‍👦‍👦 팀원 및 리뷰어](#-팀원-및-리뷰어)
-- [🗓 타임라인](#-타임라인)
-- [🏗 프로젝트 구조](#-프로젝트-구조)
-- [⚡️ 트러블 슈팅](#%EF%B8%8F-트러블-슈팅)
+- [📜 프로젝트 내용](#-프로젝트-내용)
 - [📱 실행 화면](#-실행-화면)
+- [🏗 프로젝트 구조](#-프로젝트-구조)
+- [🗓 타임라인](#-타임라인)
+- [⚡️ [Step 2] 트러블 슈팅](#%EF%B8%8F-step-2-트러블-슈팅)
+- [⚡️ [Step 3] 트러블 슈팅](#%EF%B8%8F-step-3-트러블-슈팅)
 - [🔗 참고 링크](#-참고-링크)
+<br>
+
+## 👨‍👨‍👦‍👦 팀원 및 리뷰어
+- **minsson**🎾 (@minsson) 
+- **Judy**🐰 (@Judy-999) 
+- 리뷰어: **하리보**🧸(@HARIBO)
 <br>
 
 ## 📜 프로젝트 내용
@@ -19,10 +26,26 @@
 > 
 <br>
 
-## 👨‍👨‍👦‍👦 팀원 및 리뷰어
-- **minsson**🎾 (@minsson) 
-- **Judy**🐰 (@Judy-999) 
-- 리뷰어: **하리보**🧸(@HARIBO)
+## 📱 실행 화면
+
+| 앱 전체 구동화면 |
+| :--: |
+|![만국박람회_소개](https://user-images.githubusercontent.com/96630194/175500562-8e6aa740-5b78-4504-8d8d-84d587fc71df.gif)|
+
+|메인화면 1|메인화면 2|
+|:------:|:-----:|
+| ![](https://i.imgur.com/EfQMVbH.png)| ![](https://i.imgur.com/pozoglJ.png)|
+
+
+|한국의 출품작 화면|출품작 상세 화면|
+|:-----------:|:----------:|
+| ![](https://i.imgur.com/Ve8UsMw.png) | ![](https://i.imgur.com/XBsY7a6.png)|
+
+
+<br>
+
+## 🏗 프로젝트 구조
+![](https://i.imgur.com/jRIRS16.png)
 <br>
 
 ## 🗓 타임라인
@@ -55,33 +78,30 @@
 - 전달받은 데이터로 출품작 데이터 표시
 
 ### 2주차
-**6월 21일 (월):**
-**6월 22일 (화):**
-**6월 23일 (수):**
-**6월 24일 (목):**
+**6월 20일 (월):** : 리뷰를 기다리며 개인 공부(코드로 뷰 만들기)
+
+**6월 21일 (화):** : Step 2 리팩토링
+- 불필요한 프레임워크 제거
+- 메서드의 네이밍 또는 위치 변경
+- 같은 역할을 하는 메서드는 하나로 통합
+- 셀의 속성과 내용을 채우는 위치 변경
+
+**6월 22일 (수):** : Step 2 마무리 및 Step 3 시작
+- 셀의 높이를 동적으로 변경
+- 첫 번째 화면의 오리엔테이션을 세로로 고정
+- 버튼과 레이블에 다이나믹타입 적용
+
+**6월 23일 (목):** : Step 3 진행
+- 화면 오리엔테이션 고정하는 방식 변경
+- 오토레이아웃 오류 수정
+
+**6월 24일 (금):** : Step 3 PR 제출 및 README 작성
 <br>
 
-## 🏗 프로젝트 구조
-![](https://i.imgur.com/jRIRS16.png)
-<br>
-
-## 📱 실행 화면
-
-|메인화면 1|메인화면 2|
-|:------:|:-----:|
-| ![](https://i.imgur.com/PTsQQdM.png) | ![](https://i.imgur.com/xsI1KI1.png) |
-
-
-|한국의 출품작 화면|출품작 상세 화면|
-|:-----------:|:----------:|
-| ![](https://i.imgur.com/jXklHIW.png) | ![](https://i.imgur.com/thUc8JB.png) |
-
-<br>
-
-## ⚡️ 트러블 슈팅
+## ⚡️ [Step 2] 트러블 슈팅
 ### 1. 출품작 리스트 화면에서 출품작별 페이지로의 데이터 전달 방식
 
-#### 1) [문제점] 처음에 생각한 데이터 전달 방식
+#### [문제점] 처음에 생각한 데이터 전달 방식
 
 > **ContentViewController 내부에 프로퍼티를 생성하지 않고 데이터를 전달하는 방식**
 > 
@@ -110,14 +130,14 @@ private func setData(of data: Content) {
 ![](https://i.imgur.com/XPcRGBr.png)
 
 
-#### 2) [문제 원인] ViewController와 View에 대한 개념 이해 부족
+#### [문제 원인] ViewController와 View에 대한 개념 이해 부족
 - 구글링 결과, 아웃렛 변수들이 메모리에 올라가기 전 접근했기 때문에 에러가 발생했다는 글을 볼 수 있었음
     `@IBOutlet private weak var contentImageView: UIImageView!`
     `@IBOutlet private weak var descriptionLabel: UILabel!`
 - `guard let contentViewController = segue.destination as? ContentViewController else { return }` 라는 코드에서 에러가 발생하지 않는다는 것은 `contentViewController` 클래스의 인스턴스가 생성된 상태라는 것을 의미하고, 이는 메모리에도 올라간 상태라는 걸 의미한다고 생각함
 - `contentViewController` 클래스의 인스턴스가 생성되었다면, 내부의 아웃렛 변수도 초기화 되었을 것이라고 생각해, 메모리에 올라가기 전에 접근했다는 점을 이해하기 어려웠음
 
-#### 3) [개념 재정립] ViewController와 View는 별개의 개념
+#### [개념 재정립] ViewController와 View는 별개의 개념
 - ViewController의 인스턴스가 생성되었다고 해서 View가 생성된 것은 아님
 - 아웃렛 변수들은 View에서 코드로 가져오는 것이므로, View가 생성되지 않았다면 접근할 수 없음
 - ViewController 인스턴스 생성 -> View 생성하면서 `loadView()`를 호출 -> View 생성이 완료되면서 `viewDidLoad()`를 호출 -> 이 시점부터 View의 데이터에 접근 가능
@@ -130,7 +150,7 @@ private func setData(of data: Content) {
     ```
     
 
-#### 4) [해결책] 현재 프로젝트에서 사용한 방식
+#### [해결책] 현재 프로젝트에서 사용한 방식
 > **`ContentViewController`에 `private var content: Content?`를 정의**
 - `ContentViewController`에 `content` 저장 속성과 `receiveContentData(_:)` 메서드 정의
 - `KoreanContentListViewController`에서 `receiveContentData(_:)` 메서드를 통해 데이터를 전달받음
@@ -154,6 +174,7 @@ private func setData(of data: Content) {
     }
 
 ```
+<br>
 
 ### 2. 출품작 리스트 화면에서 출품작별 페이지로의 화면이동 
 #### 방식 1) prepare(for:sender:)만 사용 
@@ -169,6 +190,8 @@ private func setData(of data: Content) {
 
 > **프로젝트 내에서는 두 번째 방식인 performSegue, prepare 사용** <br>
 > 근거: segue를 이용해 화면 이동을 구현하는 것이 가장 직관적으로 느껴졌음. 테이블 뷰의 델리게이트 함수인 `tableView(_: didSelectRowAt:)` 함수 역시 사용해보는 것이 좋다고 생각함.
+
+<br>
 
 ### 3. catch 에러처리
 - 디코딩하는 동안 발생할 수 있는 에러를 처리하기 위해 `DataHandlingError` 타입을 구현
@@ -186,7 +209,7 @@ do {
 ```
 - 단순히 어떤 에러인지 출력하는 코드라면, 이러한 처리 방식이 어떤 것을 의도한 것인지 의문이 생김
 - 현재 프로젝트에서는 별도로 처리할 동작이 없어 이런 처리 방식도 유효하지만, 현업에서는 어떻게 처리하는지 알고 싶어짐
-
+<br>
 
 ### 4. tableView(_:cellForRowAt:) 메서드의 로직
 
@@ -219,6 +242,7 @@ func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> U
 - 셀의 속성은 계속 변경할 필요 없이 한 번만 설정하면 되는데`tableView(_:cellForRowAt:)` 함수가 불릴 때마다 불필요하게 코드가 실행됨
 - 하나의 함수에서 셀의 내용과 속성을 동시에 설정하는 것이 적절하지 못하다고 생각함
 - 위 두 가지 이유로 다른 곳에서 처리 가능한지 고민
+<br>
 
 ### 5. 메인화면의 setAllImages 메서드에서 이미지를 불러오는 방법
 
@@ -231,6 +255,8 @@ func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> U
 
 > **프로젝트 내에서는 #imageLiteral을 사용**
 > 근거: 현재 관련 이미지가 정적으로 고정된 상태이므로, 코드 내에서 이미지를 시각적으로 볼 수 있는 #imageLiteral이 더 유용하다고 생각함
+
+<br>
 
 ### 6. prepare 함수의 위치
 - `prepare` 함수를 통해 segue로 화면이 이동하기 전에 작업 수행 가능 
@@ -249,11 +275,292 @@ func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 
 
 따라서 UITableViewDelegate를 확장한 내부에서 `tableView(_: didSelectRowAt:)` 함수 정의부 상단에 배치하는게 적절하다고 생각해 위치를 현재 위치로 결정함
+<br>
 
 ### 7. segue의 네이밍
 - 스토리보드에서 테이블 뷰인 한국의 출품작 화면에서 출품작 상세 화면으로 이동하는 segue를 지정 
 - `ContentViewController`로 넘어간다는 의미로 **contentViewSegue**로 식별자를 지정 
 - 방향성을 나타내는 `to`나 다른 표현을 사용하는지 segue의 네이밍 컨벤션이 궁금해짐
+<br>
+
+## ⚡️ [Step 3] 트러블 슈팅
+### 1. 메인 화면의 오리엔테이션 고정
+#### [문제점]
+- 첫 번째 화면, 즉 메인 화면은 세로로 고정하는 요구사항이 존재
+- 이를 적용하기 위해 다음과 같은 시도를 했으나 해결되지 않는 문제가 발생함
+<br>
+
+#### 1) 첫 번째 시도
+- `AppDelegate`에서 세로로 고정하는지 확인하는 `Bool` 변수인 **isVerticalOrientationBlocked**를 선언
+- `application(_:supportedInterfaceOrientationsFor:)` 메서드에서 방향을 결정하는 로직 작성
+
+```swift
+var isVerticalOrientationBlocked = true
+
+func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    if isVerticalOrientationBlocked {
+	return .portrait
+    } else {
+	return .all
+    }
+}
+```
+
+<br>
+
+- 첫 번째 뷰 컨트롤러인 `MainViewController`에서 `AppDelegate`의 인스턴스를 가져옴
+- 뷰가 생길 때(`viewWillApper`) 세로 고정을 설정
+- 뷰가 사라질 때(`viewWillDisappear`) 세로 고정 풀기
+
+```swift
+// MainViewController.swift
+private let appDelegate = UIApplication.shared.delegate as? AppDelegate ?? AppDelegate()
+
+override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    appDelegate.isVerticalOrientationBlocked = true
+}
+
+override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    appDelegate.isVerticalOrientationBlocked = false
+}
+```
+
+- 테스트 결과 메인 화면은 세로로 고정이 되고, 다른 뷰는 회전 가능 확인
+<br>
+
+#### [문제점]
+- 회전한 상태로 이동을 하면 다음 뷰는 세로로 고정이 되지 않은 상태임에도 바로 회전이 적용되지 않음
+- 하지만 다시 회전을 반복하면 적용이 돼있음을 확인 가능
+<br>
+
+#### 첫 번째 시도의 결과
+> - 첫 번째 화면 세로 고정 잘 적용됨
+> - 첫 번재 화면에서 가로로 회전 후 두 번째 화면으로 넘어가면 화면 전환이 바로 적용되지 않음
+> - 두 번째 화면에서 가로로 회전 후 첫 번째 화면으로 돌아오면 세로 고정이 바로 적용되지 않음
+> - 위 두 가지 경우 모두 바로 적용만 안 될 뿐 다시 회전해보면 적용이 되어 있음
+
+<br>
+
+#### [고민한 점]
+- 뷰의 라이프 사이클을 혼동하여 화면의 오리엔테이션을 적용하는 시점이 문제일 수 있다고 생각해서 해결해보려 함
+<br>
+
+![](https://i.imgur.com/0on04L0.png)
+
+<br>
+
+- 위 사진과 같이 함수가 호출되는 순서와 시점을 확인하면서 아래와 같은 경우로 실험함
+<br>
+
+ |세로고정 적용|세로고정 해제|
+ |:--------:|:-------:|
+ | 첫 번째 뷰의 `willAppear`  | 첫 번째 뷰의 `willDisapper` |
+ | 첫 번째 뷰의 `willAppear`  | 첫 번째 뷰의 `DidDisapper`  |
+ | 첫 번째 뷰의 `viewDidLoad` | 첫 번째 뷰의 `willDisapper` |
+ |  첫 번째 뷰의 `viewLoad`   | 첫 번째 뷰의 `willDisapper` |
+ | 첫 번째 뷰의 `willAppear`  |  두 번째 뷰의 `willAppear`  |
+ | 첫 번째 뷰의 `viewDidLoad` | 두 번째 뷰의 `viewDidLoad`  |
+
+- 위의 모든 경우를 해봤음에도 해결되지 않음
+- 적용 시점의 문제는 아닌 것으로 결론을 내림
+
+<br>
+
+#### 2) 두 번째 시도
+
+- 위의 문제와 더불어 `AppDelegate`의 인스턴스를 직접 사용하는 것이 마음에 걸림
+- `UIViewController`에 **뷰 컨트롤러가 지원하는 인터페이스 방향**인 `supportedInterfaceOrientations` 프로퍼티가 있음을 알게 됨
+<br>
+
+#### [문제점]
+- `supportedInterfaceOrientations`의 공식문서를 살펴 본 결과 해당 뷰의 루트 뷰 또는 최상위 뷰의 오리엔테이션을 따라감
+- 따라서 오리엔테이션을 변경하는 뷰의 `supportedInterfaceOrientations` 값을 설정해도 최상위 뷰인 네비게이션 뷰 컨트롤러의 오리엔테이션이 다르면 변경한 오리엔테이션이 적용되지 않음
+<br>
+
+```swift
+class NavigationController: UINavigationController {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return self.topViewController?.supportedInterfaceOrientations ?? [.all]
+    }
+}
+```
+
+#### [해결방법]
+
+- `UINavigationController`을 상속한 클래스를 생성
+- 스토리보드의 `NavigationViewController`에 클래스 연결
+- `supportedInterfaceOrientations`는 네비게이션 스택의 가장 위의 뷰(=`topViewController`)의 오리엔테이션 값을 가지도록 설정
+- 결과: 세로 고정 적용 됨
+<br>
+
+#### [고민한 점]
+- 혹시 이전 방법의 문제도 루트 뷰의 오리엔테이션을 따라가기 때문인지 확인해봄
+<br>
+
+#### 두 번째 시도의 결과
+> - 첫 번째 화면 세로 고정 잘 적용됨
+> - 첫 번재 화면에서 가로로 회전 후 두 번째 화면으로 넘어가면 화면 전환이 바로 적용 안 됨 -> 해결 ❌
+> - 두 번째 화면에서 가로로 회전 후 첫 번째 화면으로 돌아오면 세로 고정이 바로 적용되지 않던 문제 -> 해결 ⭕️
+
+- 두 번째 문제는 해결이 되고, 첫 번째 문제는 해결되지 않음
+<br>
+
+#### 3) 세 번째 시도
+
+- 혹시 시뮬레이터에서 회전을 감지하는 오류가 있는건가 의문이 듦
+- 직접 기기에 빌드해서 확인해 본 결과 기기에서도 해당 문제는 해결되지 않음
+
+<br>
+
+#### 해결되지 않은 문제의 예시
+![](https://i.imgur.com/3Lmcqls.gif)
+
+
+<br>
+
+### 2. 테이블 뷰 셀 이미지의 크기
+
+#### [원했던 것]
+1) 셀 이미지 width를 superView의 width 대비 30% 이다
+2) 우측의 다이나믹 타입이 적용된 텍스트 크기가 달라지더라도 이미지는 superView의 width 대비 30%를 유지한다
+<br>
+
+#### [문제점] 잘못된 제약 설정
+1) `Content Image View.width = 0.3 x width @1000`
+    - 위에서 작성한 `원했던 것`을 실행하기 위한 제약 조건
+    - 결과적으로 올바른 제약이었음
+2) `Content Image View.height = 100 @750`
+    - 이미지의 비율이 유지되기 때문에, 논리적으로는 없어도 생각했던 제약
+    - 컴파일러가 높이를 지정해주지 않으면 에러를 발생시키기에 설정
+    - 이 제약식의 priority는 750이므로, 무조건 너비에 대한 조건이 우선할 것이라고 생각함
+    - 따라서, 이 제약식에는 어떤 숫자를 넣어도 아무런 효력이 발생하지 않을 것이라고 생각함
+    - 결과적으로 이 제약이 문제였음
+
+> 처음에는 모두 잘 설정된 것으로 보였으나, 이미지 높이를 200 등으로 변경하니, 
+> **화면 너비 비율에 대한 조건을 무시하고 높이에 맞춰 이미지 크기가 변경하는 것을 알 수 있었음**
+<br>
+
+#### [문제원인] 서로 상충하지 않는 제약에 대한 우선순위 지정과 논리 오류
+1) `Content Image View.width = 0.3 x width @1000`
+2) `Content Image View.height = 100 @750`
+
+- 위 제약식 2개는 `같은 대상`에 대해 제약을 거는 것이 아니므로, 우선순위를 설정하는 것은 의미가 없음
+- 유동적인 width와 달리 height는 고정적이므로 서로 상충하는 조건이지만 Autolayout은 에러를 발생시키지 않음
+- 두 제약 조건 중 어떤 것이든 constant를 수정할 때마다 이미지 크기는 두 조건 중 하나를 따르며, 그 기준은 알 수 없었음
+    (constant를 바꾸다보면 몇 분 전과 같은 값임에도 불구하고 빌드한 결과물이 달라지는 경우가 있었음)
+<br>
+
+#### [개념재정립]
+- priority에 대한 설정은 서로 같은 대상을 지정할 때만 유효하다
+- Autolayout은 같은 대상에 대한 설정이 상충하지 않는 한 오류나 워닝을 표시하지 않는다
+<br>
+
+#### [해결책]
+너비가 유동적으로 변하는 것이 목적이므로, 높이는 너비에 비례하게 설정함
+
+> <전> `Content Image View.height = 100 @750`
+<후> `Content Image View.height = Content Image View.width`
+
+<br>
+
+### 3. 셀의 동적인 높이 설정과 스택 뷰의 Distribution 관계
+- 출품작의 설명이 길면 `'...'`으로 잘리는 경우가 있음
+- 요구사항에 따라 셀의 높이를 유동적으로 조절하도록 함
+
+```swift
+contentTableView.rowHeight = UITableView.automaticDimension
+```
+<br>
+
+#### [문제점]
+- 예상과 달리 셀의 높이가 조절되지 않음
+- 찾아본 결과 Constraint가 알맞게 적용되어 있어야 한다는 것을 알게 됐지만 해당 `Label`이 들어있는 스택 뷰의 Constraint는 문제를 찾을 수 없음
+
+
+#### [해결방법]
+- 혹시나 해서 스택 뷰의 distribution을 **Fill Proportionally**에서 **Equal Spacing**으로 변경
+- 셀의 유동적인 높이가 적용됨
+
+<br>
+
+- distribution 변경에 따른 셀 높이 변경가능 결과 
+> - **Fill**: 높이 유동적 가능은 하지만 Constraint 경고
+> - **Fill Equally**: 늘어나긴 하는데 길어지면 이상함
+> - **Fill Proportionally**: 셀의 기본 높이로 나옴
+> - **Equal Spacing**: 높이 유동적 가능
+> - **Equal Centering**: 높이 유동적 가능
+
+<br>
+
+#### [의문]
+- **Fill Proportionally**일 때는 적용되지 않은 문제를 고민
+- `Label`의 크기가 늘어나야 셀의 높이가 늘어날 수 있는데 **Fill Proportionally**는 `Label`에 맞춰 글자를 우겨넣었다고 생각함
+- 위의 생각이 맞는건지, 왜 distribution의 차이에 따라 셀의 유동적인 높이 적용 여부가 달라지는지 궁금함
+
+<br>
+
+### 4. 출품작 상세 페이지의 이미지 높이
+#### [문제점]
+- 마지막 뷰에는 출품작의 이미지와 설명이 들어있음 
+- 대부분 알맞게 나왔지만 세로로 된 이미지, 특히 **<해금>** 항목은 아래와 같이 이미지의 높이가 비정상적으로 크게 나오는 문제 발생
+
+
+<img src="https://i.imgur.com/T6guLYQ.png" width="50%" height="50%">
+
+<br><br>
+
+- 이미지의 높이를 일괄적으로 지정해주면 잘 나오던 다른 항목의 이미지의 높이가 변경되는 문제가 생김
+- 높이가 높은 경우에만 제약을 주고 싶었음
+
+#### [해결방법]
+- 이미지 높이 제약을 200으로 설정한 후 `Equal`이 아닌 `Less Than Or Equal`로 하여 이미지의 높이가 큰 경우에만 해당 제약을 받도록 함
+
+<br>
+
+### 5. 아이폰 기종별 화면 하단의 여백 차이
+#### [문제점]
+- 물리적 버튼이 없는 신형 아이폰 기종에서 스크롤뷰의 끝단과 화면 하단 간의 간격이 의도했던 것보다 더 떨어짐
+
+ | |물리적 홈버튼이 있는 모델|물리적 홈버튼이 없는 모델|
+ |:---: |:--------:|:-------:|
+ | 수정 전 |<img src="https://i.imgur.com/8TseuH1.png" width="300">| <img src="https://i.imgur.com/Hxso8kM.png" width="300">|
+ | 수정 후 | <img src="https://i.imgur.com/8TseuH1.png" width="300"> | <img src="https://i.imgur.com/kQyUJwU.png" width="300">|
+ 
+<br>
+
+#### [문제원인] 
+기종별 SafeArea의 영역 차이에 대한 고려 없이 물리적 홈버튼이 없는 모델만을 고려한 오토레이아웃 설정
+
+`Safe Area.bottom = Scroll View.bottom + 20`
+
+- 물리적 홈버튼이 있는 모델: SafeArea와 Super View의 bottom이 동일
+- 물리적 홈버튼이 없는 모델: SafeArea의 bottom이 Super View의 bottom에서 일정 간격 떨어져 있음
+
+##### Safe Area가 차지하는 높이
+물리적 홈버튼이 없는 모델
+- top : 44pt
+- bottom : 34pt
+
+물리적 홈버튼이 있는 모델
+- top : 20pt
+- bottom : 0pt
+<br>
+
+#### [해결방법]
+##### 수정 전:
+`Safe Area.bottom = Scroll View.bottom + 20 @750`
+##### 수정 후:
+`Safe Area.bottom = Scroll View.bottom + 20 @750`
+`Superview.bottom <= Scroll View.bottom + 24`
+
+##### 새로 추가한 `Superview.bottom <= Scroll View.bottom + 24`의 의미:
+
+1) 스크롤뷰의 하단과 화면의 하단 사이의 간격이 24 이하가 되도록 함
+    - 홈버튼이 없는 아이폰의 경우 기본적으로 SafeArea와 화면 하단 간의 거리가 있으므로, 이 제약 조건에 의해서 스크롤뷰의 하단과 화면의 하단 사이의 간격이 24 이하가 됨
+2) 위 조건이 만족된다면, 스크롤뷰의 하단과 화면의 하단 사이의 간격은 20임
+    - 홈버튼이 있는 아이폰의 경우 기본적으로 SafeArea와 화면 하단의 위치가 같으므로, 이 제약 조건에 의해서 스크롤뷰의 하단과 화면의 하단 사이의 간격이 20이 됨
 
 <br>
 
@@ -261,4 +568,5 @@ func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 [Table Views](https://developer.apple.com/documentation/uikit/views_and_controls/table_views) <br>
 [Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data(https://developer.apple.com/documentation/uikit/uitableview)) <br>
 [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder) <br>
-[Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)
+[Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types) <br>
+[supportedInterfaceOrientations](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations)


### PR DESCRIPTION
안녕하세요 하리보(@HARlBO) 민쏜과 Judy입니다 🤗
어느새 마지막 스텝이네요 🥹
그동안 친절하고 상세하게 리뷰해주셔서 감사해요 🥰
마지막까지 잘 부탁드립니다!

## 질문드리고 싶은 내용

### 1. 메인 화면의 오리엔테이션 고정
요구사항에서 첫 번째 화면 즉 메인 화면은 세로로 고정하도록 되어 있습니다. 이를 적용하기 위해 다음과 같은 시도를 했으나 해결되지 않는 문제가 있습니다.
<br>

#### 1) 첫 번째 시도
`AppDelegate`에서 세로로 고정하는지 확인하는 `Bool` 변수인 **isVerticalOrientationBlocked**를 두고 `application(_:supportedInterfaceOrientationsFor:)` 메서드에서 방향을 결정해줬습니다.

```swift
var isVerticalOrientationBlocked = true

func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
    if isVerticalOrientationBlocked {
	return .portrait
    } else {
	return .all
    }
}
```

<br>

이후 첫 번째 뷰 컨트롤러인 `MainViewController`에서 AppDelegate의 인스턴스를 가셔와서 뷰가 생길 때(`viewWillApper`) 세로 고정을 설정하고, 뷰가 사라질 때(`viewWillDisappear`) 고정을 풀도록 했습니다.

```swift
// MainViewController.swift
private let appDelegate = UIApplication.shared.delegate as? AppDelegate ?? AppDelegate()

override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    appDelegate.isVerticalOrientationBlocked = true
}

override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    appDelegate.isVerticalOrientationBlocked = false
}
```

테스트해 본 결과 메인 화면은 세로로 고정이 되고, 다른 뷰는 회전 가능했습니다.
<br>

하지만 테스트해보니 회전한 상태로 이동을 하면 다음 뷰는 세로로 고정이 되지 않은 상태임에도 바로 회전되지 않았습니다. 하지만 다시 회전을 반복하면 적용이 되었습니다.

#### 첫 번째 시도의 결과
> - 첫 번째 화면 세로 고정 잘 적용됨
> - 첫 번재 화면에서 가로로 회전 후 두 번째 화면으로 넘어가면 화면 전환이 바로 적용되지 않음
> - 두 번째 화면에서 가로로 회전 후 첫 번째 화면으로 돌아오면 세로 고정이 바로 적용되지 않음
> - 위 두 가지 경우 모두 바로 적용만 안 될 뿐 다시 회전해보면 적용이 되어 있음

<br>

혹시 저희가 뷰의 라이프 사이클을 혼동하여 화면의 오리엔테이션을 적용하는 시점이 문제일 수 있다고 생각했습니다.
<br>

![](https://i.imgur.com/0on04L0.png)

<br>

그래서 위 사진과 같이 함수가 호출되는 순서와 시점을 확인하면서 아래와 같은 경우로 모두 실험을 해봤습니다.
<br>

 |세로고정 적용|세로고정 해제|
 |:--------:|:-------:|
 | 첫 번째 뷰의 `willAppear`  | 첫 번째 뷰의 `willDisapper` |
 | 첫 번째 뷰의 `willAppear`  | 첫 번째 뷰의 `DidDisapper`  |
 | 첫 번째 뷰의 `viewDidLoad` | 첫 번째 뷰의 `willDisapper` |
 |  첫 번째 뷰의 `viewLoad`   | 첫 번째 뷰의 `willDisapper` |
 | 첫 번째 뷰의 `willAppear`  |  두 번째 뷰의 `willAppear`  |
 | 첫 번째 뷰의 `viewDidLoad` | 두 번째 뷰의 `viewDidLoad`  |

그 외에도 적용할 조합은 있지만 위의 모든 경우를 해봤음에도 해결되지 않았고 적용 시점의 문제는 아닌 것으로 결론을 내렸습니다.

<br>

#### 2) 두 번째 시도

위의 문제들도 존재하고 `AppDelegate`의 인스턴스를 직접 사용하는 것이 마음에 걸려 다른 방법을 알아보니 `UIViewController`에 **뷰 컨트롤러가 지원하는 인터페이스 방향**인 `supportedInterfaceOrientations` 프로퍼티가 있음을 알게 되어 사용해봤습니다. 

`supportedInterfaceOrientations`의 공식문서를 살펴 본 결과 해당 뷰의 루트 뷰 또는 최상위 뷰의 오리엔테이션을 따라간다고 되어 있습니다. 따라서 오리엔테이션을 변경하는 뷰의 `supportedInterfaceOrientations` 값을 설정해도 현재 최상위 뷰인 네비게이션 뷰 컨트롤러의 오리엔테이션이 다르면 변경한 오리엔테이션이 적용되지 않았습니다.
<br>

```swift
class NavigationController: UINavigationController {
    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return self.topViewController?.supportedInterfaceOrientations ?? [.all]
    }
}
```
그래서 `UINavigationController`을 상속한 클래스를 만들고 해당 `supportedInterfaceOrientations`는 네비게이션 스택의 가장 위의 뷰(=`topViewController`)의 오리엔테이션 값을 가지도록 설정하니 세로 고정이 되었습니다.

혹시 이전 방법의 문제들도 루트 뷰의 오리엔테이션을 따라가기 때문이었을까 싶었지만 문제가 완전히 해결되진 못했습니다 🥲
<br>

#### 두 번째 시도의 결과
> - 첫 번째 화면 세로 고정 잘 적용됨
> - 첫 번재 화면에서 가로로 회전 후 두 번째 화면으로 넘어가면 화면 전환이 바로 적용 안 됨 -> 해결 ❌
> - 두 번째 화면에서 가로로 회전 후 첫 번째 화면으로 돌아오면 세로 고정이 바로 적용되지 않던 문제 -> 해결 ⭕️

<br>왜 두 번째 문제는 해결이 되고, 첫 번째 문제는 해결이 되지 않았는지 더 이유를 알 수 없게 되었습니다 😭
<br>

#### 3) 세 번째 시도

혹시 시뮬레이터에서 회전을 감지하는 부분에 오류가 있는건가 의문이 들어 직접 기기에 빌드해서 확인해 본 결과 기기에서도 해당 문제는 해결되지 않았습니다...

<br>

#### 해결되지 않은 문제의 예시
![](https://i.imgur.com/3Lmcqls.gif)

⁉️ 이 문제의 원인이 무엇인지, 해결할 수 있는 방법이 있는지 알고 싶습니다!

<br>

### 2. 셀의 동적인 높이 설정과 스택 뷰의 Distribution 관계
출품작의 설명이 길면 `'...'`으로 잘리는 경우가 있어 `Label`의 크기에 맞춰 셀의 높이를 유동적으로 조절해서 잘리지 않도록 했습니다.

```swift
contentTableView.rowHeight = UITableView.automaticDimension
```
<br>

하지만 예상과 달리 셀의 높이가 조정되지 않았고 찾아본 결과 Constraint가 알맞게 적용되어 있어야 한다는 것을 알게 됐지만, 해당 `Label`이 들어있는 스택 뷰의 Constraint는 문제가 없었습니다.


혹시나 해서 현재 **Fill Proportionally**인 스택 뷰의 distribution을 **Equal Spacing**으로 변경하니 셀의 유동적인 높이가 적용되었습니다...! 😬 
<br>

그래서 distribution을 바꾸면서 셀의 높이 변경 가능 여부를 확인해보니 다음과 같은 결과를 얻었습니다.
- **Fill**: 높이 유동적 가능은 하지만 Constraint 경고
- **Fill Equally**: 늘어나긴 하는데 길어지면 이상함
- **Fill Proportionally**: 셀의 기본 높이로 나옴
- **Equal Spacing**: 높이 유동적 가능
- **Equal Centering**: 높이 유동적 가능

<br>

**Fill Proportionally**일 때는 적용되지 않은 원인을 고민해보니 `Label`의 크기가 늘어나야 셀의 높이가 늘어날 수 있는데 **Fill Proportionally**는 `Label`에 맞춰 글자를 우겨넣었기 때문이라고 생각했습니다

⁉️ 위의 생각이 맞는건지, 왜 distribution의 차이에 따라 셀의 유동적인 높이 적용 여부가 달라지는지 궁금합니다!
