### PR TITLE
만국박람회 [STEP 2] inho, LJ

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -10,9 +10,9 @@
 		9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373329014A2300A3EAE7 /* JSON+Extension.swift */; };
 		900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */; };
 		9002373A29026F0000A3EAE7 /* ExhibitDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */; };
-		90C6E82528FE51220071FE83 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* Exposition.swift */; };
+		90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* ExpositionData.swift */; };
 		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
-		B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* Exhibit.swift */; };
+		B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* ExhibitData.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */; };
@@ -25,9 +25,9 @@
 		9002373329014A2300A3EAE7 /* JSON+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Extension.swift"; sourceTree = "<group>"; };
 		900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitTableViewCell.swift; path = Expo1900/Controller/ExhibitTableViewCell.swift; sourceTree = SOURCE_ROOT; };
 		9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitDetailViewController.swift; path = Expo1900/View/ExhibitDetailViewController.swift; sourceTree = SOURCE_ROOT; };
-		90C6E82428FE51220071FE83 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
+		90C6E82428FE51220071FE83 /* ExpositionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionData.swift; sourceTree = "<group>"; };
 		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
-		B2778F6528FE56FB00308D9E /* Exhibit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exhibit.swift; sourceTree = "<group>"; };
+		B2778F6528FE56FB00308D9E /* ExhibitData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitData.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,8 +60,8 @@
 		90C6E82628FE58290071FE83 /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				90C6E82428FE51220071FE83 /* Exposition.swift */,
-				B2778F6528FE56FB00308D9E /* Exhibit.swift */,
+				90C6E82428FE51220071FE83 /* ExpositionData.swift */,
+				B2778F6528FE56FB00308D9E /* ExhibitData.swift */,
 				9002373629014A5000A3EAE7 /* Extension */,
 			);
 			path = Model;
@@ -188,10 +188,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */,
-				B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */,
+				B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */,
 				9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
-				90C6E82528FE51220071FE83 /* Exposition.swift in Sources */,
+				90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */,
 				900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* ExpositionData.swift */; };
 		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
 		B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* ExhibitData.swift */; };
+		B2DD150F290690A700D92C76 /* ExpositionConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DD150E290690A700D92C76 /* ExpositionConstant.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */; };
@@ -28,6 +29,7 @@
 		90C6E82428FE51220071FE83 /* ExpositionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionData.swift; sourceTree = "<group>"; };
 		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
 		B2778F6528FE56FB00308D9E /* ExhibitData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitData.swift; sourceTree = "<group>"; };
+		B2DD150E290690A700D92C76 /* ExpositionConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionConstant.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,6 +62,7 @@
 		90C6E82628FE58290071FE83 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B2DD150E290690A700D92C76 /* ExpositionConstant.swift */,
 				90C6E82428FE51220071FE83 /* ExpositionData.swift */,
 				B2778F6528FE56FB00308D9E /* ExhibitData.swift */,
 				9002373629014A5000A3EAE7 /* Extension */,
@@ -190,6 +193,7 @@
 				B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */,
 				B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */,
 				9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */,
+				B2DD150F290690A700D92C76 /* ExpositionConstant.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */,
 				900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373329014A2300A3EAE7 /* JSON+Extension.swift */; };
+		900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */; };
 		90C6E82528FE51220071FE83 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* Exposition.swift */; };
 		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
 		B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* Exhibit.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		9002373329014A2300A3EAE7 /* JSON+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Extension.swift"; sourceTree = "<group>"; };
+		900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitTableViewCell.swift; path = Expo1900/Controller/ExhibitTableViewCell.swift; sourceTree = SOURCE_ROOT; };
 		90C6E82428FE51220071FE83 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
 		B2778F6528FE56FB00308D9E /* Exhibit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exhibit.swift; sourceTree = "<group>"; };
@@ -69,6 +71,7 @@
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */,
+				B222546D29019E67001DA9DE /* ExhibitViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -76,8 +79,8 @@
 		90C6E82828FE58AA0071FE83 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */,
 				C79FF4BA2589F401005FB0FD /* Main.storyboard */,
-				B222546D29019E67001DA9DE /* ExhibitViewController.swift */,
 				C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */,
 			);
 			path = View;
@@ -186,6 +189,7 @@
 				9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				90C6E82528FE51220071FE83 /* Exposition.swift in Sources */,
+				900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 			);

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373329014A2300A3EAE7 /* JSON+Extension.swift */; };
 		900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */; };
 		9002373A29026F0000A3EAE7 /* ExhibitDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */; };
+		9002376429076EB400A3EAE7 /* NumberFormatter+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002376329076EB400A3EAE7 /* NumberFormatter+Extension.swift */; };
 		90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* ExpositionData.swift */; };
 		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
 		B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* ExhibitData.swift */; };
@@ -26,6 +27,7 @@
 		9002373329014A2300A3EAE7 /* JSON+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Extension.swift"; sourceTree = "<group>"; };
 		900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitTableViewCell.swift; path = Expo1900/Controller/ExhibitTableViewCell.swift; sourceTree = SOURCE_ROOT; };
 		9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitDetailViewController.swift; path = Expo1900/View/ExhibitDetailViewController.swift; sourceTree = SOURCE_ROOT; };
+		9002376329076EB400A3EAE7 /* NumberFormatter+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NumberFormatter+Extension.swift"; sourceTree = "<group>"; };
 		90C6E82428FE51220071FE83 /* ExpositionData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionData.swift; sourceTree = "<group>"; };
 		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
 		B2778F6528FE56FB00308D9E /* ExhibitData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitData.swift; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				9002373329014A2300A3EAE7 /* JSON+Extension.swift */,
+				9002376329076EB400A3EAE7 /* NumberFormatter+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -197,6 +200,7 @@
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */,
 				900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */,
+				9002376429076EB400A3EAE7 /* NumberFormatter+Extension.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				9002373A29026F0000A3EAE7 /* ExhibitDetailViewController.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373329014A2300A3EAE7 /* JSON+Extension.swift */; };
 		90C6E82528FE51220071FE83 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* Exposition.swift */; };
+		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
 		B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* Exhibit.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
@@ -21,6 +22,7 @@
 /* Begin PBXFileReference section */
 		9002373329014A2300A3EAE7 /* JSON+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Extension.swift"; sourceTree = "<group>"; };
 		90C6E82428FE51220071FE83 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
+		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
 		B2778F6528FE56FB00308D9E /* Exhibit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exhibit.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 			isa = PBXGroup;
 			children = (
 				C79FF4BA2589F401005FB0FD /* Main.storyboard */,
+				B222546D29019E67001DA9DE /* ExhibitViewController.swift */,
 				C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */,
 			);
 			path = View;
@@ -178,6 +181,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */,
 				B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */,
 				9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
 		B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* ExhibitData.swift */; };
 		B2DD150F290690A700D92C76 /* ExpositionConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DD150E290690A700D92C76 /* ExpositionConstant.swift */; };
+		B2DD1511290787ED00D92C76 /* ExpositionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DD1510290787ED00D92C76 /* ExpositionError.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */; };
@@ -32,6 +33,7 @@
 		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
 		B2778F6528FE56FB00308D9E /* ExhibitData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExhibitData.swift; sourceTree = "<group>"; };
 		B2DD150E290690A700D92C76 /* ExpositionConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionConstant.swift; sourceTree = "<group>"; };
+		B2DD1510290787ED00D92C76 /* ExpositionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExpositionError.swift; path = Extension/ExpositionError.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -65,6 +67,7 @@
 		90C6E82628FE58290071FE83 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B2DD1510290787ED00D92C76 /* ExpositionError.swift */,
 				B2DD150E290690A700D92C76 /* ExpositionConstant.swift */,
 				90C6E82428FE51220071FE83 /* ExpositionData.swift */,
 				B2778F6528FE56FB00308D9E /* ExhibitData.swift */,
@@ -197,6 +200,7 @@
 				B2778F6628FE56FB00308D9E /* ExhibitData.swift in Sources */,
 				9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */,
 				B2DD150F290690A700D92C76 /* ExpositionConstant.swift in Sources */,
+				B2DD1511290787ED00D92C76 /* ExpositionError.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				90C6E82528FE51220071FE83 /* ExpositionData.swift in Sources */,
 				900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,23 +7,25 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373329014A2300A3EAE7 /* JSON+Extension.swift */; };
 		90C6E82528FE51220071FE83 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* Exposition.swift */; };
 		B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* Exhibit.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
-		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
+		C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */; };
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9002373329014A2300A3EAE7 /* JSON+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Extension.swift"; sourceTree = "<group>"; };
 		90C6E82428FE51220071FE83 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		B2778F6528FE56FB00308D9E /* Exhibit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exhibit.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C79FF4B82589F401005FB0FD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionViewController.swift; sourceTree = "<group>"; };
 		C79FF4BB2589F401005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -41,11 +43,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9002373629014A5000A3EAE7 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				9002373329014A2300A3EAE7 /* JSON+Extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		90C6E82628FE58290071FE83 /* Model */ = {
 			isa = PBXGroup;
 			children = (
 				90C6E82428FE51220071FE83 /* Exposition.swift */,
 				B2778F6528FE56FB00308D9E /* Exhibit.swift */,
+				9002373629014A5000A3EAE7 /* Extension */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -55,7 +66,7 @@
 			children = (
 				C79FF4B42589F401005FB0FD /* AppDelegate.swift */,
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
-				C79FF4B82589F401005FB0FD /* ViewController.swift */,
+				C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -168,7 +179,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */,
-				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
+				9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */,
+				C79FF4B92589F401005FB0FD /* ExpositionViewController.swift in Sources */,
 				90C6E82528FE51220071FE83 /* Exposition.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9002373429014A2300A3EAE7 /* JSON+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373329014A2300A3EAE7 /* JSON+Extension.swift */; };
 		900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */; };
+		9002373A29026F0000A3EAE7 /* ExhibitDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */; };
 		90C6E82528FE51220071FE83 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C6E82428FE51220071FE83 /* Exposition.swift */; };
 		B222546E29019E67001DA9DE /* ExhibitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B222546D29019E67001DA9DE /* ExhibitViewController.swift */; };
 		B2778F6628FE56FB00308D9E /* Exhibit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2778F6528FE56FB00308D9E /* Exhibit.swift */; };
@@ -23,6 +24,7 @@
 /* Begin PBXFileReference section */
 		9002373329014A2300A3EAE7 /* JSON+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Extension.swift"; sourceTree = "<group>"; };
 		900237372901A0E200A3EAE7 /* ExhibitTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitTableViewCell.swift; path = Expo1900/Controller/ExhibitTableViewCell.swift; sourceTree = SOURCE_ROOT; };
+		9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitDetailViewController.swift; path = Expo1900/View/ExhibitDetailViewController.swift; sourceTree = SOURCE_ROOT; };
 		90C6E82428FE51220071FE83 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		B222546D29019E67001DA9DE /* ExhibitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ExhibitViewController.swift; path = Expo1900/Controller/ExhibitViewController.swift; sourceTree = SOURCE_ROOT; };
 		B2778F6528FE56FB00308D9E /* Exhibit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exhibit.swift; sourceTree = "<group>"; };
@@ -72,6 +74,7 @@
 				C79FF4B62589F401005FB0FD /* SceneDelegate.swift */,
 				C79FF4B82589F401005FB0FD /* ExpositionViewController.swift */,
 				B222546D29019E67001DA9DE /* ExhibitViewController.swift */,
