### PR TITLE
만국박람회 [STEP 3] Zhilly, Mangdi

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		09D912E428FD502A001A32C0 /* ExpositionUniverselle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D912E328FD502A001A32C0 /* ExpositionUniverselle.swift */; };
 		B4B085C928FD53C400303331 /* KoreanEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B085C828FD53C400303331 /* KoreanEntry.swift */; };
 		B4BF8E8228FE9CD900AC46AD /* KoreanEntriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BF8E8128FE9CD900AC46AD /* KoreanEntriesViewController.swift */; };
+		B4C087F12907D47C00B8E816 /* KoreanEntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C087EF2907D47C00B8E816 /* KoreanEntryTableViewCell.swift */; };
+		B4C087F22907D47C00B8E816 /* KoreanEntryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4C087F02907D47C00B8E816 /* KoreanEntryTableViewCell.xib */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
 		C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* MainViewController.swift */; };
@@ -24,6 +26,8 @@
 		09D912E328FD502A001A32C0 /* ExpositionUniverselle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionUniverselle.swift; sourceTree = "<group>"; };
 		B4B085C828FD53C400303331 /* KoreanEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanEntry.swift; sourceTree = "<group>"; };
 		B4BF8E8128FE9CD900AC46AD /* KoreanEntriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanEntriesViewController.swift; sourceTree = "<group>"; };
+		B4C087EF2907D47C00B8E816 /* KoreanEntryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanEntryTableViewCell.swift; sourceTree = "<group>"; };
+		B4C087F02907D47C00B8E816 /* KoreanEntryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KoreanEntryTableViewCell.xib; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -60,6 +64,8 @@
 			children = (
 				C79FF4BA2589F401005FB0FD /* Main.storyboard */,
 				C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */,
+				B4C087F02907D47C00B8E816 /* KoreanEntryTableViewCell.xib */,
+				B4C087EF2907D47C00B8E816 /* KoreanEntryTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -170,6 +176,7 @@
 			files = (
 				C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */,
 				C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */,