+				9002373929026F0000A3EAE7 /* ExhibitDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -192,6 +195,7 @@
 				900237382901A0E200A3EAE7 /* ExhibitTableViewCell.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
+				9002373A29026F0000A3EAE7 /* ExhibitDetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class ExhibitTableViewCell: UITableViewCell {
+final class ExhibitTableViewCell: UITableViewCell {
     @IBOutlet private weak var exhibitImageView: UIImageView!
     @IBOutlet private weak var exhibitNameLabel: UILabel!
     @IBOutlet private weak var exhibitShortDescriptionLabel: UILabel!

--- a/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
@@ -1,0 +1,11 @@
+//  ExhibitTableViewCell.swift
+//  Expo1900
+//  Created by inho, LJ  on 2022/10/21.
+
+import UIKit
+
+class ExhibitTableViewCell: UITableViewCell {
+    @IBOutlet weak var exhibitImageView: UIImageView!
+    @IBOutlet weak var exhibitNameLabel: UILabel!
+    @IBOutlet weak var exhibitShortDescriptionLabel: UILabel!
+}

--- a/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
@@ -5,7 +5,14 @@
 import UIKit
 
 class ExhibitTableViewCell: UITableViewCell {
-    @IBOutlet weak var exhibitImageView: UIImageView!
-    @IBOutlet weak var exhibitNameLabel: UILabel!
-    @IBOutlet weak var exhibitShortDescriptionLabel: UILabel!
+    @IBOutlet private weak var exhibitImageView: UIImageView!
+    @IBOutlet private weak var exhibitNameLabel: UILabel!
+    @IBOutlet private weak var exhibitShortDescriptionLabel: UILabel!
+    
+    func configureCell(with exhibit: ExhibitData) {
+        self.exhibitNameLabel.text = exhibit.name
+        self.exhibitShortDescriptionLabel.text = exhibit.shortDescription
+        self.exhibitImageView.image = exhibit.image
+        self.exhibitNameLabel.font = ExpositionConstant.exhibitCellTitleFont
+    }
 }

--- a/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitTableViewCell.swift
@@ -10,9 +10,9 @@ class ExhibitTableViewCell: UITableViewCell {
     @IBOutlet private weak var exhibitShortDescriptionLabel: UILabel!
     
     func configureCell(with exhibit: ExhibitData) {
-        self.exhibitNameLabel.text = exhibit.name
-        self.exhibitShortDescriptionLabel.text = exhibit.shortDescription
         self.exhibitImageView.image = exhibit.image
+        self.exhibitNameLabel.text = exhibit.name
         self.exhibitNameLabel.font = ExpositionConstant.exhibitCellTitleFont
+        self.exhibitShortDescriptionLabel.text = exhibit.shortDescription
     }
 }

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -15,14 +15,15 @@ final class ExhibitViewController: UIViewController {
         exhibitTableView.delegate = self
         exhibitTableView.dataSource = self
         navigationItem.title = ExpositionConstant.exhibitTitleText
-        
-        guard let exhibitData = JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName,
-                                                  to: [ExhibitData].self)
-        else {
-            return
+
+        do {
+            exhibits = try JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName,
+                                                          to: [ExhibitData].self)
+        } catch ExpositionError.invalidAsset {
+            print(ExpositionError.invalidAsset.rawValue)
+        } catch {
+            print(error.localizedDescription)
         }
-        
-        exhibits = exhibitData
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -56,16 +56,17 @@ extension ExhibitViewController: UITableViewDataSource {
 
 extension ExhibitViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let exhibitData: ExhibitData = exhibits[indexPath.row]
         guard let nextViewController: ExhibitDetailViewController =
                 self.storyboard?.instantiateViewController(
-                    withIdentifier: ExpositionConstant.exhibitDetailViewController
-                ) as? ExhibitDetailViewController
-        else {
+                    identifier: ExpositionConstant.exhibitDetailViewController,
+                    creator: { coder in
+                        return ExhibitDetailViewController(exhibitData: exhibitData, coder: coder)
+                    }
+        ) else {
             return
         }
-        
-        nextViewController.fetchExhibitData(exhibits[indexPath.row])
-        
+
         self.navigationController?.pushViewController(nextViewController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 class ExhibitViewController: UIViewController {
     @IBOutlet weak var exhibitTableView: UITableView!
     let cellIdentifier: String = "exhibitCell"
-    var exhibits: [Exhibit] = []
+    var exhibits: [ExhibitData] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,7 +16,7 @@ class ExhibitViewController: UIViewController {
         exhibitTableView.dataSource = self
         navigationItem.title = "한국의 출품작"
         
-        guard let exhibitData = JSONDecoder.parse(assetName: "items", to: [Exhibit].self) else {
+        guard let exhibitData = JSONDecoder.parse(assetName: "items", to: [ExhibitData].self) else {
             return
         }
         
@@ -37,7 +37,7 @@ extension ExhibitViewController: UITableViewDataSource {
             return cell
         }
         
-        let exhibit: Exhibit = exhibits[indexPath.row]
+        let exhibit: ExhibitData = exhibits[indexPath.row]
         
         cell.exhibitNameLabel.text = exhibit.name
         cell.exhibitShortDescriptionLabel.text = exhibit.shortDescription

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -16,7 +16,9 @@ class ExhibitViewController: UIViewController {
         exhibitTableView.dataSource = self
         navigationItem.title = ExpositionConstant.exhibitTitleText
         
-        guard let exhibitData = JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName, to: [ExhibitData].self) else {
+        guard let exhibitData = JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName,
+                                                  to: [ExhibitData].self)
+        else {
             return
         }
         
@@ -30,7 +32,10 @@ extension ExhibitViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell: ExhibitTableViewCell = exhibitTableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? ExhibitTableViewCell else {
+        guard let cell: ExhibitTableViewCell =
+                exhibitTableView.dequeueReusableCell(withIdentifier: cellIdentifier,
+                                                     for: indexPath) as? ExhibitTableViewCell
+        else {
             let cell = UITableViewCell()
             cell.textLabel?.text = ExpositionConstant.cellErrorMessage
             
@@ -46,7 +51,11 @@ extension ExhibitViewController: UITableViewDataSource {
 
 extension ExhibitViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let nextViewController: ExhibitDetailViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpositionConstant.exhibitDetailViewController) as? ExhibitDetailViewController else {
+        guard let nextViewController: ExhibitDetailViewController =
+                self.storyboard?.instantiateViewController(
+                    withIdentifier: ExpositionConstant.exhibitDetailViewController)
+                as? ExhibitDetailViewController
+        else {
             return
         }
         

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class ExhibitViewController: UIViewController {
     @IBOutlet weak var exhibitTableView: UITableView!
-    let cellIdentifier: String = "exhibitCell"
+    let cellIdentifier: String = ExpositionConstant.exhibitCell
     var exhibits: [ExhibitData] = []
 
     override func viewDidLoad() {
@@ -14,9 +14,9 @@ class ExhibitViewController: UIViewController {
         
         exhibitTableView.delegate = self
         exhibitTableView.dataSource = self
-        navigationItem.title = "한국의 출품작"
+        navigationItem.title = ExpositionConstant.exhibitTitleText
         
-        guard let exhibitData = JSONDecoder.parse(assetName: "items", to: [ExhibitData].self) else {
+        guard let exhibitData = JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName, to: [ExhibitData].self) else {
             return
         }
         
@@ -49,7 +49,7 @@ extension ExhibitViewController: UITableViewDataSource {
 
 extension ExhibitViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let nextViewController: ExhibitDetailViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitDetailViewController") as? ExhibitDetailViewController else {
+        guard let nextViewController: ExhibitDetailViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpositionConstant.exhibitDetailViewController) as? ExhibitDetailViewController else {
             return
         }
         

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -7,7 +7,20 @@ import UIKit
 final class ExhibitViewController: UIViewController {
     @IBOutlet private weak var exhibitTableView: UITableView!
     private let cellIdentifier: String = ExpositionConstant.exhibitCell
-    private var exhibits: [ExhibitData] = []
+    private let exhibits: [ExhibitData]
+    
+    required init?(coder: NSCoder) {
+        guard let exhibitInformation = JSONDecoder.parse(
+            asset: ExpositionConstant.exhibitAssetName,
+            to: [ExhibitData].self
+        ) else {
+            return nil
+        }
+        
+        exhibits = exhibitInformation
+        
+        super.init(coder: coder)
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,29 +28,6 @@ final class ExhibitViewController: UIViewController {
         exhibitTableView.delegate = self
         exhibitTableView.dataSource = self
         navigationItem.title = ExpositionConstant.exhibitTitleText
-        
-        fetchExhibitsData()
-    }
-    
-    func fetchExhibitsData() {
-        do {
-            exhibits = try JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName,
-                                                          to: [ExhibitData].self)
-        } catch ExpositionError.invalidAsset {
-            showAlert(message: ExpositionError.invalidAsset.rawValue)
-        } catch {
-            showAlert(message: error.localizedDescription)
-        }
-    }
-    
-    func showAlert(message: String) {
-        let alert: UIAlertController = UIAlertController(title: ExpositionConstant.alertTitle,
-                                                         message: message,
-                                                         preferredStyle: .alert)
-        let okAction: UIAlertAction = UIAlertAction(title: ExpositionConstant.alertActionTitle,
-                                                    style: .default)
-        alert.addAction(okAction)
-        present(alert, animated: true)
     }
 }
 
@@ -68,8 +58,8 @@ extension ExhibitViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let nextViewController: ExhibitDetailViewController =
                 self.storyboard?.instantiateViewController(
-                    withIdentifier: ExpositionConstant.exhibitDetailViewController)
-                as? ExhibitDetailViewController
+                    withIdentifier: ExpositionConstant.exhibitDetailViewController
+                ) as? ExhibitDetailViewController
         else {
             return
         }

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -11,8 +11,14 @@ class ExhibitViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         exhibitTableView.dataSource = self
+        
+        guard let exhibitData = JSONDecoder.parse(assetName: "items", to: [Exhibit].self) else {
+            return
+        }
+        
+        exhibits = exhibitData
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -15,15 +15,29 @@ final class ExhibitViewController: UIViewController {
         exhibitTableView.delegate = self
         exhibitTableView.dataSource = self
         navigationItem.title = ExpositionConstant.exhibitTitleText
-
+        
+        fetchExhibitsData()
+    }
+    
+    func fetchExhibitsData() {
         do {
             exhibits = try JSONDecoder.parse(asset: ExpositionConstant.exhibitAssetName,
                                                           to: [ExhibitData].self)
         } catch ExpositionError.invalidAsset {
-            print(ExpositionError.invalidAsset.rawValue)
+            showAlert(message: ExpositionError.invalidAsset.rawValue)
         } catch {
-            print(error.localizedDescription)
+            showAlert(message: error.localizedDescription)
         }
+    }
+    
+    func showAlert(message: String) {
+        let alert: UIAlertController = UIAlertController(title: ExpositionConstant.alertTitle,
+                                                         message: message,
+                                                         preferredStyle: .alert)
+        let okAction: UIAlertAction = UIAlertAction(title: ExpositionConstant.alertActionTitle,
+                                                    style: .default)
+        alert.addAction(okAction)
+        present(alert, animated: true)
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -12,6 +12,7 @@ class ExhibitViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        exhibitTableView.delegate = self
         exhibitTableView.dataSource = self
         navigationItem.title = "한국의 출품작"
         
@@ -43,5 +44,17 @@ extension ExhibitViewController: UITableViewDataSource {
         cell.exhibitImageView.image = exhibit.image
         
         return cell
+    }
+}
+
+extension ExhibitViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let nextViewController: ExhibitDetailViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitDetailViewController") as? ExhibitDetailViewController else {
+            return
+        }
+        
+        nextViewController.exhibitData = exhibits[indexPath.row]
+        
+        self.navigationController?.pushViewController(nextViewController, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -1,0 +1,14 @@
+//  ExhibitViewController.swift
+//  Expo1900
+//  Created by inho, LJ  on 2022/10/21.
+
+import UIKit
+
+class ExhibitViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        
+    }
+}

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -5,10 +5,36 @@
 import UIKit
 
 class ExhibitViewController: UIViewController {
+    @IBOutlet weak var exhibitTableView: UITableView!
+    let cellIdentifier: String = "exhibitCell"
+    var exhibits: [Exhibit] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        exhibitTableView.dataSource = self
+    }
+}
+
+extension ExhibitViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return exhibits.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell: ExhibitTableViewCell = exhibitTableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? ExhibitTableViewCell else {
+            let cell = UITableViewCell()
+            cell.textLabel?.text = "잘못된 셀"
+            
+            return cell
+        }
         
+        let exhibit: Exhibit = exhibits[indexPath.row]
+        
+        cell.exhibitNameLabel.text = exhibit.name
+        cell.exhibitShortDescriptionLabel.text = exhibit.shortDescription
+        cell.exhibitImageView.image = exhibit.image
+        
+        return cell
     }
 }

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -13,6 +13,7 @@ class ExhibitViewController: UIViewController {
         super.viewDidLoad()
         
         exhibitTableView.dataSource = self
+        navigationItem.title = "한국의 출품작"
         
         guard let exhibitData = JSONDecoder.parse(assetName: "items", to: [Exhibit].self) else {
             return

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -32,7 +32,7 @@ extension ExhibitViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell: ExhibitTableViewCell = exhibitTableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? ExhibitTableViewCell else {
             let cell = UITableViewCell()
-            cell.textLabel?.text = "잘못된 셀"
+            cell.textLabel?.text = ExpositionConstant.cellErrorMessage
             
             return cell
         }
@@ -42,6 +42,7 @@ extension ExhibitViewController: UITableViewDataSource {
         cell.exhibitNameLabel.text = exhibit.name
         cell.exhibitShortDescriptionLabel.text = exhibit.shortDescription
         cell.exhibitImageView.image = exhibit.image
+        cell.exhibitNameLabel.font = ExpositionConstant.exhibitCellTitleFont
         
         return cell
     }

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class ExhibitViewController: UIViewController {
+final class ExhibitViewController: UIViewController {
     @IBOutlet private weak var exhibitTableView: UITableView!
     private let cellIdentifier: String = ExpositionConstant.exhibitCell
     private var exhibits: [ExhibitData] = []

--- a/Expo1900/Expo1900/Controller/ExhibitViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExhibitViewController.swift
@@ -5,9 +5,9 @@
 import UIKit
 
 class ExhibitViewController: UIViewController {
-    @IBOutlet weak var exhibitTableView: UITableView!
-    let cellIdentifier: String = ExpositionConstant.exhibitCell
-    var exhibits: [ExhibitData] = []
+    @IBOutlet private weak var exhibitTableView: UITableView!
+    private let cellIdentifier: String = ExpositionConstant.exhibitCell
+    private var exhibits: [ExhibitData] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,11 +38,7 @@ extension ExhibitViewController: UITableViewDataSource {
         }
         
         let exhibit: ExhibitData = exhibits[indexPath.row]
-        
-        cell.exhibitNameLabel.text = exhibit.name
-        cell.exhibitShortDescriptionLabel.text = exhibit.shortDescription
-        cell.exhibitImageView.image = exhibit.image
-        cell.exhibitNameLabel.font = ExpositionConstant.exhibitCellTitleFont
+        cell.configureCell(with: exhibit)
         
         return cell
     }
@@ -54,7 +50,7 @@ extension ExhibitViewController: UITableViewDelegate {
             return
         }
         
-        nextViewController.exhibitData = exhibits[indexPath.row]
+        nextViewController.fetchExhibitData(exhibits[indexPath.row])
         
         self.navigationController?.pushViewController(nextViewController, animated: true)
     }

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -20,8 +20,15 @@ class ExpositionViewController: UIViewController {
         super.viewDidLoad()
         
         expositionData = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: Exposition.self)
-        
         configureView()
+    }
+    
+    @IBAction func showExhibitButtonPressed(_ sender: UIButton) {
+        guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitViewController") as? ExhibitViewController else {
+            return
+        }
+        
+        self.navigationController?.pushViewController(nextViewController, animated: true)
     }
     
     func configureView() {

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -20,15 +20,7 @@ class ExpositionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let dataAsset: NSDataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
-            return
-        }
-        
-        do {
-            self.exposition = try JSONDecoder.jsonDecoder.decode(Exposition.self, from: dataAsset.data)
-        } catch {
-            print(error.localizedDescription)
-        }
+        exposition = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: Exposition.self)
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -14,12 +14,12 @@ class ExpositionViewController: UIViewController {
     @IBOutlet weak var leftFlagImageView: UIImageView!
     @IBOutlet weak var showExhibitButton: UIButton!
     @IBOutlet weak var rightFlagImageView: UIImageView!
-    var expositionData: Exposition?
+    var expositionData: ExpositionData?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        expositionData = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: Exposition.self)
+        expositionData = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: ExpositionData.self)
         configureView()
     }
     

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -38,7 +38,8 @@ final class ExpositionViewController: UIViewController {
         let alert: UIAlertController = UIAlertController(title: ExpositionConstant.alertTitle,
                                                          message: message,
                                                          preferredStyle: .alert)
-        let okAction: UIAlertAction = UIAlertAction(title: ExpositionConstant.alertActionTitle, style: .default)
+        let okAction: UIAlertAction = UIAlertAction(title: ExpositionConstant.alertActionTitle,
+                                                    style: .default)
         alert.addAction(okAction)
         present(alert, animated: true)
     }

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -18,17 +18,29 @@ final class ExpositionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        fetchExpositionData()
+    }
+    
+    func fetchExpositionData() {
         do {
             expositionData = try JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName,
-                                               to: ExpositionData.self)
+                                                   to: ExpositionData.self)
+            configureView()
         } catch ExpositionError.invalidAsset {
-            print(ExpositionError.invalidAsset.rawValue)
+            showAlert(message: ExpositionError.invalidAsset.rawValue)
         } catch {
-            print(error.localizedDescription)
+            showAlert(message: error.localizedDescription)
         }
-
-        configureView()
+    }
+    
+    func showAlert(message: String) {
+        let alert: UIAlertController = UIAlertController(title: ExpositionConstant.alertTitle,
+                                                         message: message,
+                                                         preferredStyle: .alert)
+        let okAction: UIAlertAction = UIAlertAction(title: ExpositionConstant.alertActionTitle, style: .default)
+        alert.addAction(okAction)
+        present(alert, animated: true)
     }
     
     @IBAction private  func showExhibitButtonPressed(_ sender: UIButton) {

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class ExpositionViewController: UIViewController {
+final class ExpositionViewController: UIViewController {
     @IBOutlet private weak var expositionTitleLabel: UILabel!
     @IBOutlet private weak var expositionImageView: UIImageView!
     @IBOutlet private weak var expositionVisitorsLabel: UILabel!
@@ -52,4 +52,3 @@ class ExpositionViewController: UIViewController {
         rightFlagImageView.image = exposition.flagImage
     }
 }
-

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -19,8 +19,15 @@ final class ExpositionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        expositionData = JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName,
-                                           to: ExpositionData.self)
+        do {
+            expositionData = try JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName,
+                                               to: ExpositionData.self)
+        } catch ExpositionError.invalidAsset {
+            print(ExpositionError.invalidAsset.rawValue)
+        } catch {
+            print(error.localizedDescription)
+        }
+
         configureView()
     }
     

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -19,12 +19,12 @@ class ExpositionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        expositionData = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: ExpositionData.self)
+        expositionData = JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName, to: ExpositionData.self)
         configureView()
     }
     
     @IBAction func showExhibitButtonPressed(_ sender: UIButton) {
-        guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitViewController") as? ExhibitViewController else {
+        guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpositionConstant.exhibitViewController) as? ExhibitViewController else {
             return
         }
         

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -5,16 +5,16 @@
 import UIKit
 
 class ExpositionViewController: UIViewController {
-    @IBOutlet weak var expositionTitleLabel: UILabel!
-    @IBOutlet weak var expositionImageView: UIImageView!
-    @IBOutlet weak var expositionVisitorsLabel: UILabel!
-    @IBOutlet weak var expositionLocationLabel: UILabel!
-    @IBOutlet weak var expositionDurationLabel: UILabel!
-    @IBOutlet weak var expositionDescriptionTextView: UITextView!
-    @IBOutlet weak var leftFlagImageView: UIImageView!
-    @IBOutlet weak var showExhibitButton: UIButton!
-    @IBOutlet weak var rightFlagImageView: UIImageView!
-    var expositionData: ExpositionData?
+    @IBOutlet private weak var expositionTitleLabel: UILabel!
+    @IBOutlet private weak var expositionImageView: UIImageView!
+    @IBOutlet private weak var expositionVisitorsLabel: UILabel!
+    @IBOutlet private weak var expositionLocationLabel: UILabel!
+    @IBOutlet private weak var expositionDurationLabel: UILabel!
+    @IBOutlet private weak var expositionDescriptionTextView: UITextView!
+    @IBOutlet private weak var leftFlagImageView: UIImageView!
+    @IBOutlet private weak var showExhibitButton: UIButton!
+    @IBOutlet private weak var rightFlagImageView: UIImageView!
+    private var expositionData: ExpositionData?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -23,7 +23,7 @@ class ExpositionViewController: UIViewController {
         configureView()
     }
     
-    @IBAction func showExhibitButtonPressed(_ sender: UIButton) {
+    @IBAction private  func showExhibitButtonPressed(_ sender: UIButton) {
         guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpositionConstant.exhibitViewController) as? ExhibitViewController else {
             return
         }
@@ -31,7 +31,7 @@ class ExpositionViewController: UIViewController {
         self.navigationController?.pushViewController(nextViewController, animated: true)
     }
     
-    func configureView() {
+    private func configureView() {
         guard let exposition = expositionData else {
             return
         }

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -19,12 +19,17 @@ class ExpositionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        expositionData = JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName, to: ExpositionData.self)
+        expositionData = JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName,
+                                           to: ExpositionData.self)
         configureView()
     }
     
     @IBAction private  func showExhibitButtonPressed(_ sender: UIButton) {
-        guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: ExpositionConstant.exhibitViewController) as? ExhibitViewController else {
+        guard let nextViewController: ExhibitViewController =
+                self.storyboard?.instantiateViewController(
+                    withIdentifier: ExpositionConstant.exhibitViewController)
+                as? ExhibitViewController
+        else {
             return
         }
         

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -1,10 +1,10 @@
-//  Expo1900 - ViewController.swift
+//  Expo1900 - ExpositionViewController.swift
 //  Created by inho, LJ
 //  Copyright © yagom academy. All rights reserved.
 
 import UIKit
 
-class ViewController: UIViewController {
+class ExpositionViewController: UIViewController {
     
     @IBOutlet weak var expositionTitleLabel: UILabel!
     @IBOutlet weak var expositionImageView: UIImageView!
@@ -15,9 +15,20 @@ class ViewController: UIViewController {
     @IBOutlet weak var leftFlagImageView: UIImageView!
     @IBOutlet weak var showExhibitButton: UIButton!
     @IBOutlet weak var rightFlagImageView: UIImageView!
+    var exposition: Exposition?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        guard let dataAsset: NSDataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
+            return
+        }
+        
+        do {
+            self.exposition = try JSONDecoder.jsonDecoder.decode(Exposition.self, from: dataAsset.data)
+        } catch {
+            print(error.localizedDescription)
+        }
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -14,11 +14,7 @@ final class ExpositionViewController: UIViewController {
     @IBOutlet private weak var leftFlagImageView: UIImageView!
     @IBOutlet private weak var showExhibitButton: UIButton!
     @IBOutlet private weak var rightFlagImageView: UIImageView!
-    private var expositionData: ExpositionData {
-        didSet {
-            configureView()
-        }
-    }
+    private let expositionData: ExpositionData
     
     required init?(coder: NSCoder) {
         guard let expositionInformation = JSONDecoder.parse(
@@ -35,14 +31,15 @@ final class ExpositionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
+        configureView()
     }
     
     @IBAction private  func showExhibitButtonPressed(_ sender: UIButton) {
         guard let nextViewController: ExhibitViewController =
                 self.storyboard?.instantiateViewController(
-                    withIdentifier: ExpositionConstant.exhibitViewController)
-                as? ExhibitViewController
+                    withIdentifier: ExpositionConstant.exhibitViewController
+                ) as? ExhibitViewController
         else {
             return
         }

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -14,34 +14,28 @@ final class ExpositionViewController: UIViewController {
     @IBOutlet private weak var leftFlagImageView: UIImageView!
     @IBOutlet private weak var showExhibitButton: UIButton!
     @IBOutlet private weak var rightFlagImageView: UIImageView!
-    private var expositionData: ExpositionData?
+    private var expositionData: ExpositionData {
+        didSet {
+            configureView()
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        guard let expositionInformation = JSONDecoder.parse(
+            asset: ExpositionConstant.expositionAssetName,
+            to: ExpositionData.self
+        ) else {
+            return nil
+        }
+        
+        expositionData = expositionInformation
+        
+        super.init(coder: coder)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        fetchExpositionData()
-    }
-    
-    func fetchExpositionData() {
-        do {
-            expositionData = try JSONDecoder.parse(asset: ExpositionConstant.expositionAssetName,
-                                                   to: ExpositionData.self)
-            configureView()
-        } catch ExpositionError.invalidAsset {
-            showAlert(message: ExpositionError.invalidAsset.rawValue)
-        } catch {
-            showAlert(message: error.localizedDescription)
-        }
-    }
-    
-    func showAlert(message: String) {
-        let alert: UIAlertController = UIAlertController(title: ExpositionConstant.alertTitle,
-                                                         message: message,
-                                                         preferredStyle: .alert)
-        let okAction: UIAlertAction = UIAlertAction(title: ExpositionConstant.alertActionTitle,
-                                                    style: .default)
-        alert.addAction(okAction)
-        present(alert, animated: true)
     }
     
     @IBAction private  func showExhibitButtonPressed(_ sender: UIButton) {
@@ -57,10 +51,6 @@ final class ExpositionViewController: UIViewController {
     }
     
     private func configureView() {
-        guard let expositionData = expositionData else {
-            return
-        }
-        
         expositionTitleLabel.text = expositionData.title
         expositionImageView.image = expositionData.expositionImage
         expositionVisitorsLabel.text = expositionData.visitorInformation

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -5,7 +5,6 @@
 import UIKit
 
 class ExpositionViewController: UIViewController {
-    
     @IBOutlet weak var expositionTitleLabel: UILabel!
     @IBOutlet weak var expositionImageView: UIImageView!
     @IBOutlet weak var expositionVisitorsLabel: UILabel!
@@ -15,12 +14,30 @@ class ExpositionViewController: UIViewController {
     @IBOutlet weak var leftFlagImageView: UIImageView!
     @IBOutlet weak var showExhibitButton: UIButton!
     @IBOutlet weak var rightFlagImageView: UIImageView!
-    var exposition: Exposition?
+    var expositionData: Exposition?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        exposition = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: Exposition.self)
+        expositionData = JSONDecoder.parse(assetName: "exposition_universelle_1900", to: Exposition.self)
+        
+        configureView()
+    }
+    
+    func configureView() {
+        guard let exposition = expositionData else {
+            return
+        }
+        
+        expositionTitleLabel.text = exposition.title
+        expositionImageView.image = exposition.expositionImage
+        expositionVisitorsLabel.text = exposition.visitorInformation
+        expositionLocationLabel.text = exposition.locationInformation
+        expositionDurationLabel.text = exposition.durationInformation
+        expositionDescriptionTextView.text = exposition.description
+        leftFlagImageView.image = exposition.flagImage
+        showExhibitButton.setTitle(exposition.exhibitButtonText, for: .normal)
+        rightFlagImageView.image = exposition.flagImage
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpositionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionViewController.swift
@@ -57,18 +57,18 @@ final class ExpositionViewController: UIViewController {
     }
     
     private func configureView() {
-        guard let exposition = expositionData else {
+        guard let expositionData = expositionData else {
             return
         }
         
-        expositionTitleLabel.text = exposition.title
-        expositionImageView.image = exposition.expositionImage
-        expositionVisitorsLabel.text = exposition.visitorInformation
-        expositionLocationLabel.text = exposition.locationInformation
-        expositionDurationLabel.text = exposition.durationInformation
-        expositionDescriptionTextView.text = exposition.description
-        leftFlagImageView.image = exposition.flagImage
-        showExhibitButton.setTitle(exposition.exhibitButtonText, for: .normal)
-        rightFlagImageView.image = exposition.flagImage
+        expositionTitleLabel.text = expositionData.title
+        expositionImageView.image = expositionData.expositionImage
+        expositionVisitorsLabel.text = expositionData.visitorInformation
+        expositionLocationLabel.text = expositionData.locationInformation
+        expositionDurationLabel.text = expositionData.durationInformation
+        expositionDescriptionTextView.text = expositionData.description
+        leftFlagImageView.image = expositionData.flagImage
+        showExhibitButton.setTitle(expositionData.exhibitButtonText, for: .normal)
+        rightFlagImageView.image = expositionData.flagImage
     }
 }

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -6,6 +6,16 @@ import UIKit
 
 class ViewController: UIViewController {
     
+    @IBOutlet weak var expositionTitleLabel: UILabel!
+    @IBOutlet weak var expositionImageView: UIImageView!
+    @IBOutlet weak var expositionVisitorsLabel: UILabel!
+    @IBOutlet weak var expositionLocationLabel: UILabel!
+    @IBOutlet weak var expositionDurationLabel: UILabel!
+    @IBOutlet weak var expositionDescriptionTextView: UITextView!
+    @IBOutlet weak var leftFlagImageView: UIImageView!
+    @IBOutlet weak var showExhibitButton: UIButton!
+    @IBOutlet weak var rightFlagImageView: UIImageView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }

--- a/Expo1900/Expo1900/Model/Exhibit.swift
+++ b/Expo1900/Expo1900/Model/Exhibit.swift
@@ -2,11 +2,16 @@
 //  Expo1900
 //  Created by inho, LJ  on 2022/10/18.
 
+import UIKit
+
 struct Exhibit: Decodable {
     let name: String
     let imageName: String
     let shortDescription: String
     let description: String
+    var image: UIImage? {
+        return UIImage(named: imageName)
+    }
     
     enum CodingKeys: String, CodingKey {
         case name

--- a/Expo1900/Expo1900/Model/ExhibitData.swift
+++ b/Expo1900/Expo1900/Model/ExhibitData.swift
@@ -1,10 +1,10 @@
-//  Exhibit.swift
+//  ExhibitData.swift
 //  Expo1900
 //  Created by inho, LJ  on 2022/10/18.
 
 import UIKit
 
-struct Exhibit: Decodable {
+struct ExhibitData: Decodable {
     let name: String
     let imageName: String
     let shortDescription: String

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -2,10 +2,30 @@
 //  Expo1900
 //  Created by inho, LJ on 2022/10/18.
 
+import UIKit
+
 struct Exposition: Decodable {
     let title: String
     let visitors: Int
     let location: String
     let duration: String
     let description: String
+    var visitorInformation: String {
+        return "방문객 : \(visitors) 명"
+    }
+    var locationInformation: String {
+        return "개최지 : \(location)"
+    }
+    var durationInformation: String {
+        return "개최 기간 : \(duration)"
+    }
+    var expositionImage: UIImage? {
+        return UIImage(named: "poster")
+    }
+    var flagImage: UIImage? {
+        return UIImage(named: "flag")
+    }
+    var exhibitButtonText: String {
+        return "한국의 출품작 보러가기"
+    }
 }

--- a/Expo1900/Expo1900/Model/ExpositionConstant.swift
+++ b/Expo1900/Expo1900/Model/ExpositionConstant.swift
@@ -1,0 +1,22 @@
+//  ExpositionConstant.swift
+//  Expo1900
+//  Created by inho, LJ on 2022/10/24.
+
+import UIKit
+
+enum ExpositionConstant {
+    static let exhibitCell: String = "exhibitCell"
+    
+    static let expositionAssetName: String = "exposition_universelle_1900"
+    static let exhibitAssetName: String = "items"
+    static let expositionImageName: String = "poster"
+    static let flagImageName: String = "flag"
+    
+    static let exhibitViewController: String = "exhibitViewController"
+    static let exhibitDetailViewController: String = "exhibitDetailViewController"
+    static let exhibitTitleText: String = "한국의 출품작"
+    
+    static let exhibitCellTitleFont: UIFont = .preferredFont(forTextStyle: .title1)
+}
+
+

--- a/Expo1900/Expo1900/Model/ExpositionConstant.swift
+++ b/Expo1900/Expo1900/Model/ExpositionConstant.swift
@@ -19,4 +19,7 @@ enum ExpositionConstant {
     static let cellErrorMessage: String = "잘못된 셀"
     
     static let exhibitCellTitleFont: UIFont = .preferredFont(forTextStyle: .title1)
+    
+    static let alertTitle: String = "오류"
+    static let alertActionTitle: String = "OK"
 }

--- a/Expo1900/Expo1900/Model/ExpositionConstant.swift
+++ b/Expo1900/Expo1900/Model/ExpositionConstant.swift
@@ -14,9 +14,9 @@ enum ExpositionConstant {
     
     static let exhibitViewController: String = "exhibitViewController"
     static let exhibitDetailViewController: String = "exhibitDetailViewController"
+
     static let exhibitTitleText: String = "한국의 출품작"
+    static let cellErrorMessage: String = "잘못된 셀"
     
     static let exhibitCellTitleFont: UIFont = .preferredFont(forTextStyle: .title1)
 }
-
-

--- a/Expo1900/Expo1900/Model/ExpositionData.swift
+++ b/Expo1900/Expo1900/Model/ExpositionData.swift
@@ -1,10 +1,10 @@
-//  Exposition.swift
+//  ExpositionData.swift
 //  Expo1900
 //  Created by inho, LJ on 2022/10/18.
 
 import UIKit
 
-struct Exposition: Decodable {
+struct ExpositionData: Decodable {
     let title: String
     let visitors: Int
     let location: String

--- a/Expo1900/Expo1900/Model/ExpositionData.swift
+++ b/Expo1900/Expo1900/Model/ExpositionData.swift
@@ -11,7 +11,11 @@ struct ExpositionData: Decodable {
     let duration: String
     let description: String
     var visitorInformation: String {
-        return "방문객 : \(visitors) 명"
+        guard let convertedVisitors = NumberFormatter.decimalFormatter.string(for: visitors) else {
+            return String(visitors)
+        }
+        
+        return "방문객 : \(convertedVisitors) 명"
     }
     var locationInformation: String {
         return "개최지 : \(location)"

--- a/Expo1900/Expo1900/Model/ExpositionData.swift
+++ b/Expo1900/Expo1900/Model/ExpositionData.swift
@@ -20,10 +20,10 @@ struct ExpositionData: Decodable {
         return "개최 기간 : \(duration)"
     }
     var expositionImage: UIImage? {
-        return UIImage(named: "poster")
+        return UIImage(named: ExpositionConstant.expositionImageName)
     }
     var flagImage: UIImage? {
-        return UIImage(named: "flag")
+        return UIImage(named: ExpositionConstant.flagImageName)
     }
     var exhibitButtonText: String {
         return "한국의 출품작 보러가기"

--- a/Expo1900/Expo1900/Model/Extension/ExpositionError.swift
+++ b/Expo1900/Expo1900/Model/Extension/ExpositionError.swift
@@ -2,6 +2,6 @@
 //  Expo1900
 //  Created by inho, LJ on 2022/10/25.
 
-enum ExpositionError:String, Error {
+enum ExpositionError: String, Error {
     case invalidAsset = "유효하지 않은 Asset입니다."
 }

--- a/Expo1900/Expo1900/Model/Extension/ExpositionError.swift
+++ b/Expo1900/Expo1900/Model/Extension/ExpositionError.swift
@@ -1,0 +1,7 @@
+//  ExpositionError.swift
+//  Expo1900
+//  Created by inho, LJ on 2022/10/25.
+
+enum ExpositionError:String, Error {
+    case invalidAsset = "유효하지 않은 Asset입니다."
+}

--- a/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
@@ -7,11 +7,15 @@ import UIKit
 extension JSONDecoder {
     static let jsonDecoder: JSONDecoder = .init()
     
-    static func parse<T: Decodable>(asset: String, to dataType: T.Type) throws -> T {
+    static func parse<T: Decodable>(asset: String, to dataType: T.Type) -> T? {
         guard let dataAsset: NSDataAsset = NSDataAsset(name: asset) else {
-            throw ExpositionError.invalidAsset
+            return nil
         }
         
-        return try jsonDecoder.decode(T.self, from: dataAsset.data)
+        do {
+            return try jsonDecoder.decode(dataType, from: dataAsset.data)
+        } catch {
+            return nil
+        }
     }
 }

--- a/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
@@ -7,15 +7,11 @@ import UIKit
 extension JSONDecoder {
     static let jsonDecoder: JSONDecoder = .init()
     
-    static func parse<T: Decodable>(asset: String, to dataType: T.Type) -> T? {
+    static func parse<T: Decodable>(asset: String, to dataType: T.Type) throws -> T {
         guard let dataAsset: NSDataAsset = NSDataAsset(name: asset) else {
-            return nil
+            throw ExpositionError.invalidAsset
         }
         
-        do {
-            return try Self.jsonDecoder.decode(T.self, from: dataAsset.data)
-        } catch {
-            return nil
-        }
+        return try jsonDecoder.decode(T.self, from: dataAsset.data)
     }
 }

--- a/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
@@ -6,4 +6,16 @@ import UIKit
 
 extension JSONDecoder {
     static let jsonDecoder: JSONDecoder = .init()
+    
+    static func parse<T: Decodable>(assetName: String, to dataType: T.Type) -> T? {
+        guard let dataAsset: NSDataAsset = NSDataAsset(name: assetName) else {
+            return nil
+        }
+        
+        do {
+            return try Self.jsonDecoder.decode(T.self, from: dataAsset.data)
+        } catch {
+            return nil
+        }
+    }
 }

--- a/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
@@ -7,8 +7,8 @@ import UIKit
 extension JSONDecoder {
     static let jsonDecoder: JSONDecoder = .init()
     
-    static func parse<T: Decodable>(assetName: String, to dataType: T.Type) -> T? {
-        guard let dataAsset: NSDataAsset = NSDataAsset(name: assetName) else {
+    static func parse<T: Decodable>(asset: String, to dataType: T.Type) -> T? {
+        guard let dataAsset: NSDataAsset = NSDataAsset(name: asset) else {
             return nil
         }
         

--- a/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/JSON+Extension.swift
@@ -1,0 +1,9 @@
+//  JSON+Extension.swift
+//  Expo1900
+//  Created by inho, LJ  on 2022/10/20.
+
+import UIKit
+
+extension JSONDecoder {
+    static let jsonDecoder: JSONDecoder = .init()
+}

--- a/Expo1900/Expo1900/Model/Extension/NumberFormatter+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/NumberFormatter+Extension.swift
@@ -1,0 +1,14 @@
+//  NumberFormatter+Extension.swift
+//  Expo1900
+//  Created by inho, LJ on 2022/10/25.
+
+import Foundation
+
+extension NumberFormatter {
+    static let decimalFormatter: NumberFormatter = {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        return numberFormatter
+    }()
+}

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -138,13 +138,38 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="CTH-hu-XQB">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="117" id="CTH-hu-XQB" customClass="ExhibitTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="117"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CTH-hu-XQB" id="sdv-3F-Cgi">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="117"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dx8-1U-JxX">
+                                                    <rect key="frame" x="8" y="0.0" width="125" height="117"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eQ9-dX-uc0">
+                                                    <rect key="frame" x="175" y="23" width="42" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Qy-20-1bp">
+                                                    <rect key="frame" x="175" y="69" width="42" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="exhibitImageView" destination="dx8-1U-JxX" id="qiM-eQ-QYh"/>
+                                            <outlet property="exhibitNameLabel" destination="eQ9-dX-uc0" id="2lS-pG-O14"/>
+                                            <outlet property="exhibitShortDescriptionLabel" destination="7Qy-20-1bp" id="2ba-bU-U0q"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
@@ -161,7 +186,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Mf4-oK-1kj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1933" y="117"/>
+            <point key="canvasLocation" x="1931.8840579710147" y="116.51785714285714"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="t7f-jh-1EM">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -183,6 +183,9 @@
                             <constraint firstItem="5a0-Xp-kpN" firstAttribute="trailing" secondItem="bcU-XE-3py" secondAttribute="trailing" id="nX2-lm-Fjb"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="exhibitTableView" destination="bcU-XE-3py" id="aih-5G-ESL"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Mf4-oK-1kj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,24 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5p9-5Z-Y1X">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QkO-g0-Q1I">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="549"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aTi-ZE-BE7">
+                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dIF-Lu-P8r">
+                                                <rect key="frame" x="103.5" y="30.5" width="207" height="50"/>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xtS-TY-iSg">
+                                                <rect key="frame" x="186.5" y="90.5" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OjF-wJ-Jof">
+                                                <rect key="frame" x="186.5" y="121" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBb-2l-Uug">
+                                                <rect key="frame" x="186.5" y="151.5" width="41.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="LE1-HP-wvM">
+                                                <rect key="frame" x="2" y="182" width="410.5" height="317"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</mutableString>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="azA-XX-JLf">
+                                                <rect key="frame" x="41.5" y="509" width="331" height="40"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zZ9-5J-cqf">
+                                                        <rect key="frame" x="0.0" y="0.0" width="53" height="40"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="zZ9-5J-cqf" secondAttribute="height" multiplier="4:3" id="Fdp-bb-hZd"/>
+                                                            <constraint firstAttribute="height" constant="40" id="cn0-AI-oEL"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5fS-5N-wGS">
+                                                        <rect key="frame" x="53" y="0.0" width="228" height="40"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                    </button>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KzD-YA-2QO">
+                                                        <rect key="frame" x="281" y="0.0" width="50" height="40"/>
+                                                    </imageView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="KzD-YA-2QO" firstAttribute="height" secondItem="zZ9-5J-cqf" secondAttribute="height" id="NWB-uK-NBg"/>
+                                                    <constraint firstItem="KzD-YA-2QO" firstAttribute="width" secondItem="zZ9-5J-cqf" secondAttribute="width" multiplier="0.943396" id="sfO-jX-jVc"/>
+                                                </constraints>
+                                            </stackView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="dIF-Lu-P8r" firstAttribute="width" secondItem="QkO-g0-Q1I" secondAttribute="width" multiplier="0.5" id="6Wf-vx-eOK"/>
+                                            <constraint firstItem="azA-XX-JLf" firstAttribute="width" secondItem="QkO-g0-Q1I" secondAttribute="width" multiplier="0.8" id="WGa-Oa-pds"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="QkO-g0-Q1I" firstAttribute="width" secondItem="5p9-5Z-Y1X" secondAttribute="width" id="0tz-Oy-BZg"/>
+                                    <constraint firstItem="QkO-g0-Q1I" firstAttribute="leading" secondItem="5p9-5Z-Y1X" secondAttribute="leading" id="3xS-Ow-QfD"/>
+                                    <constraint firstItem="QkO-g0-Q1I" firstAttribute="top" secondItem="5p9-5Z-Y1X" secondAttribute="top" id="8dk-Dp-Jbm"/>
+                                    <constraint firstAttribute="trailing" secondItem="QkO-g0-Q1I" secondAttribute="trailing" id="8uJ-1k-oIy"/>
+                                    <constraint firstAttribute="bottom" secondItem="QkO-g0-Q1I" secondAttribute="bottom" id="JP2-c8-yot"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="LbK-NZ-zlG"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="QmS-0M-A8x"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="5p9-5Z-Y1X" secondAttribute="trailing" id="XrM-3B-MNT"/>
+                            <constraint firstItem="5p9-5Z-Y1X" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="ZtS-rp-LQp"/>
+                            <constraint firstItem="5p9-5Z-Y1X" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="hzd-Iv-Ujf"/>
+                            <constraint firstItem="5p9-5Z-Y1X" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="jr0-yl-kSh"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="73.913043478260875" y="116.51785714285714"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,44 +14,44 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ExpositionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5p9-5Z-Y1X">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QkO-g0-Q1I">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="448.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="549"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aTi-ZE-BE7">
-                                                <rect key="frame" x="279.5" y="0.0" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dIF-Lu-P8r">
-                                                <rect key="frame" x="150" y="30.5" width="300" height="50"/>
+                                                <rect key="frame" x="103.5" y="30.5" width="207" height="50"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xtS-TY-iSg">
-                                                <rect key="frame" x="279.5" y="90.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="90.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OjF-wJ-Jof">
-                                                <rect key="frame" x="279.5" y="121" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="121" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBb-2l-Uug">
-                                                <rect key="frame" x="279.5" y="151.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="186.5" y="151.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="LE1-HP-wvM">
-                                                <rect key="frame" x="1.5" y="182" width="597.5" height="216.5"/>
+                                                <rect key="frame" x="2" y="182" width="410.5" height="317"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -57,22 +59,22 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="azA-XX-JLf">
-                                                <rect key="frame" x="60" y="408.5" width="480" height="40"/>
+                                                <rect key="frame" x="41.5" y="509" width="331" height="40"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zZ9-5J-cqf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="53.5" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="53" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="zZ9-5J-cqf" secondAttribute="height" multiplier="4:3" id="Fdp-bb-hZd"/>
                                                             <constraint firstAttribute="height" constant="40" id="cn0-AI-oEL"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5fS-5N-wGS">
-                                                        <rect key="frame" x="53.5" y="0.0" width="376" height="40"/>
+                                                        <rect key="frame" x="53" y="0.0" width="228" height="40"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KzD-YA-2QO">
-                                                        <rect key="frame" x="429.5" y="0.0" width="50.5" height="40"/>
+                                                        <rect key="frame" x="281" y="0.0" width="50" height="40"/>
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -193,6 +193,60 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Mf4-oK-1kj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1931.8840579710147" y="116.51785714285714"/>
+        </scene>
+        <!--Exhibit Detail View Controller-->
+        <scene sceneID="ORC-ii-qfK">
+            <objects>
+                <viewController id="mFr-PO-XYi" customClass="ExhibitDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="khM-dR-GKl">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sb3-oJ-oEJ">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GNT-mD-2mT">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Top-Nf-KPG">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="273"/>
+                                            </imageView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="lpY-R5-AP7">
+                                                <rect key="frame" x="0.0" y="273" width="414" height="545"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="GNT-mD-2mT" secondAttribute="trailing" id="9YA-Rb-Gh5"/>
+                                    <constraint firstItem="GNT-mD-2mT" firstAttribute="height" secondItem="XsZ-3A-KOQ" secondAttribute="height" priority="750" id="9mI-rE-maC"/>
+                                    <constraint firstAttribute="bottom" secondItem="GNT-mD-2mT" secondAttribute="bottom" id="CfU-Sr-xQ5"/>
+                                    <constraint firstItem="GNT-mD-2mT" firstAttribute="top" secondItem="Sb3-oJ-oEJ" secondAttribute="top" id="ap5-jS-pbe"/>
+                                    <constraint firstItem="GNT-mD-2mT" firstAttribute="leading" secondItem="Sb3-oJ-oEJ" secondAttribute="leading" id="hpS-fZ-0Gh"/>
+                                    <constraint firstItem="GNT-mD-2mT" firstAttribute="width" secondItem="XsZ-3A-KOQ" secondAttribute="width" id="kfS-pT-BKm"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="wJu-tk-oxz"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="XsZ-3A-KOQ"/>
+                            </scrollView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="YkR-Zw-ayX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="YkR-Zw-ayX" firstAttribute="bottom" secondItem="Sb3-oJ-oEJ" secondAttribute="bottom" id="39v-N9-hNm"/>
+                            <constraint firstItem="YkR-Zw-ayX" firstAttribute="trailing" secondItem="Sb3-oJ-oEJ" secondAttribute="trailing" id="BMG-8H-yeL"/>
+                            <constraint firstItem="Sb3-oJ-oEJ" firstAttribute="top" secondItem="YkR-Zw-ayX" secondAttribute="top" id="NCq-aq-nmd"/>
+                            <constraint firstItem="Sb3-oJ-oEJ" firstAttribute="leading" secondItem="YkR-Zw-ayX" secondAttribute="leading" id="hjE-mE-fyL"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fP6-1B-NYP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2953.6231884057975" y="116.51785714285714"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="t7f-jh-1EM">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -141,11 +141,11 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="exhibitCell" rowHeight="143" id="CTH-hu-XQB" customClass="ExhibitTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="exhibitCell" rowHeight="143" id="CTH-hu-XQB" customClass="ExhibitTableViewCell" customModule="Expo1900" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="44.5" width="414" height="143"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CTH-hu-XQB" id="sdv-3F-Cgi">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="143"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="143"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dx8-1U-JxX">
@@ -197,7 +197,7 @@
         <!--Exhibit Detail View Controller-->
         <scene sceneID="ORC-ii-qfK">
             <objects>
-                <viewController id="mFr-PO-XYi" customClass="ExhibitDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="exhibitDetailViewController" id="mFr-PO-XYi" customClass="ExhibitDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="khM-dR-GKl">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -243,6 +243,10 @@
                             <constraint firstItem="Sb3-oJ-oEJ" firstAttribute="leading" secondItem="YkR-Zw-ayX" secondAttribute="leading" id="hjE-mE-fyL"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="exhibitDescriptionTextView" destination="lpY-R5-AP7" id="qBO-wM-8yn"/>
+                        <outlet property="exhibitImageView" destination="Top-Nf-KPG" id="rzi-sO-6uD"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fP6-1B-NYP" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,57 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Exposition View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ExpositionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5p9-5Z-Y1X">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QkO-g0-Q1I">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="549"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="600" height="448.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aTi-ZE-BE7">
-                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="279.5" y="0.0" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dIF-Lu-P8r">
-                                                <rect key="frame" x="103.5" y="30.5" width="207" height="50"/>
+                                                <rect key="frame" x="150" y="30.5" width="300" height="50"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xtS-TY-iSg">
-                                                <rect key="frame" x="186.5" y="90.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="279.5" y="90.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OjF-wJ-Jof">
-                                                <rect key="frame" x="186.5" y="121" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="279.5" y="121" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kBb-2l-Uug">
-                                                <rect key="frame" x="186.5" y="151.5" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="279.5" y="151.5" width="41.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="LE1-HP-wvM">
-                                                <rect key="frame" x="2" y="182" width="410.5" height="317"/>
+                                                <rect key="frame" x="1.5" y="182" width="597.5" height="216.5"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -59,22 +57,22 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="azA-XX-JLf">
-                                                <rect key="frame" x="41.5" y="509" width="331" height="40"/>
+                                                <rect key="frame" x="60" y="408.5" width="480" height="40"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zZ9-5J-cqf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="53" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="53.5" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="zZ9-5J-cqf" secondAttribute="height" multiplier="4:3" id="Fdp-bb-hZd"/>
                                                             <constraint firstAttribute="height" constant="40" id="cn0-AI-oEL"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5fS-5N-wGS">
-                                                        <rect key="frame" x="53" y="0.0" width="228" height="40"/>
+                                                        <rect key="frame" x="53.5" y="0.0" width="376" height="40"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KzD-YA-2QO">
-                                                        <rect key="frame" x="281" y="0.0" width="50" height="40"/>
+                                                        <rect key="frame" x="429.5" y="0.0" width="50.5" height="40"/>
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -53,7 +53,7 @@
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="LE1-HP-wvM">
                                                 <rect key="frame" x="2" y="182" width="410.5" height="317"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <mutableString key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</mutableString>
+                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -109,6 +109,17 @@
                             <constraint firstItem="5p9-5Z-Y1X" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="jr0-yl-kSh"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="expositionDescriptionTextView" destination="LE1-HP-wvM" id="weC-aI-hp6"/>
+                        <outlet property="expositionDurationLabel" destination="kBb-2l-Uug" id="FN5-gL-cV1"/>
+                        <outlet property="expositionImageView" destination="dIF-Lu-P8r" id="HWf-79-24D"/>
+                        <outlet property="expositionLocationLabel" destination="OjF-wJ-Jof" id="DRT-6F-XrU"/>
+                        <outlet property="expositionTitleLabel" destination="aTi-ZE-BE7" id="WIe-5q-w7X"/>
+                        <outlet property="expositionVisitorsLabel" destination="xtS-TY-iSg" id="6pY-rT-kYg"/>
+                        <outlet property="leftFlagImageView" destination="zZ9-5J-cqf" id="2n6-mA-HOJ"/>
+                        <outlet property="rightFlagImageView" destination="KzD-YA-2QO" id="G7C-kd-VPv"/>
+                        <outlet property="showExhibitButton" destination="5fS-5N-wGS" id="NX3-RJ-7M3"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5p9-5Z-Y1X">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="QkO-g0-Q1I">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="549"/>
@@ -109,6 +109,7 @@
                             <constraint firstItem="5p9-5Z-Y1X" firstAttribute="bottom" secondItem="6Tk-OE-BBY" secondAttribute="bottom" id="jr0-yl-kSh"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="m0p-3e-CFd"/>
                     <connections>
                         <outlet property="expositionDescriptionTextView" destination="LE1-HP-wvM" id="weC-aI-hp6"/>
                         <outlet property="expositionDurationLabel" destination="kBb-2l-Uug" id="FN5-gL-cV1"/>
@@ -122,6 +123,24 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="984.05797101449286" y="116.51785714285714"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="t7f-jh-1EM">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="nuu-eU-bOG" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="K6o-7V-PLU">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="vZe-1p-9gG"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8HL-CO-Ccb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="73.913043478260875" y="116.51785714285714"/>
         </scene>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -148,25 +148,38 @@
                                             <rect key="frame" x="0.0" y="0.0" width="385.5" height="143"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dx8-1U-JxX">
-                                                    <rect key="frame" x="20" y="13" width="125" height="117"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eQ9-dX-uc0">
-                                                    <rect key="frame" x="172" y="38" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Qy-20-1bp">
-                                                    <rect key="frame" x="172" y="84" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
+                                                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" alignment="center" spacing="27" translatesAutoresizingMaskIntoConstraints="NO" id="Q5A-bb-AHM">
+                                                    <rect key="frame" x="20" y="13" width="193.5" height="117"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="dx8-1U-JxX">
+                                                            <rect key="frame" x="0.0" y="0.0" width="125" height="117"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" constant="125" id="rk3-1u-BfM"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="N14-IC-awr">
+                                                            <rect key="frame" x="152" y="25.5" width="41.5" height="66"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eQ9-dX-uc0">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Qy-20-1bp">
+                                                                    <rect key="frame" x="0.0" y="45.5" width="41.5" height="20.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                    </subviews>
+                                                </stackView>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="Q5A-bb-AHM" firstAttribute="centerY" secondItem="sdv-3F-Cgi" secondAttribute="centerY" id="ctM-E9-WEL"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="exhibitImageView" destination="dx8-1U-JxX" id="qiM-eQ-QYh"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="nuu-eU-bOG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -125,6 +125,43 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="984.05797101449286" y="116.51785714285714"/>
+        </scene>
+        <!--Exhibit View Controller-->
+        <scene sceneID="U94-nD-Xfz">
+            <objects>
+                <viewController id="7WV-p8-lVN" customClass="ExhibitViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5TZ-GM-zht">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="bcU-XE-3py">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="CTH-hu-XQB">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CTH-hu-XQB" id="sdv-3F-Cgi">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="5a0-Xp-kpN"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="5a0-Xp-kpN" firstAttribute="bottom" secondItem="bcU-XE-3py" secondAttribute="bottom" id="Gaf-Gl-itn"/>
+                            <constraint firstItem="bcU-XE-3py" firstAttribute="leading" secondItem="5a0-Xp-kpN" secondAttribute="leading" id="Jv4-uQ-hI2"/>
+                            <constraint firstItem="bcU-XE-3py" firstAttribute="top" secondItem="5a0-Xp-kpN" secondAttribute="top" id="YJ3-x1-Dol"/>
+                            <constraint firstItem="5a0-Xp-kpN" firstAttribute="trailing" secondItem="bcU-XE-3py" secondAttribute="trailing" id="nX2-lm-Fjb"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Mf4-oK-1kj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1933" y="117"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="t7f-jh-1EM">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -72,6 +72,9 @@
                                                         <rect key="frame" x="53" y="0.0" width="228" height="40"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                        <connections>
+                                                            <action selector="showExhibitButtonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="X3I-0x-SGo"/>
+                                                        </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="KzD-YA-2QO">
                                                         <rect key="frame" x="281" y="0.0" width="50" height="40"/>
@@ -129,7 +132,7 @@
         <!--Exhibit View Controller-->
         <scene sceneID="U94-nD-Xfz">
             <objects>
-                <viewController id="7WV-p8-lVN" customClass="ExhibitViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="exhibitViewController" id="7WV-p8-lVN" customClass="ExhibitViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5TZ-GM-zht">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -138,26 +141,26 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="117" id="CTH-hu-XQB" customClass="ExhibitTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="117"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="exhibitCell" rowHeight="143" id="CTH-hu-XQB" customClass="ExhibitTableViewCell" customModule="Expo1900" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="143"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CTH-hu-XQB" id="sdv-3F-Cgi">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="117"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="143"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dx8-1U-JxX">
-                                                    <rect key="frame" x="8" y="0.0" width="125" height="117"/>
+                                                    <rect key="frame" x="20" y="13" width="125" height="117"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eQ9-dX-uc0">
-                                                    <rect key="frame" x="175" y="23" width="42" height="21"/>
+                                                    <rect key="frame" x="172" y="38" width="42" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Qy-20-1bp">
-                                                    <rect key="frame" x="175" y="69" width="42" height="21"/>
+                                                    <rect key="frame" x="172" y="84" width="42" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-class ExhibitDetailViewController: UIViewController {
+final class ExhibitDetailViewController: UIViewController {
     @IBOutlet private weak var exhibitImageView: UIImageView!
     @IBOutlet private weak var exhibitDescriptionTextView: UITextView!
     private var exhibitData: ExhibitData?

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -7,25 +7,26 @@ import UIKit
 final class ExhibitDetailViewController: UIViewController {
     @IBOutlet private weak var exhibitImageView: UIImageView!
     @IBOutlet private weak var exhibitDescriptionTextView: UITextView!
-    private var exhibitData: ExhibitData?
-
+    private let exhibitData: ExhibitData
+    
+    required init?(exhibitData: ExhibitData, coder: NSCoder) {
+        self.exhibitData = exhibitData
+        super.init(coder: coder)
+    }
+    
+    required init?(coder: NSCoder) {
+        return nil
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureView()
     }
-    
-    func fetchExhibitData(_ data: ExhibitData?) {
-        exhibitData = data
-    }
-    
-    func configureView() {
-        guard let exhibit = exhibitData else {
-            return
-        }
 
-        navigationItem.title = exhibit.name
-        exhibitImageView.image = exhibit.image
-        exhibitDescriptionTextView.text = exhibit.description
+    func configureView() {
+        navigationItem.title = exhibitData.name
+        exhibitImageView.image = exhibitData.image
+        exhibitDescriptionTextView.text = exhibitData.description
     }
 }

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -12,16 +12,20 @@ class ExhibitDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        guard let exhibit = exhibitData else {
-            return
-        }
-        
-        exhibitImageView.image = exhibit.image
-        exhibitDescriptionTextView.text = exhibit.description
-        navigationItem.title = exhibit.name
+        configureView()
     }
     
     func fetchExhibitData(_ data: ExhibitData?) {
-        self.exhibitData = data
+        exhibitData = data
+    }
+    
+    func configureView() {
+        guard let exhibit = exhibitData else {
+            return
+        }
+
+        navigationItem.title = exhibit.name
+        exhibitImageView.image = exhibit.image
+        exhibitDescriptionTextView.text = exhibit.description
     }
 }

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -5,8 +5,18 @@
 import UIKit
 
 class ExhibitDetailViewController: UIViewController {
+    @IBOutlet weak var exhibitImageView: UIImageView!
+    @IBOutlet weak var exhibitDescriptionTextView: UITextView!
+    var exhibitData: Exhibit?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        guard let exhibit = exhibitData else {
+            return
+        }
+        
+        exhibitImageView.image = exhibit.image
+        exhibitDescriptionTextView.text = exhibit.description
     }
 }

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -7,7 +7,7 @@ import UIKit
 class ExhibitDetailViewController: UIViewController {
     @IBOutlet weak var exhibitImageView: UIImageView!
     @IBOutlet weak var exhibitDescriptionTextView: UITextView!
-    var exhibitData: Exhibit?
+    var exhibitData: ExhibitData?
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -1,0 +1,12 @@
+//  ExhibitDetailViewController.swift
+//  Expo1900
+//  Created by inho, LJ  on 2022/10/21.
+
+import UIKit
+
+class ExhibitDetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -18,5 +18,6 @@ class ExhibitDetailViewController: UIViewController {
         
         exhibitImageView.image = exhibit.image
         exhibitDescriptionTextView.text = exhibit.description
+        navigationItem.title = exhibit.name
     }
 }

--- a/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
+++ b/Expo1900/Expo1900/View/ExhibitDetailViewController.swift
@@ -5,9 +5,9 @@
 import UIKit
 
 class ExhibitDetailViewController: UIViewController {
-    @IBOutlet weak var exhibitImageView: UIImageView!
-    @IBOutlet weak var exhibitDescriptionTextView: UITextView!
-    var exhibitData: ExhibitData?
+    @IBOutlet private weak var exhibitImageView: UIImageView!
+    @IBOutlet private weak var exhibitDescriptionTextView: UITextView!
+    private var exhibitData: ExhibitData?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -19,5 +19,9 @@ class ExhibitDetailViewController: UIViewController {
         exhibitImageView.image = exhibit.image
         exhibitDescriptionTextView.text = exhibit.description
         navigationItem.title = exhibit.name
+    }
+    
+    func fetchExhibitData(_ data: ExhibitData?) {
+        self.exhibitData = data
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-## 야곰 아카데미
-# README - 만국박람회
+# README - 🇫🇷만국박람회🇰🇷
 
 ## iOS 커리어 스타터 캠프
+
+### 계산기 프로젝트 저장소
 ---
 ### 목차
 1. [개요](#1.개요)
@@ -22,37 +23,45 @@
 |:-:|:-:|
 ---
 # 2.타임라인
-| 날짜 | 중요 진행 상황&nbsp; | 코드 관련 사항 |
-|---|---|---|
-|10/18| `STEP1` 구현 | JSON데이터를 분석할 ExhibitData, ExpositionData 구조체 구현
-|10/20| `STEP2` 구현 | ExpositionViewController의 UI요소 생성 및 구성(configureView()), JSONDecode의 parse메서드 생성, 
-|10/21| `STEP2` 구현 | ExhibitViewController와 테이블 뷰 생성 및 ExhibitTableVIewCell 생성, </br>화면 전환 기능 구현, ExhibitDetailViewController의 UI요소 생성 및 구성
+| 날짜 | 중요 진행 상황&nbsp;&nbsp; | 코드 관련 사항&nbsp;
+|---|:-:|---|
+|10/18| `STEP1` 구현 | `JSON`데이터를 분석할 `ExhibitData`, `ExpositionData` 구조체 구현
+|10/20| `STEP2` 구현 | `ExpositionViewController`의 UI요소 생성 및 구성(`configureView()`), `JSONDecode`의 `parse`메서드 생성, 
+|10/21| `STEP2` 구현 | `ExhibitViewController`와 테이블 뷰 생성 및 `ExhibitTableVIewCell` 생성, 화면 전환 기능 구현, `ExhibitDetailViewController`의 UI요소 생성 및 구성
+|10/24| `STEP2` 구현 | `ExpositionConstant` 네임스페이스 생성, 코드에 접근 수준 수정
+|10/25| `STEP2` 구현 | `ExhibitDetailViewController`의 `configureView`메서드 분리, 클래스에 `final` 키워드 적용, `Error`타입 생성
+|10/26| `STEP2` 구현 | `AutoLayout` 구현방법 고민 
+|10/27| `STEP2` 구현 | `showAlert`메서드 생성, `fetchData` 메서드 생성
+|10/28| `STEP2` 구현 | 뷰컨트롤러의 초기화방법 변경(required Initializer 구현)
 
 
 # 3.시각화된프로젝트구조
-<img src="https://i.imgur.com/LmRGwvy.png" width=600>
+<img src="https://i.imgur.com/53laOW3.png" width=600>
 
 # 4.실행화면
-(오토레이아웃 반영 후 추가 예정)
+|<img src="https://user-images.githubusercontent.com/97071996/198536163-9b2abf8c-9d1f-4266-9449-49cd263209a1.gif" width=200>|
+|:-:|
+|실행 화면|
+
 
 ---
 # 5.트러블슈팅
 ### 1️⃣ Step1
 #### JSON 포맷 데이터의 `decodable` 프로토콜 채택
 - 데이터를 주고받을때, 특정 포맷으로 변환하기 위해 `codable`프로토콜을 채택한다.
-그리고 `Codable`은 `encodable & decodable`의 type alias인데, 이번 프로젝트에서는 `encoding`의 과정이 없기때문에 `decodable`프로토콜만 채택했다.
-➡️ 나중의 확장성을 고려한다면 `Codable`을 채택하는 것이 맞지만, 아직 니즈가 없는데 미리 만들어두는 오버엔지니어링을 하게된다. 오버엔지니어링의 단점은 추후 기획이 변경되었을 때 유연한 대응이 어렵다는 것이다.
+그리고 `Codable`은 `encodable & decodable`의 type alias인데, 이번 프로젝트에서는 `encoding`의 과정이 없기때문에 `decodable`프로토콜만 채택했다.</br>
+➡️ 나중의 확장성을 고려한다면 `Codable`을 채택하는 것이 맞지만, 아직 니즈가 없는데 미리 만들어두는 오버엔지니어링을 하게된다. 오버엔제니어링의 단점은 추후 기획이 변경되었을 때 유연한 대응이 어렵다는 것이다.
 
 ### 2️⃣ Step2
 #### JSONDecoder의 extension
 - JSON을 디코딩할때마다 `JSONDecoder`인스턴스가 불필요하게 여러번 생성되어 메모리가 낭비되는 부분을 보완하기 위해 JSONDecoder클래스에 타입 프로퍼티인 `jsonDecoder`을 생성하여 인스턴스가 한번 생성되도록 구현했다. (비용이 많이드는 object인`DateFormatter`를 활용하는 방법에서 배운 방법이다.)
+</br>
 
 ```swift
 static let jsonDecoder: JSONDecoder = .init()
 ```
-</br>
-
 - 프로젝트 내에서 JSON데이터를 디코딩할때, 반복되는 부분을 줄이고 하나의 메서드로 묶은 뒤 제네릭 타입을 이용해서 원하는 타입대로 디코딩할 수 있는 메서드를 구현했다.
+</br>
     
 ```swift
 static func parse<T: Decodable>(assetName: String, to dataType: T.Type) -> T? {
@@ -67,16 +76,16 @@ static func parse<T: Decodable>(assetName: String, to dataType: T.Type) -> T? {
     }
 }
 ```
-</br>
 
 #### 화면 전환 방법 `NavigationController`사용 / `Segue`사용
 - `NavigationController`사용한 방법</br>
 **장점** : 코드로 명시적으로 지정할 수 있어 실수할 가능성이 적다.</br>
 **단점** : 스토리보드상에서 화면의 흐름을 한눈에 볼 수 없다.</br>
-- `Segue`사용한 방법</br>
+- `Segue`사용한 방법
 **장점** : 구현방법이 간단하다.(스토리보드 ctrl + drag)</br>
 **단점** : `Segue`식별자 지정하는 것을 빠뜨리거나 하는 등의 실수할 가능성이 높다. 어떤 Segue가 어떤 식별자이름인지 일일히 확인해야 한다. `Segue`가 많아졌을때, 스토리보드 화면이 복잡해진다.</br>
 - 스토리보드에서 발생하는 에러는 빌드하여도 에러로 잡히지 않기때문에 나중에 원인을 찾기가 쉽지 않다. 두가지 방법 중 에러날 가능성이 적은 NavigationController사용한 방법으로 구현했다.
+</br>
 
 ```swift
 guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitViewController") as? ExhibitViewController else {
@@ -85,13 +94,13 @@ guard let nextViewController: ExhibitViewController = self.storyboard?.instantia
         
 self.navigationController?.pushViewController(nextViewController, animated: true)
 ```
-</br>
 
 #### `UIButton`의 `title` 지정 방법
 - `UIButton`의 `title`에 원하는 값을 주기 위해서 버튼의 `titleLabel?.text`에 접근하여 값을 주었는데, 버튼을 한번 눌렀을때 `default`값인 `Button`으로 돌아오는 문제가 있었다. 
 - [공식문서](https://developer.apple.com/documentation/uikit/uibutton/1624018-settitle)에서는 버튼의 상태에 따른 레이블을 지정할때 `setTitle()`메서드를 이용해야 하고,  `normal`상태에 대한 값을 지정하지 않으면 기본 텍스트를 사용한다고 한다. 그래서 버튼이 클릭되고, 상태가 바뀐 후에 원래 텍스트인 `Button`으로 바뀌었던 것 같다.
     > If you don’t specify a title for the other states, the button uses the title associated with the normal state. If you don’t set the value for normal, then the property defaults to a system value.
-    </br>
+</br>
+
 ```swift
 //기존 코드
 button.titleLabel.text = "한국의 출품작 보러가기"
@@ -99,16 +108,80 @@ button.titleLabel.text = "한국의 출품작 보러가기"
 button.setTitle(exposition.exhibitButtonText, for: .normal)
 ```
 
+#### `Initializer`를 이용하여 초기화
+- `ExpositionViewController`의 `ExpositionData`프로퍼티는 뷰컨트롤러가 생성되면서 asset의 파일을 디코딩한 값을 전달받고 있었다. 초기화와 뷰에 로드되는 중간에 디코딩이 발생하고 있어서 프로퍼티를 `ExpositionData?`타입으로 지정해 처음에는 nil값이 할당되었다. (뷰컨트롤러를 생성한 후에 프로퍼티에 값을 변경하는 방법)
+- 그런데 뷰를 보여주기 위해서 값이 필요하니 뷰컨트롤러를 초기화하는 시점에 프로퍼티를 함께 초기화하기 위해서 뷰컨트롤러의 `required init?(coder:)`메서드를 이용했다. (뷰컨트롤러 생성과 함께 프로퍼티에 값 초기화하는 방법)
+
+**`required init?(coder:)`가 담고있는 내용**
+- `ExpositionViewController`가 상속받은 `UIViewController`는 `NSCoding` 프로토콜을 채택하고, `NSCoding`프로토콜의 필수구현 메서드 중 하나가 `init?(coder: NSCoder)` 이다.
+- 이 이니셜라이저는 지정된 `unarchiver`의 데이터에서 초기화된 객체를 반환해준다. 여기서 `unarchiver`의 데이터는 `JSON`파일을 디코드한 `swift`코드형태의 데이터라고 이해했다.
+- 매개변수`coder`의 타입인 `NSCoder`타입은 메모리나 타입 사이에서 값을 전송하기위한 기반을 `UIViewController`를 상속받은 서브클래스에 제공하기 때문에 `coder`매개변수의 타입으로 쓰인다고 이해하였다.
+- `required`는 필수 이니셜라이저에 붙는 키워드로 필수 이니셜라이저를 가진 클래스를 상속한 모든 자식클래스(subclass)는 해당 이니셜라이저를 구현 해야함을 나타낸다.
+- `init?` 초기화가 실패할 수도 있는 `Failable` 이니셜라이저이다. 
+</br>
+
+```swift
+//수정 후
+func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    //뷰컨트롤러 생성
+    guard let nextViewController: ExhibitDetailViewController = self.storyboard?.instantiateViewController(
+        withIdentifier: "exhibitDetailViewController") as? ExhibitDetailViewController 
+    else {
+        return
+    }
+    //프로퍼티에 데이터 전달
+    nextViewController.exhibitData = exhibits[indexPath.row]
+    ...
+}
+
+//수정 전
+func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    //뷰컨트롤러 생성과 데이터 전달
+    guard let nextViewController: ExhibitDetailViewController =
+            self.storyboard?.instantiateViewController(
+                identifier: "exhibitDetailViewController",
+                creator: { coder in
+                    return ExhibitDetailViewController(exhibitData: exhibits[indexPath.row], coder: coder)
+                }
+    ) else {
+        return
+    }
+    ...
+}
+```
+
+#### 레이블의 텍스트에 특정 부분에 원하는 특성을 주기(`NSAttributedString`)
+- 만국박람회의 정보를 보여주는 화면에서 `개최지: 프랑스 파리`와 같은 레이블 중 `개최지`부분의 글자만 크게 적용해야하는 내용이 있었다.처음에는 두개의 레이블을 생성하여 각각 구현할까 하다가 `NSAttributedString`이라는 방법을 찾게 되었다. 
+    - `NSAttributedString`은 일부 텍스트에 연관된 속성을 가진 문자열이다. 문자열 내에 개별 문자 또는 일정 범위에만 속성을 적용하고 관리한다.
+- 먼저 `UILabel`의 `extension`내에 특정 문자의 폰트를 굵게만드는 역할을 하므로 `bold()`라는 메서드를 정의하고, 문자열을 `attributedString`으로 변환한뒤, `addAttribute(_:value:range:)`메서드를 이용한다.
+    - `addAttribute(_:value:range:)`은 첫번째 파라미터로 받은 속성에 `value`파라미터로 받은 값을 저장하고, `range`파라미터로 받은 범위 내의 문자에 적용한다.
+
+</br>
+
+```swift
+extension UILabel {
+    func bold(_ input: String) {
+        guard let text = text else { return }
+        
+        let fontStyle = UIFont.preferredFont(forTextStyle: .body)
+        attributedString.addAttribute(.font,
+                                      value: fontStyle,
+                                      range: (text as NSString).range(of: input))
+        
+        self.attributedText = attributedString
+    }
+}
+```
+
 ---
 # 6.참고링크
-[UITableView](https://developer.apple.com/documentation/uikit/uitableview/)
-
-[UITableViewDelegate](https://developer.apple.com/documentation/uikit/uitableviewdelegate/)
-
-[UITableViewDataSource](https://developer.apple.com/documentation/uikit/uitableviewdatasource/)
-
-[pushViewController](https://developer.apple.com/documentation/uikit/uinavigationcontroller/1621887-pushviewcontroller/)
-
-[JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
-
-[Codable](https://developer.apple.com/documentation/swift/codable/)
+- [UITableView](https://developer.apple.com/documentation/uikit/uitableview/)
+    - [UITableViewDelegate](https://developer.apple.com/documentation/uikit/uitableviewdelegate/)
+    - [UITableViewDataSource](https://developer.apple.com/documentation/uikit/uitableviewdatasource/)
+- [UINavigationController](https://developer.apple.com/documentation/uikit/uinavigationcontroller/)
+    - [pushViewController](https://developer.apple.com/documentation/uikit/uinavigationcontroller/1621887-pushviewcontroller/)
+- [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
+    - [Codable](https://developer.apple.com/documentation/swift/codable/)
+- [Initializer](https://docs.swift.org/swift-book/LanguageGuide/Initialization.html#)
+    - [NSCoding](https://developer.apple.com/documentation/foundation/nscoding/)
+- [NSAttributedString](https://developer.apple.com/documentation/foundation/nsattributedstring)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,102 @@
 ## 야곰 아카데미
+# README - 만국박람회
 
-### 만국박람회 프로젝트 저장소
+## iOS 커리어 스타터 캠프
+---
+### 목차
+1. [개요](#1.개요)
+2. [타임라인](#2.타임라인)
+3. [시각화된 프로젝트 구조](#3.시각화된프로젝트구조)
+4. [실행화면](#4.실행화면)
+5. [트러블 슈팅](#5.트러블슈팅)
+6. [참고 링크](#6.참고링크)
 
-- 이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다
+---
+# 1. 개요
+### 만국박람회 프로젝트
+- 만국박람회에 참가한 한국의 출품작을 볼 수 있는 프로젝트입니다.
 
+### 팀원 
+
+|inho(@inho-98)|LJ(@lj-7-77)|
+|:-:|:-:|
+---
+# 2.타임라인
+| 날짜 | 중요 진행 상황 | 코드 관련 사항
+|---|---|---|
+|10/18| `STEP1` 구현 | JSON데이터를 분석할 ExhibitData, ExpositionData 구조체 구현
+|10/20| `STEP2` 구현 | ExpositionViewController의 UI요소 생성 및 구성(configureView()), JSONDecode의 parse메서드 생성, 
+|10/21| `STEP2` 구현 | ExhibitViewController와 테이블 뷰 생성 및 ExhibitTableVIewCell 생성, 화면 전환 기능 구현, ExhibitDetailViewController의 UI요소 생성 및 구성
+
+
+# 3.시각화된프로젝트구조
+<img src="https://i.imgur.com/LmRGwvy.png" width=600>
+
+# 4.실행화면
+(오토레이아웃 반영 후 추가 예정)
+
+---
+# 5.트러블슈팅
+### 1️⃣ Step1
+#### JSON 포맷 데이터의 `decodable` 프로토콜 채택
+- 데이터를 주고받을때, 특정 포맷으로 변환하기 위해 `codable`프로토콜을 채택한다.
+그리고 `Codable`은 `encodable & decodable`의 type alias인데, 이번 프로젝트에서는 `encoding`의 과정이 없기때문에 `decodable`프로토콜만 채택했다.
+➡️ 나중의 확장성을 고려한다면 `Codable`을 채택하는 것이 맞지만, 아직 니즈가 없는데 미리 만들어두는 오버엔지니어링을 하게된다. 오버엔제니어링의 단점은 추후 기획이 변경되었을 때 유연한 대응이 어렵다는 것이다.
+
+### 2️⃣ Step2
+#### JSONDecoder의 extension
+- JSON을 디코딩할때마다 `JSONDecoder`인스턴스가 불필요하게 여러번 생성되어 메모리가 낭비되는 부분을 보완하기 위해 JSONDecoder클래스에 타입 프로퍼티인 `jsonDecoder`을 생성하여 인스턴스가 한번 생성되도록 구현했다. (비용이 많이드는 object인`DateFormatter`를 활용하는 방법에서 배운 방법이다.)
+```swift
+static let jsonDecoder: JSONDecoder = .init()
+```
+- 프로젝트 내에서 JSON데이터를 디코딩할때, 반복되는 부분을 줄이고 하나의 메서드로 묶은 뒤 제네릭 타입을 이용해서 원하는 타입대로 디코딩할 수 있는 메서드를 구현했다.
+    
+```swift
+static func parse<T: Decodable>(assetName: String, to dataType: T.Type) -> T? {
+    guard let dataAsset: NSDataAsset = NSDataAsset(name: assetName) else {
+        return nil
+    }
+        
+    do {
+        return try Self.jsonDecoder.decode(T.self, from: dataAsset.data)
+    } catch {
+        return nil
+    }
+}
+```
+
+#### 화면 전환 방법 `NavigationController`사용 / `Segue`사용
+- `NavigationController`사용한 방법
+**장점** : 코드로 명시적으로 지정할 수 있어 실수할 가능성이 적다.
+**단점** : 스토리보드상에서 화면의 흐름을 한눈에 볼 수 없다.
+- `Segue`사용한 방법
+**장점** : 구현방법이 간단하다.(스토리보드 ctrl + drag)
+**단점** : `Segue`식별자 지정하는 것을 빠뜨리거나 하는 등의 실수할 가능성이 높다. 어떤 Segue가 어떤 식별자이름인지 일일히 확인해야 한다. `Segue`가 많아졌을때, 스토리보드 화면이 복잡해진다.
+- 스토리보드에서 발생하는 에러는 빌드하여도 에러로 잡히지 않기때문에 나중에 원인을 찾기가 쉽지 않다. 두가지 방법 중 에러날 가능성이 적은 NavigationController사용한 방법으로 구현했다.
+```swift
+guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitViewController") as? ExhibitViewController else {
+    return
+}
+        
+self.navigationController?.pushViewController(nextViewController, animated: true)
+```
+
+#### `UIButton`의 `title` 지정 방법
+- `UIButton`의 `title`에 원하는 값을 주기 위해서 버튼의 `titleLabel?.text`에 접근하여 값을 주었는데, 버튼을 한번 눌렀을때 `default`값인 `Button`으로 돌아오는 문제가 있었다. 
+- [공식문서](https://developer.apple.com/documentation/uikit/uibutton/1624018-settitle)에서는 버튼의 상태에 따른 레이블을 지정할때 `setTitle()`메서드를 이용해야 하고,  `normal`상태에 대한 값을 지정하지 않으면 기본 텍스트를 사용한다고 한다. 그래서 버튼이 클릭되고, 상태가 바뀐 후에 원래 텍스트인 `Button`으로 바뀌었던 것 같다.
+    > If you don’t specify a title for the other states, the button uses the title associated with the normal state. If you don’t set the value for normal, then the property defaults to a system value.
+```swift
+//기존 코드
+button.titleLabel.text = "한국의 출품작 보러가기"
+//새로운 코드
+button.setTitle(exposition.exhibitButtonText, for: .normal)
+```
+
+---
+# 6.참고링크
+[UITableView](https://developer.apple.com/documentation/uikit/uitableview/)
+[UITableViewDelegate](https://developer.apple.com/documentation/uikit/uitableviewdelegate/)
+[UITableViewDataSource](https://developer.apple.com/documentation/uikit/uitableviewdatasource/)
+[pushViewController](https://developer.apple.com/documentation/uikit/uinavigationcontroller/1621887-pushviewcontroller/)
+[JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
+[Codable](https://developer.apple.com/documentation/swift/codable/)

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 |:-:|:-:|
 ---
 # 2.타임라인
-| 날짜 | 중요 진행 상황 | 코드 관련 사항
+| 날짜 | 중요 진행 상황&nbsp; | 코드 관련 사항 |
 |---|---|---|
 |10/18| `STEP1` 구현 | JSON데이터를 분석할 ExhibitData, ExpositionData 구조체 구현
 |10/20| `STEP2` 구현 | ExpositionViewController의 UI요소 생성 및 구성(configureView()), JSONDecode의 parse메서드 생성, 
-|10/21| `STEP2` 구현 | ExhibitViewController와 테이블 뷰 생성 및 ExhibitTableVIewCell 생성, 화면 전환 기능 구현, ExhibitDetailViewController의 UI요소 생성 및 구성
+|10/21| `STEP2` 구현 | ExhibitViewController와 테이블 뷰 생성 및 ExhibitTableVIewCell 생성, </br>화면 전환 기능 구현, ExhibitDetailViewController의 UI요소 생성 및 구성
 
 
 # 3.시각화된프로젝트구조
@@ -41,14 +41,17 @@
 #### JSON 포맷 데이터의 `decodable` 프로토콜 채택
 - 데이터를 주고받을때, 특정 포맷으로 변환하기 위해 `codable`프로토콜을 채택한다.
 그리고 `Codable`은 `encodable & decodable`의 type alias인데, 이번 프로젝트에서는 `encoding`의 과정이 없기때문에 `decodable`프로토콜만 채택했다.
-➡️ 나중의 확장성을 고려한다면 `Codable`을 채택하는 것이 맞지만, 아직 니즈가 없는데 미리 만들어두는 오버엔지니어링을 하게된다. 오버엔제니어링의 단점은 추후 기획이 변경되었을 때 유연한 대응이 어렵다는 것이다.
+➡️ 나중의 확장성을 고려한다면 `Codable`을 채택하는 것이 맞지만, 아직 니즈가 없는데 미리 만들어두는 오버엔지니어링을 하게된다. 오버엔지니어링의 단점은 추후 기획이 변경되었을 때 유연한 대응이 어렵다는 것이다.
 
 ### 2️⃣ Step2
 #### JSONDecoder의 extension
 - JSON을 디코딩할때마다 `JSONDecoder`인스턴스가 불필요하게 여러번 생성되어 메모리가 낭비되는 부분을 보완하기 위해 JSONDecoder클래스에 타입 프로퍼티인 `jsonDecoder`을 생성하여 인스턴스가 한번 생성되도록 구현했다. (비용이 많이드는 object인`DateFormatter`를 활용하는 방법에서 배운 방법이다.)
+
 ```swift
 static let jsonDecoder: JSONDecoder = .init()
 ```
+</br>
+
 - 프로젝트 내에서 JSON데이터를 디코딩할때, 반복되는 부분을 줄이고 하나의 메서드로 묶은 뒤 제네릭 타입을 이용해서 원하는 타입대로 디코딩할 수 있는 메서드를 구현했다.
     
 ```swift
@@ -64,15 +67,17 @@ static func parse<T: Decodable>(assetName: String, to dataType: T.Type) -> T? {
     }
 }
 ```
+</br>
 
 #### 화면 전환 방법 `NavigationController`사용 / `Segue`사용
-- `NavigationController`사용한 방법
-**장점** : 코드로 명시적으로 지정할 수 있어 실수할 가능성이 적다.
-**단점** : 스토리보드상에서 화면의 흐름을 한눈에 볼 수 없다.
-- `Segue`사용한 방법
-**장점** : 구현방법이 간단하다.(스토리보드 ctrl + drag)
-**단점** : `Segue`식별자 지정하는 것을 빠뜨리거나 하는 등의 실수할 가능성이 높다. 어떤 Segue가 어떤 식별자이름인지 일일히 확인해야 한다. `Segue`가 많아졌을때, 스토리보드 화면이 복잡해진다.
+- `NavigationController`사용한 방법</br>
+**장점** : 코드로 명시적으로 지정할 수 있어 실수할 가능성이 적다.</br>
+**단점** : 스토리보드상에서 화면의 흐름을 한눈에 볼 수 없다.</br>
+- `Segue`사용한 방법</br>
+**장점** : 구현방법이 간단하다.(스토리보드 ctrl + drag)</br>
+**단점** : `Segue`식별자 지정하는 것을 빠뜨리거나 하는 등의 실수할 가능성이 높다. 어떤 Segue가 어떤 식별자이름인지 일일히 확인해야 한다. `Segue`가 많아졌을때, 스토리보드 화면이 복잡해진다.</br>
 - 스토리보드에서 발생하는 에러는 빌드하여도 에러로 잡히지 않기때문에 나중에 원인을 찾기가 쉽지 않다. 두가지 방법 중 에러날 가능성이 적은 NavigationController사용한 방법으로 구현했다.
+
 ```swift
 guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitViewController") as? ExhibitViewController else {
     return
@@ -80,11 +85,13 @@ guard let nextViewController: ExhibitViewController = self.storyboard?.instantia
         
 self.navigationController?.pushViewController(nextViewController, animated: true)
 ```
+</br>
 
 #### `UIButton`의 `title` 지정 방법
 - `UIButton`의 `title`에 원하는 값을 주기 위해서 버튼의 `titleLabel?.text`에 접근하여 값을 주었는데, 버튼을 한번 눌렀을때 `default`값인 `Button`으로 돌아오는 문제가 있었다. 
 - [공식문서](https://developer.apple.com/documentation/uikit/uibutton/1624018-settitle)에서는 버튼의 상태에 따른 레이블을 지정할때 `setTitle()`메서드를 이용해야 하고,  `normal`상태에 대한 값을 지정하지 않으면 기본 텍스트를 사용한다고 한다. 그래서 버튼이 클릭되고, 상태가 바뀐 후에 원래 텍스트인 `Button`으로 바뀌었던 것 같다.
     > If you don’t specify a title for the other states, the button uses the title associated with the normal state. If you don’t set the value for normal, then the property defaults to a system value.
+    </br>
 ```swift
 //기존 코드
 button.titleLabel.text = "한국의 출품작 보러가기"
@@ -95,8 +102,13 @@ button.setTitle(exposition.exhibitButtonText, for: .normal)
 ---
 # 6.참고링크
 [UITableView](https://developer.apple.com/documentation/uikit/uitableview/)
+
 [UITableViewDelegate](https://developer.apple.com/documentation/uikit/uitableviewdelegate/)
+
 [UITableViewDataSource](https://developer.apple.com/documentation/uikit/uitableviewdatasource/)
+
 [pushViewController](https://developer.apple.com/documentation/uikit/uinavigationcontroller/1621887-pushviewcontroller/)
+
 [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
+
 [Codable](https://developer.apple.com/documentation/swift/codable/)


### PR DESCRIPTION
# 만국박람회 STEP2 PR

안녕하세요 @hyunable , inho(@inho-98), LJ(@lj-7-77) 입니다!
STEP 2 PR 보냅니다. 잘 부탁드립니다.🙇‍♂️🙇‍♀️

## 고민했던 점
#### 1️⃣ `JSON extension` & `NumberFormatter extension`
- `JSON` 데이터를 변환하는 과정이 `ExpositionViewController`, `ExhibitViewController`에서 등장합니다. 그때마다 `JSONDecoder`인스턴스를 만드는 대신에 `JSONDecoder`클래스의 타입 프로퍼티로 디코더 인스턴스를 만들어서 불필요하게 인스턴스가 생성되는 것을 줄였습니다. (이전에 공부할 때 `DateFormatter`를 다루는 방법에서 배운 것입니다.)
- 그리고 `asset`파일에서 원하는 데이터를 가져오고 `decode`하는 과정을 `parse(asset: to dataType:)`이라는 메서드와 제네릭을 이용해서 반복되는 코드를 줄였습니다. 원하는 파일의 이름과 리턴하고 싶은 데이터 타입을 전달하여 디코딩 하는 메서드입니다.
</br>

```swift
//JSONDecoder extension
static let jsonDecoder: JSONDecoder = .init()
    
static func parse<T: Decodable>(asset: String, to dataType: T.Type) -> T? {
    guard let dataAsset: NSDataAsset = NSDataAsset(name: asset) else {
        return nil
    }
        
    do {
        return try Self.jsonDecoder.decode(T.self, from: dataAsset.data)
    } catch {
        return nil
    }
}
```

- `JSONDecoder`의 타입 프로퍼티를 만든것과 같은 이유로 `NumberFormatter`의 `extension`을 활용했습니다. 

#### 2️⃣ `NavigationController`를 이용한 화면 전환 방식
- 뷰컨트롤러에서 화면을 전환할때 `segue` 대신 코드를 이용하여 구현했습니다. 각 방식의 장단점을 고민했습니다.
    - `NavigationController`사용한 방법
    **장점** : 코드로 명시적으로 지정할 수 있어 실수할 가능성이 적다.
    **단점** : 스토리보드상에서 화면의 흐름을 한눈에 볼 수 없다.
    - `Segue`사용한 방법
    **장점** : 구현방법이 간단하다.(스토리보드 ctrl + drag)
    **단점** : `Segue`식별자 지정하는 것을 빠뜨리거나 하는 등의 실수할 가능성이 높다. 어떤 Segue가 어떤 식별자이름인지 일일히 확인해야 한다. `Segue`가 많아졌을때, 스토리보드 화면이 복잡해진다.

- 스토리보드에서 발생하는 에러는 빌드하여도 에러로 잡히지 않기때문에 나중에 원인을 찾기가 쉽지 않습니다. 두가지 방법 중 에러날 가능성이 적은 `NavigationController`위에 `push`, `pop`하는 방법으로 구현했습니다.
</br>

```swift
guard let nextViewController: ExhibitViewController = self.storyboard?.instantiateViewController(withIdentifier: "exhibitViewController") as? ExhibitViewController else {
    return
}
        
self.navigationController?.pushViewController(nextViewController, animated: true)
```

#### 3️⃣ `ExhibitTableViewCell`을 구성하는 방법
`exhibitTableView`의 `DataSource`에 있는 `cellForRowAt` 메서드는 테이블뷰에 셀을 보여줄 때마다 호출되는 메서드이고, 자주 호출되기 때문에 최소한의 기능만 갖고있는 것이 좋습니다.
원래는 셀에 이미지, 텍스트, 폰트를 전달하여 뷰를 구성하는 코드가 cellForRowAt메서드 안에 구현되어있었으나 `ExhibitTableViewCell` 타입의 `configureCell(with:)`메서드로 분리하였습니다. `cell`을 구성하는 역할을 자신이 하고있다는 점에서도 더 낫다고 판단하였습니다.
</br>

```swift
func configureCell(with exhibit: ExhibitData) {
    self.exhibitImageView.image = exhibit.image
    self.exhibitNameLabel.text = exhibit.name
    self.exhibitNameLabel.font = ExpositionConstant.exhibitCellTitleFont
    self.exhibitShortDescriptionLabel.text = exhibit.shortDescription
}
```

#### 4️⃣ `ExpositionConstant`타입의 `namespace`
- 열거형 타입을 만들어서 모듈 내의 문자열, 숫자, 폰트 등을 관리하도록 구현했습니다. 
- 현재는 공백을 주어서 나타내는 값들을 시각적으로 나누어 주고 있는데, 이런 경우에 주석을 활용하는지도 궁금합니다! 🤔 `//MARK: - 주석`
</br>

```swift
enum ExpositionConstant {
    static let exhibitCell: String = "exhibitCell"
    
    static let expositionAssetName: String = "exposition_universelle_1900"
    static let exhibitAssetName: String = "items"
    ...
    
    static let exhibitCellTitleFont: UIFont = .preferredFont(forTextStyle: .title1)
}
```
---
## 조언을 얻고싶은 부분
#### 1️⃣ JSON 데이터를 나타낼 타입의 접근제어
- `JSON`데이터를 디코드해서 담아줄 `ExhibitData`와 `ExpositionData`타입을 구현해 주었는데요, 다른 파일들에는 필요한 부분에 `private`접근 수준을 적용해 주었는데, 위 두 구조체에는 접근제어를 주지 않았습니다.
디코딩한 데이터를 접근해야 하기도 하고 두 타입 모두 상수 혹은 연산 프로퍼티만 가지고 있어서 값을 변경할 수 없어서 접근제어를 추가하지 않았는데요, `JSON`을 디코딩할 타입들에 대한 접근제어를 어떻게 관리하는지 궁금합니다..!🤔

#### 2️⃣ 초기값이 없을 경우 빈 값과 옵셔널
```swift
// ExpositionViewController.swift 파일
private var expositionData: ExpositionData?
```
위 경우에는 `expositionData`변수를 선언하는 시점에는 값이 없는 상태이고, 실행과정에서 `JSON`디코딩이 되면서 값이 전달됩니다. 초기값을 가지고 있지 않기 때문에 옵셔널로 선언하였습니다.
</br>

```swift
// ExhibitViewController.swift 파일
private var exhibits: [ExhibitData] = [] //[ExhibitData]?
```
그런데 `exhibits` 프로퍼티도 위와 같은 이유로 옵셔널 배열 타입으로 구현되어야 할까 고민했는데, 그렇게 하면 뷰컨트롤러의 셀의 갯수 혹은 셀을 리턴하는 메서드에서 옵셔널 바인딩의 `else`구문에서 의미없는 값을 리턴해야합니다. 프로퍼티를 옵셔널 배열타입으로 선언하면서 해결할 수 있는 방법이 있을지 궁금합니다🥲