+				B4C087F22907D47C00B8E816 /* KoreanEntryTableViewCell.xib in Resources */,
 				C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -187,6 +194,7 @@
 				B4BF8E8228FE9CD900AC46AD /* KoreanEntriesViewController.swift in Sources */,
 				09D912E428FD502A001A32C0 /* ExpositionUniverselle.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
+				B4C087F12907D47C00B8E816 /* KoreanEntryTableViewCell.swift in Sources */,
 				0999C5EB2900DD220010C863 /* EntriesDetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Expo1900/Expo1900/Controller/KoreanEntriesViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanEntriesViewController.swift
@@ -7,7 +7,7 @@ final class KoreanEntriesViewController: UIViewController {
     
     @IBOutlet private weak var koreanEntriesTableView: UITableView!
     
-    private let cellIdentifier: String = "koreanEntryCell"
+    private let cellIdentifier = KoreanEntryTableViewCell().cellIdentifier
     private var koreanEntries: [KoreanEntry] = []
     
     override func viewDidLoad() {
@@ -59,9 +59,11 @@ extension KoreanEntriesViewController: UITableViewDataSource {
         
         let entry: KoreanEntry = self.koreanEntries[indexPath.row]
         
-        customCell.entryImage.image = UIImage(named: entry.imageName)
-        customCell.entryTitleLabel.text = entry.name
-        customCell.entryShortDescription.text = entry.shortDescription
+        customCell.configureCell(
+            imageName: entry.imageName,
+            entryName: entry.name,
+            description: entry.shortDescription
+        )
         
         return customCell
     }

--- a/Expo1900/Expo1900/Controller/KoreanEntriesViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanEntriesViewController.swift
@@ -12,7 +12,8 @@ final class KoreanEntriesViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        koreanEntriesTableView.register(UINib(nibName: "KoreanEntryTableViewCell", bundle: nil), forCellReuseIdentifier: cellIdentifier)
+
         loadKoreanEntries()
         navigationController?.isNavigationBarHidden = false
     }
@@ -57,18 +58,18 @@ extension KoreanEntriesViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = koreanEntriesTableView.dequeueReusableCell(
+        let customCell: KoreanEntryTableViewCell = koreanEntriesTableView.dequeueReusableCell(
             withIdentifier: self.cellIdentifier,
             for: indexPath
-        )
-        let entry: KoreanEntry = self.koreanEntries[indexPath.row]
-        var content = cell.defaultContentConfiguration()
+        ) as? KoreanEntryTableViewCell ?? KoreanEntryTableViewCell()
         
-        content.image = UIImage(named: entry.imageName)
-        content.text = entry.name
-        content.secondaryText = entry.shortDescription
-        cell.contentConfiguration = content
-        return cell
+        let entry: KoreanEntry = self.koreanEntries[indexPath.row]
+        
+        customCell.entryImage.image = UIImage(named: entry.imageName)
+        customCell.entryTitleLabel.text = entry.name
+        customCell.entryShortDescription.text = entry.shortDescription
+        
+        return customCell
     }
 }
 

--- a/Expo1900/Expo1900/Controller/KoreanEntriesViewController.swift
+++ b/Expo1900/Expo1900/Controller/KoreanEntriesViewController.swift
@@ -12,19 +12,13 @@ final class KoreanEntriesViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        koreanEntriesTableView.register(UINib(nibName: "KoreanEntryTableViewCell", bundle: nil), forCellReuseIdentifier: cellIdentifier)
+        koreanEntriesTableView.register(
+            UINib(nibName: "KoreanEntryTableViewCell", bundle: nil),
+            forCellReuseIdentifier: cellIdentifier
+        )
 
         loadKoreanEntries()
         navigationController?.isNavigationBarHidden = false
-    }
-    
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "showEntryDetail" {
-            guard let entriesDetailViewController = segue.destination as? EntriesDetailViewController,
-                  let indexPath = koreanEntriesTableView.indexPathForSelectedRow else { return }
-            
-            entriesDetailViewController.koreanEntry = koreanEntries[indexPath.row]
-        }
     }
     
     private func loadKoreanEntries() {
@@ -75,4 +69,12 @@ extension KoreanEntriesViewController: UITableViewDataSource {
 
 extension KoreanEntriesViewController: UITableViewDelegate {
     
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let entriesDetailViewController =
+        storyboard?.instantiateViewController(withIdentifier: "entriesDetailViewController") as?
+        EntriesDetailViewController ?? EntriesDetailViewController()
+        
+        entriesDetailViewController.koreanEntry = koreanEntries[indexPath.row]
+        show(entriesDetailViewController, sender: nil)
+    }
 }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -20,8 +20,21 @@ final class MainViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        changeSupportAllOrientation(to: false)
         navigationController?.isNavigationBarHidden = true
         navigationController?.navigationBar.topItem?.backButtonTitle = "메인"
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        changeSupportAllOrientation(to: true)
+    }
+    
+    private func changeSupportAllOrientation(to option: Bool) {
+        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
+            appDelegate.isSupportAllOrientation = option
+        }
     }
     
     private func configureLabels() {

--- a/Expo1900/Expo1900/Delegate/AppDelegate.swift
+++ b/Expo1900/Expo1900/Delegate/AppDelegate.swift
@@ -5,8 +5,8 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
+    
+    var isSupportAllOrientation = true
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -25,6 +25,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return isSupportAllOrientation ? UIInterfaceOrientationMask.all : UIInterfaceOrientationMask.portrait
     }
 
 

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -172,28 +172,6 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="JUQ-Pk-2Ig">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="koreanEntryCell" textLabel="pLV-uw-3xc" style="IBUITableViewCellStyleDefault" id="EO1-tE-vid">
-                                        <rect key="frame" x="0.0" y="50" width="414" height="43.5"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EO1-tE-vid" id="tKU-Qw-8eI">
-                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pLV-uw-3xc">
-                                                    <rect key="frame" x="20" y="0.0" width="355.5" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                        <connections>
-                                            <segue destination="ulZ-oC-zn6" kind="show" identifier="showEntryDetail" id="eTJ-nD-sVQ"/>
-                                        </connections>
-                                    </tableViewCell>
-                                </prototypes>
                                 <connections>
                                     <outlet property="dataSource" destination="QWn-3S-hw7" id="UKR-hz-4eT"/>
                                     <outlet property="delegate" destination="QWn-3S-hw7" id="RoC-EK-mjS"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lf3-i1-umS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lf3-i1-umS">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -97,13 +97,13 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="beH-VI-GtS">
-                                                <rect key="frame" x="55.5" y="390" width="303" height="20"/>
+                                                <rect key="frame" x="69" y="390" width="276" height="20"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="500" verticalHuggingPriority="500" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="idL-cO-BQe">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJZ-eJ-ITS">
-                                                        <rect key="frame" x="61.5" y="0.0" width="180" height="20"/>
+                                                        <rect key="frame" x="61.5" y="0.0" width="153" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="20" id="U2V-bO-sIs"/>
                                                         </constraints>
@@ -114,7 +114,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="500" verticalHuggingPriority="500" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YVz-MF-9nK">
-                                                        <rect key="frame" x="261.5" y="0.0" width="41.5" height="20"/>
+                                                        <rect key="frame" x="234.5" y="0.0" width="41.5" height="20"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
@@ -199,7 +199,7 @@
         <!--Entries Detail View Controller-->
         <scene sceneID="K6o-Ii-HhA">
             <objects>
-                <viewController id="ulZ-oC-zn6" customClass="EntriesDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="entriesDetailViewController" id="ulZ-oC-zn6" customClass="EntriesDetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="h6I-Ou-Rqc">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -269,7 +269,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="lf3-i1-umS" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="XBA-bQ-Hwc">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -286,7 +286,7 @@
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="144" height="200"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lf3-i1-umS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lf3-i1-umS">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,89 +21,83 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="1500"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Tkw-tY-Ndk">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="410"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="411.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LBU-he-LRo">
-                                                <rect key="frame" x="175" y="0.0" width="64" height="32.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LBU-he-LRo">
+                                                <rect key="frame" x="174" y="0.0" width="66.5" height="33.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="WOx-cM-mJC">
-                                                <rect key="frame" x="135" y="40.5" width="144" height="200"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="poster" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WOx-cM-mJC">
+                                                <rect key="frame" x="135" y="41.5" width="144" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mn8-Wa-jRS">
-                                                <rect key="frame" x="160.5" y="248.5" width="93.5" height="24"/>
+                                                <rect key="frame" x="160.5" y="249.5" width="93.5" height="24"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13h-6o-EUm">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13h-6o-EUm">
                                                         <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2SD-DC-fP5">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2SD-DC-fP5">
                                                         <rect key="frame" x="52" y="0.0" width="41.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hc9-AL-4QU">
-                                                <rect key="frame" x="160.5" y="280.5" width="93.5" height="24"/>
+                                                <rect key="frame" x="160.5" y="281.5" width="93.5" height="24"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-Uv-rHf">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-Uv-rHf">
                                                         <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ceU-UL-xc1">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ceU-UL-xc1">
                                                         <rect key="frame" x="52" y="0.0" width="41.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s8q-Pa-s7v">
-                                                <rect key="frame" x="149" y="312.5" width="116" height="24"/>
+                                                <rect key="frame" x="149" y="313.5" width="116" height="24"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hpo-Ta-Yxe">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hpo-Ta-Yxe">
                                                         <rect key="frame" x="0.0" y="0.0" width="74.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="18b-Yv-8dm">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="18b-Yv-8dm">
                                                         <rect key="frame" x="74.5" y="0.0" width="41.5" height="24"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8H4-UP-Qps">
-                                                <rect key="frame" x="20.5" y="344.5" width="373" height="37.5"/>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="내용" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8H4-UP-Qps">
+                                                <rect key="frame" x="20.5" y="345.5" width="373" height="38"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <attributedString key="attributedText">
-                                                    <fragment content="내용">
-                                                        <attributes>
-                                                            <font key="NSFont" metaFont="system" size="18"/>
-                                                            <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                                        </attributes>
-                                                    </fragment>
-                                                </attributedString>
+                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="beH-VI-GtS">
-                                                <rect key="frame" x="69" y="390" width="276" height="20"/>
+                                                <rect key="frame" x="55.5" y="391.5" width="303" height="20"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="500" verticalHuggingPriority="500" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="idL-cO-BQe">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJZ-eJ-ITS">
-                                                        <rect key="frame" x="61.5" y="0.0" width="153" height="20"/>
+                                                        <rect key="frame" x="61.5" y="0.0" width="180" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="20" id="U2V-bO-sIs"/>
                                                         </constraints>
@@ -114,7 +108,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="500" verticalHuggingPriority="500" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YVz-MF-9nK">
-                                                        <rect key="frame" x="234.5" y="0.0" width="41.5" height="20"/>
+                                                        <rect key="frame" x="261.5" y="0.0" width="41.5" height="20"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
@@ -208,23 +202,16 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ba1-ze-fsD">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="83"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="88"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="aNu-77-UeJ">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aNu-77-UeJ">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
                                             </imageView>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pj9-K9-lbb">
-                                                <rect key="frame" x="0.0" y="50" width="414" height="33"/>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="내용" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pj9-K9-lbb">
+                                                <rect key="frame" x="0.0" y="50" width="414" height="38"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <attributedString key="attributedText">
-                                                    <fragment content="내용">
-                                                        <attributes>
-                                                            <color key="NSColor" systemColor="labelColor"/>
-                                                            <font key="NSFont" metaFont="system" size="14"/>
-                                                            <font key="NSOriginalFont" metaFont="system" size="14"/>
-                                                        </attributes>
-                                                    </fragment>
-                                                </attributedString>
+                                                <color key="textColor" systemColor="labelColor"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                         </subviews>
@@ -269,7 +256,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="lf3-i1-umS" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="XBA-bQ-Hwc">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -286,7 +273,7 @@
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="144" height="200"/>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lf3-i1-umS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="lf3-i1-umS">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,28 +21,28 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="1500"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Tkw-tY-Ndk">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="411.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="394.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LBU-he-LRo">
-                                                <rect key="frame" x="174" y="0.0" width="66.5" height="33.5"/>
+                                                <rect key="frame" x="177.5" y="0.0" width="59" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="poster" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WOx-cM-mJC">
-                                                <rect key="frame" x="135" y="41.5" width="144" height="200"/>
+                                                <rect key="frame" x="135" y="38" width="144" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mn8-Wa-jRS">
-                                                <rect key="frame" x="160.5" y="249.5" width="93.5" height="24"/>
+                                                <rect key="frame" x="167" y="246" width="80" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="13h-6o-EUm">
-                                                        <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2SD-DC-fP5">
-                                                        <rect key="frame" x="52" y="0.0" width="41.5" height="24"/>
+                                                        <rect key="frame" x="44.5" y="0.0" width="35.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -50,16 +50,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hc9-AL-4QU">
-                                                <rect key="frame" x="160.5" y="281.5" width="93.5" height="24"/>
+                                                <rect key="frame" x="167" y="274.5" width="80" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-Uv-rHf">
-                                                        <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="44.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ceU-UL-xc1">
-                                                        <rect key="frame" x="52" y="0.0" width="41.5" height="24"/>
+                                                        <rect key="frame" x="44.5" y="0.0" width="35.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -67,16 +67,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s8q-Pa-s7v">
-                                                <rect key="frame" x="149" y="313.5" width="116" height="24"/>
+                                                <rect key="frame" x="157.5" y="303" width="99" height="20.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hpo-Ta-Yxe">
-                                                        <rect key="frame" x="0.0" y="0.0" width="74.5" height="24"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="63.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="18b-Yv-8dm">
-                                                        <rect key="frame" x="74.5" y="0.0" width="41.5" height="24"/>
+                                                        <rect key="frame" x="63.5" y="0.0" width="35.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -84,20 +84,20 @@
                                                 </subviews>
                                             </stackView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="내용" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8H4-UP-Qps">
-                                                <rect key="frame" x="20.5" y="345.5" width="373" height="38"/>
+                                                <rect key="frame" x="20.5" y="331.5" width="373" height="35"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="beH-VI-GtS">
-                                                <rect key="frame" x="55.5" y="391.5" width="303" height="20"/>
+                                                <rect key="frame" x="69" y="374.5" width="276" height="20"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="500" verticalHuggingPriority="500" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="idL-cO-BQe">
                                                         <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJZ-eJ-ITS">
-                                                        <rect key="frame" x="61.5" y="0.0" width="180" height="20"/>
+                                                        <rect key="frame" x="61.5" y="0.0" width="153" height="20"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="20" id="U2V-bO-sIs"/>
                                                         </constraints>
@@ -108,7 +108,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="500" verticalHuggingPriority="500" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="YVz-MF-9nK">
-                                                        <rect key="frame" x="261.5" y="0.0" width="41.5" height="20"/>
+                                                        <rect key="frame" x="234.5" y="0.0" width="41.5" height="20"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
@@ -201,14 +201,14 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MMi-n0-Unq">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ba1-ze-fsD">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="88"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Ba1-ze-fsD">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="214"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aNu-77-UeJ">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="179"/>
                                             </imageView>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="내용" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pj9-K9-lbb">
-                                                <rect key="frame" x="0.0" y="50" width="414" height="38"/>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="252" scrollEnabled="NO" editable="NO" text="내용" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pj9-K9-lbb">
+                                                <rect key="frame" x="20.5" y="179" width="373" height="35"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -222,7 +222,9 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="Ba1-ze-fsD" firstAttribute="bottom" secondItem="ASU-p9-JrH" secondAttribute="bottom" id="EFi-Vg-UTA"/>
+                                    <constraint firstItem="Pj9-K9-lbb" firstAttribute="width" secondItem="Z6C-VA-C4a" secondAttribute="width" multiplier="0.9" id="QTN-4t-Dzk"/>
                                     <constraint firstItem="Ba1-ze-fsD" firstAttribute="trailing" secondItem="ASU-p9-JrH" secondAttribute="trailing" id="T7G-6e-IyZ"/>
+                                    <constraint firstItem="aNu-77-UeJ" firstAttribute="height" relation="lessThanOrEqual" secondItem="Z6C-VA-C4a" secondAttribute="height" multiplier="0.2" id="XDK-py-RAV"/>
                                     <constraint firstItem="Ba1-ze-fsD" firstAttribute="top" secondItem="ASU-p9-JrH" secondAttribute="top" id="sXw-Q9-q8m"/>
                                     <constraint firstItem="Ba1-ze-fsD" firstAttribute="leading" secondItem="ASU-p9-JrH" secondAttribute="leading" id="uaY-sh-Sbf"/>
                                     <constraint firstItem="Ba1-ze-fsD" firstAttribute="width" secondItem="Z6C-VA-C4a" secondAttribute="width" id="vmI-uf-hgS"/>
@@ -256,7 +258,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="lf3-i1-umS" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="XBA-bQ-Hwc">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -273,7 +275,7 @@
         <image name="flag" width="851" height="567"/>
         <image name="poster" width="144" height="200"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Expo1900/Expo1900/View/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/KoreanEntryTableViewCell.swift
@@ -1,0 +1,22 @@
+//  KoreanEntryTableViewCell.swift
+//  Created by Mangdi, zhilly on 2022/10/26
+
+import UIKit
+
+class KoreanEntryTableViewCell: UITableViewCell {
+
+    @IBOutlet weak var entryImage: UIImageView!
+    @IBOutlet weak var entryTitleLabel: UILabel!
+    @IBOutlet weak var entryShortDescription: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+}

--- a/Expo1900/Expo1900/View/KoreanEntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/KoreanEntryTableViewCell.swift
@@ -9,14 +9,11 @@ class KoreanEntryTableViewCell: UITableViewCell {
     @IBOutlet weak var entryTitleLabel: UILabel!
     @IBOutlet weak var entryShortDescription: UILabel!
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
-    }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    let cellIdentifier: String = "koreanEntryCell"
+    
+    func configureCell(imageName: String, entryName: String, description: String) {
+        entryImage.image = UIImage(named: imageName)
+        entryTitleLabel.text = entryName
+        entryShortDescription.text = description
     }
 }

--- a/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
+++ b/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,11 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="324" height="87"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="293.66666666666669" height="87"/>
+                <rect key="frame" x="0.0" y="0.0" width="295.33333333333331" height="87"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="902" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDr-p2-cUo">
-                        <rect key="frame" x="89.333333333333329" y="41.666666666666657" width="196.33333333333337" height="37.333333333333343"/>
+                        <rect key="frame" x="89.333333333333329" y="38" width="196.33333333333337" height="41"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -30,7 +30,7 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="901" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkR-7X-kWc">
-                        <rect key="frame" x="89.333333333333329" y="8" width="196.33333333333337" height="33.666666666666664"/>
+                        <rect key="frame" x="89.333333333333329" y="8" width="196.33333333333337" height="30"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
+++ b/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,23 +14,23 @@
             <rect key="frame" x="0.0" y="0.0" width="324" height="87"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="295.33333333333331" height="87"/>
+                <rect key="frame" x="0.0" y="0.0" width="293.66666666666669" height="87"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="902" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDr-p2-cUo">
-                        <rect key="frame" x="90.000000000000014" y="38" width="197.33333333333337" height="41"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="902" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDr-p2-cUo">
+                        <rect key="frame" x="89.333333333333329" y="41.666666666666657" width="196.33333333333337" height="37.333333333333343"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AjX-dn-wca">
-                        <rect key="frame" x="8" y="8" width="74" height="71"/>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AjX-dn-wca">
+                        <rect key="frame" x="8" y="8" width="73.333333333333329" height="71"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="AjX-dn-wca" secondAttribute="height" priority="900" id="Ggs-us-gq4"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="901" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkR-7X-kWc">
-                        <rect key="frame" x="90.000000000000014" y="8" width="197.33333333333337" height="30"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="901" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkR-7X-kWc">
+                        <rect key="frame" x="89.333333333333329" y="8" width="196.33333333333337" height="33.666666666666664"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
+++ b/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,41 +14,40 @@
             <rect key="frame" x="0.0" y="0.0" width="324" height="87"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="293.66666666666669" height="87"/>
+                <rect key="frame" x="0.0" y="0.0" width="295.33333333333331" height="87"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="H7R-YC-iIx">
-                        <rect key="frame" x="8" y="8" width="277.66666666666669" height="71"/>
-                        <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AjX-dn-wca">
-                                <rect key="frame" x="0.0" y="0.0" width="73.333333333333329" height="71"/>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="KTM-hH-BxG">
-                                <rect key="frame" x="81.333333333333329" y="0.0" width="196.33333333333337" height="71"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkR-7X-kWc">
-                                        <rect key="frame" x="0.0" y="0.0" width="196.33333333333334" height="35.666666666666664"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDr-p2-cUo">
-                                        <rect key="frame" x="0.0" y="35.666666666666657" width="196.33333333333334" height="35.333333333333343"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                            </stackView>
-                        </subviews>
-                    </stackView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="902" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDr-p2-cUo">
+                        <rect key="frame" x="90.000000000000014" y="38" width="197.33333333333337" height="41"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AjX-dn-wca">
+                        <rect key="frame" x="8" y="8" width="74" height="71"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="AjX-dn-wca" secondAttribute="height" priority="900" id="Ggs-us-gq4"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="901" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkR-7X-kWc">
+                        <rect key="frame" x="90.000000000000014" y="8" width="197.33333333333337" height="30"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="H7R-YC-iIx" secondAttribute="trailing" constant="8" id="QEM-id-jt8"/>
-                    <constraint firstAttribute="bottom" secondItem="H7R-YC-iIx" secondAttribute="bottom" constant="8" id="QLn-hs-Q4C"/>
-                    <constraint firstItem="H7R-YC-iIx" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="R01-MQ-j3P"/>
-                    <constraint firstItem="AjX-dn-wca" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.25" id="imO-2K-czT"/>
-                    <constraint firstItem="H7R-YC-iIx" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="kV8-bN-nId"/>
+                    <constraint firstAttribute="trailing" secondItem="DkR-7X-kWc" secondAttribute="trailing" constant="8" id="2S4-jv-ir2"/>
+                    <constraint firstItem="TDr-p2-cUo" firstAttribute="leading" secondItem="AjX-dn-wca" secondAttribute="trailing" constant="8" id="390-kF-Kol"/>
+                    <constraint firstItem="AjX-dn-wca" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="71K-PW-R52"/>
+                    <constraint firstAttribute="bottom" secondItem="AjX-dn-wca" secondAttribute="bottom" constant="8" id="8xa-8v-wc3"/>
+                    <constraint firstItem="AjX-dn-wca" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="DSN-7s-xc5"/>
+                    <constraint firstItem="DkR-7X-kWc" firstAttribute="leading" secondItem="AjX-dn-wca" secondAttribute="trailing" constant="8" id="EhC-S5-oFI"/>
+                    <constraint firstAttribute="trailing" secondItem="TDr-p2-cUo" secondAttribute="trailing" constant="8" id="Saz-ae-QSe"/>
+                    <constraint firstItem="TDr-p2-cUo" firstAttribute="top" secondItem="DkR-7X-kWc" secondAttribute="bottom" id="bTm-hz-Is7"/>
+                    <constraint firstItem="AjX-dn-wca" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.25" id="eBd-rt-xVs"/>
+                    <constraint firstAttribute="bottom" secondItem="TDr-p2-cUo" secondAttribute="bottom" constant="8" id="eLK-YZ-DI9"/>
+                    <constraint firstItem="DkR-7X-kWc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="mSY-Df-rXx"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -57,7 +56,7 @@
                 <outlet property="entryShortDescription" destination="TDr-p2-cUo" id="z5t-jd-ZNW"/>
                 <outlet property="entryTitleLabel" destination="DkR-7X-kWc" id="b42-eU-ZDv"/>
             </connections>
-            <point key="canvasLocation" x="146.15384615384616" y="26.658767772511847"/>
+            <point key="canvasLocation" x="82" y="-76"/>
         </tableViewCell>
     </objects>
 </document>

--- a/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
+++ b/Expo1900/Expo1900/View/KoreanEntryTableViewCell.xib
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="koreanEntryCell" rowHeight="87" id="KGk-i7-Jjw" customClass="KoreanEntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="324" height="87"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="293.66666666666669" height="87"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="H7R-YC-iIx">
+                        <rect key="frame" x="8" y="8" width="277.66666666666669" height="71"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="AjX-dn-wca">
+                                <rect key="frame" x="0.0" y="0.0" width="73.333333333333329" height="71"/>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="KTM-hH-BxG">
+                                <rect key="frame" x="81.333333333333329" y="0.0" width="196.33333333333337" height="71"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DkR-7X-kWc">
+                                        <rect key="frame" x="0.0" y="0.0" width="196.33333333333334" height="35.666666666666664"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TDr-p2-cUo">
+                                        <rect key="frame" x="0.0" y="35.666666666666657" width="196.33333333333334" height="35.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="H7R-YC-iIx" secondAttribute="trailing" constant="8" id="QEM-id-jt8"/>
+                    <constraint firstAttribute="bottom" secondItem="H7R-YC-iIx" secondAttribute="bottom" constant="8" id="QLn-hs-Q4C"/>
+                    <constraint firstItem="H7R-YC-iIx" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="R01-MQ-j3P"/>
+                    <constraint firstItem="AjX-dn-wca" firstAttribute="width" secondItem="H2p-sc-9uM" secondAttribute="width" multiplier="0.25" id="imO-2K-czT"/>
+                    <constraint firstItem="H7R-YC-iIx" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="kV8-bN-nId"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="entryImage" destination="AjX-dn-wca" id="AUi-nD-d9w"/>
+                <outlet property="entryShortDescription" destination="TDr-p2-cUo" id="z5t-jd-ZNW"/>
+                <outlet property="entryTitleLabel" destination="DkR-7X-kWc" id="b42-eU-ZDv"/>
+            </connections>
+            <point key="canvasLocation" x="146.15384615384616" y="26.658767772511847"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 8. [참고 링크](#8-참고-링크)
 
 ## 1. 소개
-> UITableView, UIScrollView와 JSON 데이터를 활용한 만국 박람회 소개 애플리케이션 입니다.
+UITableView, UIScrollView와 JSON 데이터를 활용한 만국 박람회 소개 애플리케이션 입니다.
 <br>
 
 ## 2. 팀원
@@ -32,23 +32,30 @@
 [STEP-1]
 - 2022.10.17
     - JSON 파일을 Decoding할 Model 타입 생성
-    - 프로젝트 파일 폴더별로 정리
-    - STEP-1 Pull Request
+    - 프로젝트 파일들을 MVC방식으로 정리
 
 [STEP-2] 
 - 2022.10.18
     - 프로젝트에 Asset 파일 추가
-    - JSON 파일을 Decoding해서 Model에 저장할 수 있는 코드 추가
-    - 메인 화면 구성
-    - 한국의 출품작 목록 화면 구성
-    - 기초 레이아웃 설정
+    - JSON 파일을 Decoding해서 화면에 데이터를 뿌려줄수있게 구현
+    - 한국의 출품작 (두번째화면)을 테이블뷰로 구현
 - 2022.10.20
-    - 한국의 출품작 상세 설명 화면 구성
-    - 화면간 데이터 전달하는 기능 구현
-    - 리팩토링
-    - STEP-2 Pull Request
+    - 출품작의 디테일뷰 (세번째화면) 구현
+    - 두번째화면에서 세번째화면으로 넘어갈때 prepare로 값을전달하여 구현
+- 2022.10.23
+    - 첫화면의 네비게이션바가 안보이게, status bar 영역까지 컨텐츠가 보이도록 구현
+    - 네비게이션 back버튼의 타이틀 버그 수정 및 에러처리 도입
 
 [STEP-3]
+- 2022.10.25
+    - 첫화면은 세로로만, 나머지화면은 가로세로 적용되게 구현
+- 2022.10.26
+    - 테이블뷰의 셀을 기본형에서 CustomCell로 구현
+    - 2번째화면에서 3번째화면으로 세그가 아닌 TableView Delegate로 값 전달하게 구현
+    - 셀의 레이블뷰 내용이 전부 보일수있도록 오토레이아웃 수정
+    - 모든화면에 Dynamic Type 적용
+- 2022.10.27
+    - 세번째화면의 오토레이아웃 수정
 
 <br>
 
@@ -72,25 +79,34 @@
 │   ├── ExpositionUniverselle.swift
 │   └── KoreanEntry.swift
 └── View
-    └── Base.lproj
-        ├── LaunchScreen.storyboard
-        └── Main.storyboard
+    ├── Base.lproj
+    │   ├── LaunchScreen.storyboard
+    │   └── Main.storyboard
+    ├── KoreanEntryTableViewCell.swift
+    └── KoreanEntryTableViewCell.xib
 ```
 
 
 <br>
 
 ## 5. 실행 화면
-![celle](https://user-images.githubusercontent.com/49121469/197090538-185541b7-438c-4142-8852-43cb89210e99.gif)
+### 세로화면 실행
+<img src=https://user-images.githubusercontent.com/99257965/198444794-974a2a7c-59f5-4506-9f4d-66497555d0f7.gif>
 
+### 가로화면 실행
+<img src=https://user-images.githubusercontent.com/99257965/198447614-1cafb9b1-c054-40ed-b52a-8896c08b6630.gif width=500>
+
+
+### 모든 화면에 Dynamic Type을 적용
+<img src=https://user-images.githubusercontent.com/99257965/198439670-17d106f1-b8ea-467c-a9e8-3a18be8dd27d.gif width=500>
 
 
 ## 6. 트러블 슈팅
 <details>
     <summary>다른 컨트롤러로 이동힐 때의 방법 고민</summary>
-KoreanEntriesViewController에서 EntriesViewController로 이동할때 UITableViewDelegate를 사용할지 세그의 prepare를 사용할지 고민되었습니다.
+`KoreanEntriesViewController` 에서 `EntriesViewController`로 이동할때 `UITableViewDelegate`를 사용할지 세그의 prepare를 사용할지 고민되었습니다.
     
-테이블뷰의 셀을 클릭할때 값을 넘겨줘야하는데 셀을 클릭하는 상호작용은 delegate가 맡을텐데 UITableViewDelegate를 이용하는것이 맞을것이다. 하는 생각과 값을 넘겨주는 것이니까 세그를 사용하는게 맞다 하는 두가지 생각이 들었습니다. 둘중 어느방법이 나을까 고민하다가 공식문서에 테이블뷰의 indexPathForSelectedRow 라는 속성이 있다는것을 알곤, 세그의 prepare로 쉽게 구현이 가능했습니다.
+테이블뷰의 셀을 클릭할때 값을 넘겨줘야하는데 셀을 클릭하는 상호작용은 delegate가 맡을텐데 `UITableViewDelegate`를 이용하는것이 맞을것이다. 하는 생각과 값을 넘겨주는 것이니까 세그를 사용하는게 맞다 하는 두가지 생각이 들었습니다. 둘중 어느방법이 나을까 고민하다가 공식문서에 테이블뷰의 `indexPathForSelectedRow` 라는 속성이 있다는것을 알곤, 세그의 prepare로 쉽게 구현이 가능했습니다.
 만약 delegate로 구현했다면 코드가 훨씬 더 길어졌을것같단 생각이 들었습니다.
 이로써 문서읽어보기의 중요성을 다시한번 상기시켜봅니다.
 <img width="959" alt="스크린샷 2022-10-20 오후 5 22 53" src="https://user-images.githubusercontent.com/49121469/197091019-fea1d2cd-a249-4e6b-81a5-1250e0f18631.png">
@@ -98,21 +114,39 @@ KoreanEntriesViewController에서 EntriesViewController로 이동할때 UITableV
 </details>
 
 <details>
-    <summary>UIScrollView 초기 레이아웃 설정</summary>
-    UIScrollView는 다른 요소들 보다 초기에 설정해줘야할 제약사항들이 많았습니다. 계속 에러가 나는 현상을 겪었고, 원인은 안에 있는 View에 height나 width에 제약사항을 잘못 걸어줘서 나는 에러였습니다. 
+    <summary>`UIScrollView` 초기 레이아웃 설정</summary>
+    `UIScrollView`는 다른 요소들 보다 초기에 설정해줘야할 제약사항들이 많았습니다. 계속 에러가 나는 현상을 겪었고, 원인은 안에 있는 View에 height나 width에 제약사항을 잘못 걸어줘서 나는 에러였습니다. 
 
 해결 방법 : 
-    1. ScrollView 내부에 요소의 width를 ScrollView의 Frame Layout Guide에 Equal Width를 해줬습니다.
-    2. height는 세로 ScrollView이기 때문에 동적으로 변할 수 있도록 constant를 0으로 설정하고 priority 값을 조정해줬습니다.
+    1. `ScrollView` 내부에 요소의 width를 `ScrollView`의 `Frame Layout Guide`에 Equal Width를 해줬습니다.
+    2. height는 세로 `ScrollView`이기 때문에 동적으로 변할 수 있도록 constant를 0으로 설정하고 priority 값을 조정해줬습니다.
     
 </details>
     
     
 <details>
-    <summary>UITableViewCell의 textLabel이 deprecated 된것</summary>
-    tableViewCell의 textLabel.text = "" 이러한코드를 작성할때 노란글씨로 deprecated라는 경고문을 보았습니다. 
+    <summary>`UITableViewCell`의 textLabel이 deprecated 된것</summary>
+    `tableViewCell`의 textLabel.text = "" 이러한코드를 작성할때 노란글씨로 `deprecated`라는 경고문을 보았습니다. 
     그렇다면 어떤식으로 작성해야하는지 왜 그렇게 해야하는지에 찾아봤습니다.
     wwdc 2020에 나온 내용으로, ios14 버전부터 셀에 새로운 content configurations을 사용한다는것과 테이블뷰와 컬렉션뷰에 들어가는 셀을 동일한 접근 방식을 사용하는 표준이라는점 그리고 경량화하고 성능을 높이기 위해 쓰인다는것을 알게 되었습니다. 이 밖에도 여러가지 정보가 있습니다. 아래 WWDC2020 Cell Notes 링크를 통해 더 자세히 알아볼수 있습니다.
+
+</details>
+
+
+<details>
+    <summary>커스텀셀의 오토레이아웃</summary>
+    커스텀셀을 생성하고 이미지 하나와 제목레이블 하나 그리고 설명하는 레이블 하나로 구성해주었습니다.
+    레이블 두개를 스택뷰로 묶고 그다음 이미지와 스택뷰를 또 스택뷰로 묶어주었습니다.
+    근데 설명레이블에 들어있는 텍스트만큼 높이를 유동적으로 주는것이 목표였는데 이미지의 크기만큼 높이가 더이상 늘어나지 않아서 어떻게 해야할까 고민이었습니다.
+    결국 오토레이아웃에 대한 이해도가 부족하여 생긴 일이었습니다.
+    다시 오토레이아웃에 대해 공부해보면서 차근차근 해결했습니다.
+
+</details>
+
+<details>
+    <summary>JSON 파일 Decoding 실패 시 오류처리</summary>
+    JSON 파일을 Decoding 실패 했을 때 처음엔 그냥 빈 값을 반환해주는 구조였습니다. 이렇게 되면 사용자 입장에서 보면 어떤 오류 때문에 데이터들이 안나오는지 알 수 없기 때문에 alert을 사용자에게 띄워줘서 메시지를 확인 할 수 있도록 했습니다.
+    
 
 </details>
     
@@ -123,6 +157,11 @@ KoreanEntriesViewController에서 EntriesViewController로 이동할때 UITableV
 - UITableView와 UITableViewCell의 이해
 - Cell의 재사용
 - JSON 형식의 데이터 Encoding, Decoding
+- 네비게이션 컨트롤러를 활용한 화면 전환
+- 다양한 기기에 AutoLayout 적용하기
+- 화면회전 방법에 대한 이해
+- 접근성의 개념과 필요성에 대한 이해
+- Dynamic Types에 대한 이해
 
 
 <br>
@@ -135,6 +174,7 @@ KoreanEntriesViewController에서 EntriesViewController로 이동할때 UITableV
     - [Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
     - [Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)
 - [WWDC2020 Cell Notes](https://www.wwdcnotes.com/notes/wwdc20/10027/)
+- [Accessibility Inspector (WWDC 2019)](https://developer.apple.com/videos/play/wwdc2019/257/)
 
 
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ UITableView, UIScrollView와 JSON 데이터를 활용한 만국 박람회 소개
 <br>
 
 ## 4. 시각화된 프로젝트 구조
+### 클래스 다이어그램
+![universelleUML](https://user-images.githubusercontent.com/49121469/198496550-c04c4036-3ccd-4825-b8d8-0e97bcfcf7d8.png)
+
 ### File Tree
 
 ```bash


### PR DESCRIPTION
@uuu1101 
안녕하세요 태태 :)
STEP-3 완료해서 PR 보냅니다!
AutoLayout에 시간을 제일 많이 할애했습니다 ㅠㅠ

## 🤔 고민했던점

### TableViewCell에 대한 고민
저희가 원래 구현했던 방식으로는 Layout을 잡아주기 힘들 것 같다고 판단해서
Custom Cell을 따로 만들어줘서 구현하는 방식으로 변경했습니다.

xib파일을 같이 만들어줘서 Cell의 xib 파일에서 AutoLayout을 잡아주는 방식으로 진행했습니다.

### 특정화면 세로방향 고정
애플리케이션 전체를 화면 고정할 때에는 프로젝트 설정에서 정해줄 수 있는데, 특정화면을 세로고정하거나, 특정화면에 들어가면 방향을 다시 바꿔준다거나 상세하게 설정해야 할 때에는 어떤 방식으로 해야할지 고민했습니다.

결론은 AppDelegate 파일에서 변수를 하나 두고, `supportedInterfaceOrientationsFor` 를 이용해 화면 고정값을 정해주는 방식으로 진행했습니다.

ViewController 단위에서 화면을 고정해야하거나, 화면을 회전시켜줘야 할 때, viewWillAppear, viewDisAppear 에서 AppDelegate에 접근해 변수를 수정해서 AppDelegate에서 이 ViewController에 대한 화면 전환 값을 알 수 있도록 구현했습니다.


## ✏️ 조언을 얻고 싶은 부분

(서로 구동환경 Xcode 버전과 iOS 버전이 같지 않음)
질리의 시뮬레이터(Version 14.0.1 (986.3))는 가로세로 화면 회전이 정상적으로 작동이 되는데
망디의 시뮬레이터(Version 13.4.1 (977.2))는 정상적인 작동이 되지 않습니다.
가로세로가 바뀌는 그런 기본적인동작이 고작 시뮬레이터의 버전이 조금 낮기때문에? 안되는거라고 보기가 힘든데 혹시 이부분에 대해서 조언해주실수있을까 여쭤봅니다..!

|질리 화면|망디 화면|
|--|--|
|![](https://user-images.githubusercontent.com/99257965/198177304-fe9c1bdf-f3f2-42e4-8075-985ea1ab6b09.gif)|![](https://user-images.githubusercontent.com/49121469/198176460-ed5c3ccc-940b-4e06-b956-ca691848eed5.gif)|