### PR TITLE
만국박람회 [Step3] 애종, 로빈

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1AE4FDEA29023CE20027F2A3 /* ItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE4FDE929023CE20027F2A3 /* ItemDetailViewController.swift */; };
 		1AE4FDEE2908D5A00027F2A3 /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE4FDED2908D5A00027F2A3 /* ItemCell.swift */; };
+		1AE4FDF0290905530027F2A3 /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE4FDEF290905530027F2A3 /* NavigationController.swift */; };
 		1AF7876828FE3E0F0094A911 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7876728FE3E0F0094A911 /* Exposition.swift */; };
 		1AF7878729022ACD0094A911 /* KoreanItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7878629022ACD0094A911 /* KoreanItemsViewController.swift */; };
 		1AF7878929023A210094A911 /* ItemDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1AF7878829023A210094A911 /* ItemDetail.storyboard */; };
@@ -36,6 +37,7 @@
 /* Begin PBXFileReference section */
 		1AE4FDE929023CE20027F2A3 /* ItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailViewController.swift; sourceTree = "<group>"; };
 		1AE4FDED2908D5A00027F2A3 /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
+		1AE4FDEF290905530027F2A3 /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
 		1AF7876728FE3E0F0094A911 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		1AF7878629022ACD0094A911 /* KoreanItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemsViewController.swift; sourceTree = "<group>"; };
 		1AF7878829023A210094A911 /* ItemDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ItemDetail.storyboard; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 				1AF7878629022ACD0094A911 /* KoreanItemsViewController.swift */,
 				1AE4FDE929023CE20027F2A3 /* ItemDetailViewController.swift */,
 				1AE4FDED2908D5A00027F2A3 /* ItemCell.swift */,
+				1AE4FDEF290905530027F2A3 /* NavigationController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 				1AF7876828FE3E0F0094A911 /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
+				1AE4FDF0290905530027F2A3 /* NavigationController.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				1AF7878729022ACD0094A911 /* KoreanItemsViewController.swift in Sources */,
 			);
@@ -470,6 +474,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Expo1900/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -488,6 +493,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Expo1900/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		1AE4FDEA29023CE20027F2A3 /* ItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE4FDE929023CE20027F2A3 /* ItemDetailViewController.swift */; };
+		1AE4FDEE2908D5A00027F2A3 /* ItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE4FDED2908D5A00027F2A3 /* ItemCell.swift */; };
 		1AF7876828FE3E0F0094A911 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7876728FE3E0F0094A911 /* Exposition.swift */; };
 		1AF7878729022ACD0094A911 /* KoreanItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF7878629022ACD0094A911 /* KoreanItemsViewController.swift */; };
 		1AF7878929023A210094A911 /* ItemDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1AF7878829023A210094A911 /* ItemDetail.storyboard */; };
@@ -34,6 +35,7 @@
 
 /* Begin PBXFileReference section */
 		1AE4FDE929023CE20027F2A3 /* ItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemDetailViewController.swift; sourceTree = "<group>"; };
+		1AE4FDED2908D5A00027F2A3 /* ItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemCell.swift; sourceTree = "<group>"; };
 		1AF7876728FE3E0F0094A911 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		1AF7878629022ACD0094A911 /* KoreanItemsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KoreanItemsViewController.swift; sourceTree = "<group>"; };
 		1AF7878829023A210094A911 /* ItemDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ItemDetail.storyboard; sourceTree = "<group>"; };
@@ -84,6 +86,7 @@
 				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
 				1AF7878629022ACD0094A911 /* KoreanItemsViewController.swift */,
 				1AE4FDE929023CE20027F2A3 /* ItemDetailViewController.swift */,
+				1AE4FDED2908D5A00027F2A3 /* ItemCell.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -266,6 +269,7 @@
 			files = (
 				572241D028FE3AA3006E1783 /* Item.swift in Sources */,
 				1AE4FDEA29023CE20027F2A3 /* ItemDetailViewController.swift in Sources */,
+				1AE4FDEE2908D5A00027F2A3 /* ItemCell.swift in Sources */,
 				57FF4DE12907A00600717706 /* Converter.swift in Sources */,
 				1AF7876828FE3E0F0094A911 /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,

--- a/Expo1900/Expo1900/Controllers/ItemCell.swift
+++ b/Expo1900/Expo1900/Controllers/ItemCell.swift
@@ -1,0 +1,26 @@
+//
+//  ItemCell.swift
+//  Expo1900
+//
+//  Created by 노유빈 on 2022/10/26.
+//
+
+import UIKit
+
+class ItemCell: UITableViewCell {
+    @IBOutlet weak var itemImageView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var subtitleLabel: UILabel!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/Expo1900/Expo1900/Controllers/ItemCell.swift
+++ b/Expo1900/Expo1900/Controllers/ItemCell.swift
@@ -2,7 +2,7 @@
 //  ItemCell.swift
 //  Expo1900
 //
-//  Created by 노유빈 on 2022/10/26.
+//  Created by Rhovin, Aejong on 2022/10/26.
 //
 
 import UIKit

--- a/Expo1900/Expo1900/Controllers/ItemCell.swift
+++ b/Expo1900/Expo1900/Controllers/ItemCell.swift
@@ -19,7 +19,7 @@ class ItemCell: UITableViewCell {
 
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
+        
         // Configure the view for the selected state
     }
 

--- a/Expo1900/Expo1900/Controllers/ItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ItemDetailViewController.swift
@@ -24,6 +24,5 @@ final class ItemDetailViewController: UIViewController {
         itemImageView.image = UIImage(named: selectedItem?.imageName ?? "flag")
         itemImageView.contentMode = .scaleAspectFit
         itemDescLabel.text = selectedItem?.desc
-        itemDescLabel.numberOfLines = 0
     }
 }

--- a/Expo1900/Expo1900/Controllers/KoreanItemsViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanItemsViewController.swift
@@ -46,5 +46,6 @@ extension KoreanItemsViewController: UITableViewDelegate {
         itemDetailViewController.selectedItem = items?[indexPath.row]
         
         self.navigationController?.pushViewController(itemDetailViewController, animated: true)
+        tableView.deselectRow(at: indexPath, animated: true)
     }
 }

--- a/Expo1900/Expo1900/Controllers/KoreanItemsViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreanItemsViewController.swift
@@ -27,14 +27,13 @@ extension KoreanItemsViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell = koreanItemsTableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
+        guard let cell: ItemCell = koreanItemsTableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? ItemCell else {
+            return UITableViewCell()
+        }
         
-        cell.accessoryType = .disclosureIndicator
-        cell.imageView?.image = UIImage(named: items?[indexPath.row].imageName ?? "")
-        cell.textLabel?.text = items?[indexPath.row].name
-        cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .title1)
-        cell.detailTextLabel?.text = items?[indexPath.row].shortDesc
-        cell.detailTextLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        cell.itemImageView?.image = UIImage(named: items?[indexPath.row].imageName ?? "")
+        cell.titleLabel?.text = items?[indexPath.row].name
+        cell.subtitleLabel?.text = items?[indexPath.row].shortDesc
         
         return cell
     }

--- a/Expo1900/Expo1900/Controllers/MainViewController.swift
+++ b/Expo1900/Expo1900/Controllers/MainViewController.swift
@@ -30,11 +30,12 @@ final class MainViewController: UIViewController {
         self.navigationController?.isNavigationBarHidden = true
     }
     
-    private func configureLabel(text: String?, textStyle: UIFont.TextStyle, numberOfLines: Int = 1) -> UILabel {
+    private func configureLabel(text: String?, textStyle: UIFont.TextStyle, numberOfLines: Int = 0) -> UILabel {
         let label = UILabel()
         label.text = text
         label.font = UIFont.preferredFont(forTextStyle: textStyle)
         label.numberOfLines = numberOfLines
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }
@@ -65,6 +66,9 @@ final class MainViewController: UIViewController {
             button.setTitle("🇰🇷 한국의 출품작 보러가기 🇰🇷", for: .normal)
             button.setTitleColor(.systemBlue, for: .normal)
             button.addAction(action, for: .touchUpInside)
+            button.titleLabel?.numberOfLines = 0
+            button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
             
             return button
         }()
@@ -87,6 +91,7 @@ final class MainViewController: UIViewController {
     private func configureView() {
         configureLabels()
         posterImageView = UIImageView(image: UIImage(named: "poster"))
+        posterImageView.adjustsImageSizeForAccessibilityContentSizeCategory = true
         configureButton()
         addSubviews()
     }

--- a/Expo1900/Expo1900/Controllers/NavigationController.swift
+++ b/Expo1900/Expo1900/Controllers/NavigationController.swift
@@ -1,0 +1,18 @@
+//
+//  NavigationController.swift
+//  Expo1900
+//
+//  Created by Rhovin, Aejong on 2022/10/26.
+//
+
+import UIKit
+
+class NavigationController: UINavigationController {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard let _ = self.topViewController as? MainViewController else {
+            return .all
+        }
+        
+        return .portrait
+    }
+}

--- a/Expo1900/Expo1900/Controllers/NavigationController.swift
+++ b/Expo1900/Expo1900/Controllers/NavigationController.swift
@@ -9,10 +9,6 @@ import UIKit
 
 class NavigationController: UINavigationController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        guard let _ = self.topViewController as? MainViewController else {
-            return .all
-        }
-        
-        return .portrait
+        return self.topViewController as? MainViewController != nil ? .portrait : .all
     }
 }

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,10 +18,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5u-8I-Xij">
-                                <rect key="frame" x="20" y="92" width="374" height="804"/>
+                                <rect key="frame" x="20" y="88" width="374" height="808"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zkd-PA-cqB">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="804"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="808"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -64,38 +64,55 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MXd-6I-fGC">
-                                <rect key="frame" x="20" y="92" width="374" height="804"/>
+                                <rect key="frame" x="20" y="88" width="374" height="808"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="374" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="85" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="44.5" width="374" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TYe-Ox-9k4" id="OIn-1e-3Bp">
-                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345.5" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
-                                                    <rect key="frame" x="0.0" y="1" width="68.5" height="68.5"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
-                                                    <rect key="frame" x="76.5" y="8" width="66.5" height="54"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="T7W-n0-cP5">
+                                                    <rect key="frame" x="0.0" y="9" width="337.5" height="67"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
-                                                            <rect key="frame" x="0.0" y="0.0" width="66.5" height="33.5"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
-                                                            <rect key="frame" x="0.0" y="33.5" width="66.5" height="20.5"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
+                                                            <rect key="frame" x="0.0" y="0.0" width="67.5" height="67"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" secondItem="hiT-2Y-2mB" secondAttribute="height" multiplier="1:1" id="S00-e5-pAm"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
+                                                            <rect key="frame" x="75.5" y="10" width="262" height="47"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="262" height="30"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
+                                                                    <rect key="frame" x="0.0" y="30" width="262" height="17"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
                                                     </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="hiT-2Y-2mB" firstAttribute="width" secondItem="T7W-n0-cP5" secondAttribute="width" multiplier="0.2" id="Q0m-SN-oz8"/>
+                                                    </constraints>
                                                 </stackView>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="T7W-n0-cP5" secondAttribute="trailing" constant="8" id="50b-Xf-Tlj"/>
+                                                <constraint firstItem="T7W-n0-cP5" firstAttribute="leading" secondItem="OIn-1e-3Bp" secondAttribute="leading" id="8wb-nz-dOD"/>
+                                                <constraint firstAttribute="bottom" secondItem="T7W-n0-cP5" secondAttribute="bottom" constant="9" id="UaZ-fP-x5y"/>
+                                                <constraint firstItem="T7W-n0-cP5" firstAttribute="centerY" secondItem="OIn-1e-3Bp" secondAttribute="centerY" id="pex-mX-jcJ"/>
+                                                <constraint firstItem="T7W-n0-cP5" firstAttribute="top" secondItem="OIn-1e-3Bp" secondAttribute="top" constant="9" id="wYB-I6-cJj"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="itemImageView" destination="hiT-2Y-2mB" id="D51-qD-D5k"/>
@@ -130,7 +147,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wav-5u-leO" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="RZq-Fv-yH7">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,10 +18,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5u-8I-Xij">
-                                <rect key="frame" x="20" y="88" width="374" height="808"/>
+                                <rect key="frame" x="20" y="92" width="374" height="804"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zkd-PA-cqB">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="808"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="804"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -64,36 +64,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MXd-6I-fGC">
-                                <rect key="frame" x="20" y="88" width="374" height="808"/>
+                                <rect key="frame" x="20" y="92" width="374" height="804"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="85" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="374" height="85"/>
+                                        <rect key="frame" x="0.0" y="50" width="374" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TYe-Ox-9k4" id="OIn-1e-3Bp">
-                                            <rect key="frame" x="0.0" y="0.0" width="345.5" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="T7W-n0-cP5">
-                                                    <rect key="frame" x="0.0" y="9" width="337.5" height="67"/>
+                                                    <rect key="frame" x="0.0" y="9" width="335.5" height="67"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
-                                                            <rect key="frame" x="0.0" y="0.0" width="67.5" height="67"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="67" height="67"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="hiT-2Y-2mB" secondAttribute="height" multiplier="1:1" id="S00-e5-pAm"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
-                                                            <rect key="frame" x="75.5" y="10" width="262" height="47"/>
+                                                            <rect key="frame" x="75" y="6.5" width="260.5" height="54"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="262" height="30"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="260.5" height="33.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
-                                                                    <rect key="frame" x="0.0" y="30" width="262" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="33.5" width="260.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -144,10 +144,10 @@
         <!--Navigation Controller-->
         <scene sceneID="c3l-8n-Fxy">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wav-5u-leO" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wav-5u-leO" customClass="NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="RZq-Fv-yH7">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,10 +18,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5u-8I-Xij">
-                                <rect key="frame" x="0.0" y="92" width="414" height="804"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zkd-PA-cqB">
-                                        <rect key="frame" x="20" y="0.0" width="374" height="804"/>
+                                        <rect key="frame" x="20" y="0.0" width="374" height="808"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -64,36 +64,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MXd-6I-fGC">
-                                <rect key="frame" x="20" y="92" width="374" height="804"/>
+                                <rect key="frame" x="20" y="88" width="374" height="808"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="85" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="374" height="85"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="374" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TYe-Ox-9k4" id="OIn-1e-3Bp">
-                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345.5" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="T7W-n0-cP5">
-                                                    <rect key="frame" x="0.0" y="9" width="335.5" height="67"/>
+                                                    <rect key="frame" x="0.0" y="9" width="337.5" height="67"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
-                                                            <rect key="frame" x="0.0" y="0.0" width="67" height="67"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="67.5" height="67"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="hiT-2Y-2mB" secondAttribute="height" multiplier="1:1" id="S00-e5-pAm"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
-                                                            <rect key="frame" x="75" y="6.5" width="260.5" height="54"/>
+                                                            <rect key="frame" x="75.5" y="10" width="262" height="47"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="260.5" height="33.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="262" height="30"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
-                                                                    <rect key="frame" x="0.0" y="33.5" width="260.5" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="30" width="262" height="17"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -147,7 +147,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wav-5u-leO" customClass="NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="RZq-Fv-yH7">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -67,33 +67,41 @@
                                 <rect key="frame" x="20" y="92" width="374" height="804"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="itemCell" textLabel="Cm5-FV-T31" detailTextLabel="V8V-H0-E5h" imageView="NOr-8c-hN7" style="IBUITableViewCellStyleSubtitle" id="JLh-AQ-m4V">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="50" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JLh-AQ-m4V" id="DLb-op-PDa">
-                                            <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TYe-Ox-9k4" id="OIn-1e-3Bp">
+                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Cm5-FV-T31">
-                                                    <rect key="frame" x="101" y="6" width="25" height="14.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="V8V-H0-E5h">
-                                                    <rect key="frame" x="101" y="22.5" width="44" height="14.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="flag" id="NOr-8c-hN7">
-                                                    <rect key="frame" x="20" y="0.0" width="66" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
+                                                    <rect key="frame" x="0.0" y="1" width="68.5" height="68.5"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
+                                                    <rect key="frame" x="76.5" y="8" width="66.5" height="54"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
+                                                            <rect key="frame" x="0.0" y="0.0" width="66.5" height="33.5"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
+                                                            <rect key="frame" x="0.0" y="33.5" width="66.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="itemImageView" destination="hiT-2Y-2mB" id="D51-qD-D5k"/>
+                                            <outlet property="subtitleLabel" destination="Wta-5d-FRU" id="jPf-NC-WBG"/>
+                                            <outlet property="titleLabel" destination="4a2-yN-h9L" id="wcN-tr-hVU"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
@@ -136,7 +144,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="flag" width="851" height="567"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,10 +18,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5u-8I-Xij">
-                                <rect key="frame" x="20" y="92" width="374" height="804"/>
+                                <rect key="frame" x="20" y="88" width="374" height="808"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zkd-PA-cqB">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="804"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="808"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -64,36 +64,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MXd-6I-fGC">
-                                <rect key="frame" x="20" y="92" width="374" height="804"/>
+                                <rect key="frame" x="20" y="88" width="374" height="808"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="85" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="374" height="85"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="374" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TYe-Ox-9k4" id="OIn-1e-3Bp">
-                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345.5" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="T7W-n0-cP5">
-                                                    <rect key="frame" x="0.0" y="9" width="335.5" height="67"/>
+                                                    <rect key="frame" x="0.0" y="9" width="337.5" height="67"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
-                                                            <rect key="frame" x="0.0" y="0.0" width="67" height="67"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="67.5" height="67"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="hiT-2Y-2mB" secondAttribute="height" multiplier="1:1" id="S00-e5-pAm"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
-                                                            <rect key="frame" x="75" y="6.5" width="260.5" height="54"/>
+                                                            <rect key="frame" x="75.5" y="10" width="262" height="47"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="260.5" height="33.5"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="262" height="30"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
-                                                                    <rect key="frame" x="0.0" y="33.5" width="260.5" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="30" width="262" height="17"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -147,7 +147,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wav-5u-leO" customClass="NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="RZq-Fv-yH7">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wav-5u-leO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,17 +18,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d5u-8I-Xij">
-                                <rect key="frame" x="20" y="88" width="374" height="808"/>
+                                <rect key="frame" x="0.0" y="92" width="414" height="804"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="zkd-PA-cqB">
-                                        <rect key="frame" x="0.0" y="0.0" width="374" height="808"/>
+                                        <rect key="frame" x="20" y="0.0" width="374" height="804"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="zkd-PA-cqB" firstAttribute="width" secondItem="xdb-rZ-lKJ" secondAttribute="width" id="OZx-Bq-r1X"/>
-                                    <constraint firstAttribute="trailing" secondItem="zkd-PA-cqB" secondAttribute="trailing" id="Ogb-es-4aY"/>
+                                    <constraint firstAttribute="trailing" secondItem="zkd-PA-cqB" secondAttribute="trailing" constant="20" id="1RO-gV-0xY"/>
+                                    <constraint firstItem="zkd-PA-cqB" firstAttribute="centerX" secondItem="d5u-8I-Xij" secondAttribute="centerX" id="2yM-XQ-M7f"/>
                                     <constraint firstAttribute="bottom" secondItem="zkd-PA-cqB" secondAttribute="bottom" id="P6D-Xa-gXW"/>
-                                    <constraint firstItem="zkd-PA-cqB" firstAttribute="leading" secondItem="d5u-8I-Xij" secondAttribute="leading" id="RhI-rb-s8c"/>
+                                    <constraint firstAttribute="leading" secondItem="zkd-PA-cqB" secondAttribute="leading" constant="-20" id="lLF-Mb-hfa"/>
                                     <constraint firstItem="zkd-PA-cqB" firstAttribute="height" secondItem="xdb-rZ-lKJ" secondAttribute="height" priority="250" id="mSd-oS-q3j"/>
                                     <constraint firstItem="zkd-PA-cqB" firstAttribute="top" secondItem="d5u-8I-Xij" secondAttribute="top" id="vof-yq-6cW"/>
                                 </constraints>
@@ -39,9 +39,9 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="d5u-8I-Xij" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="0Nb-je-5wD"/>
+                            <constraint firstItem="d5u-8I-Xij" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="0Nb-je-5wD"/>
                             <constraint firstAttribute="bottom" secondItem="d5u-8I-Xij" secondAttribute="bottom" id="X22-o6-xgN"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="d5u-8I-Xij" secondAttribute="trailing" constant="20" id="jnI-nN-Azh"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="d5u-8I-Xij" secondAttribute="trailing" id="jnI-nN-Azh"/>
                             <constraint firstItem="d5u-8I-Xij" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="l01-wm-lkP"/>
                         </constraints>
                     </view>
@@ -64,36 +64,36 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="MXd-6I-fGC">
-                                <rect key="frame" x="20" y="88" width="374" height="808"/>
+                                <rect key="frame" x="20" y="92" width="374" height="804"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" rowHeight="85" id="TYe-Ox-9k4" customClass="ItemCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="374" height="85"/>
+                                        <rect key="frame" x="0.0" y="50" width="374" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TYe-Ox-9k4" id="OIn-1e-3Bp">
-                                            <rect key="frame" x="0.0" y="0.0" width="345.5" height="85"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="343.5" height="85"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="T7W-n0-cP5">
-                                                    <rect key="frame" x="0.0" y="9" width="337.5" height="67"/>
+                                                    <rect key="frame" x="0.0" y="9" width="335.5" height="67"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hiT-2Y-2mB">
-                                                            <rect key="frame" x="0.0" y="0.0" width="67.5" height="67"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="67" height="67"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="hiT-2Y-2mB" secondAttribute="height" multiplier="1:1" id="S00-e5-pAm"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-2k-iEf">
-                                                            <rect key="frame" x="75.5" y="10" width="262" height="47"/>
+                                                            <rect key="frame" x="75" y="6.5" width="260.5" height="54"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4a2-yN-h9L">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="262" height="30"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="260.5" height="33.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wta-5d-FRU">
-                                                                    <rect key="frame" x="0.0" y="30" width="262" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="33.5" width="260.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -147,7 +147,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wav-5u-leO" customClass="NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="RZq-Fv-yH7">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/Views/ItemDetail.storyboard
+++ b/Expo1900/Expo1900/Views/ItemDetail.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="20" y="44" width="350" height="800"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J3H-Hv-aiQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="358" height="244.33333333333334"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="358" height="241"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fxc-Mp-rIQ">
                                                 <rect key="frame" x="29" y="8" width="300" height="200"/>
@@ -29,9 +29,9 @@
                                                     <constraint firstAttribute="height" constant="200" id="G4L-Nq-s06"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k9c-HJ-Dqp">
-                                                <rect key="frame" x="0.0" y="224" width="338" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k9c-HJ-Dqp">
+                                                <rect key="frame" x="0.0" y="224" width="338" height="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>

--- a/Expo1900/Expo1900/Views/ItemDetail.storyboard
+++ b/Expo1900/Expo1900/Views/ItemDetail.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,19 +18,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hQz-ir-uut">
-                                <rect key="frame" x="20" y="44" width="350" height="800"/>
+                                <rect key="frame" x="0.0" y="47" width="390" height="797"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J3H-Hv-aiQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="358" height="241"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="399" height="244.33333333333334"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fxc-Mp-rIQ">
-                                                <rect key="frame" x="29" y="8" width="300" height="200"/>
+                                                <rect key="frame" x="29" y="8" width="341" height="200"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="200" id="G4L-Nq-s06"/>
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k9c-HJ-Dqp">
-                                                <rect key="frame" x="0.0" y="224" width="338" height="17"/>
+                                                <rect key="frame" x="20" y="224" width="359" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -62,8 +62,8 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="hQz-ir-uut" secondAttribute="trailing" constant="20" id="G9g-7E-hVH"/>
-                            <constraint firstItem="hQz-ir-uut" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="HMK-gn-cGC"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="hQz-ir-uut" secondAttribute="trailing" id="G9g-7E-hVH"/>
+                            <constraint firstItem="hQz-ir-uut" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="HMK-gn-cGC"/>
                             <constraint firstItem="hQz-ir-uut" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Xp2-vj-5h9"/>
                             <constraint firstAttribute="bottom" secondItem="hQz-ir-uut" secondAttribute="bottom" id="lKB-xb-n36"/>
                             <constraint firstItem="k9c-HJ-Dqp" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="yc1-1R-8Pv"/>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 3. [구현 내용](#-구현-내용)
 4. [타임라인](#-타임라인)
 5. [실행 화면](#-실행-화면)
-6. [트러블 슈팅 & 어려웠던 점](#-트러블-슈팅-&-어려웠던-점)
+6. [트러블 슈팅 & 어려웠던 점](#-트러블-슈팅--어려웠던-점)
 7. [참고 링크](#-참고-링크)
 
 ## 🌱 소개
@@ -240,7 +240,7 @@ imageView와 Label들을 stackView로 설정하여 가로,세로로 보여지는
 | 네비게이션 이동   |  가로 / 세로 모드        | 다이나믹 타입   | 
 | :------------------: | :--------------: | :--------------:  |
 | ![](https://i.imgur.com/IA0sjhx.gif) | ![가로모드 테스트](https://user-images.githubusercontent.com/73284068/198534965-dd10dc16-1aa1-429d-a65a-677417cafaba.gif) |    ![다이나믹타입 테스트](https://user-images.githubusercontent.com/73284068/198534983-3b28e844-0f04-4bf6-b2af-d9934d07726a.gif)
- |
+ 
 
 
 ## ❓ 트러블 슈팅 & 어려웠던 점
@@ -311,19 +311,18 @@ self.navigationController?.pushViewController(itemDetailViewController, animated
 
 ## 📖 참고 링크
 
-[UITableView](https://developer.apple.com/documentation/uikit/uitableview)
-[Table Views](https://developer.apple.com/documentation/uikit/views_and_controls/table_views)
-[Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data)
-[Configuring the Cells for Your Table](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/configuring_the_cells_for_your_table)
-[JSON](https://ko.wikipedia.org/wiki/JSON)
+[UITableView](https://developer.apple.com/documentation/uikit/uitableview) <br>
+[Table Views](https://developer.apple.com/documentation/uikit/views_and_controls/table_views) <br>
+[Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data) <br>
+[Configuring the Cells for Your Table](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/configuring_the_cells_for_your_table) <br>
+[JSON](https://ko.wikipedia.org/wiki/JSON) <br>
 [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
-- [Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
-- [Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)
+<br> - [Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
+<br> - [Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)
+[LLDB 정복하기](https://yagom.net/courses/start-lldb/) <br>
+[Swift Language Guide - Protocols](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html) <br>
+[Swift Language Guide - Extentions](https://docs.swift.org/swift-book/LanguageGuide/Extensions.html) <br>
+[Swift Language Guide - Closures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html) <br>
+[NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter) <br>
 
-[LLDB 정복하기](https://yagom.net/courses/start-lldb/)
-[Swift Language Guide - Protocols](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html)
-[Swift Language Guide - Extentions](https://docs.swift.org/swift-book/LanguageGuide/Extensions.html)
-[Swift Language Guide - Closures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html)
-[NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)
-
-[🔝 맨 위로 이동하기](# -만국박람회- )
+[🔝 맨 위로 이동하기](#-만국박람회-)

--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ imageView와 Label들을 stackView로 설정하여 가로,세로로 보여지는
 ## 📱 실행 화면
 | 네비게이션 이동   |  가로 / 세로 모드        | 다이나믹 타입   | 
 | :------------------: | :--------------: | :--------------:  |
-| ![](https://i.imgur.com/IA0sjhx.gif) | ![](https://i.imgur.com/hW0KjFC.gif) |     ![](https://i.imgur.com/EyklbqE.gif) |
+| ![](https://i.imgur.com/IA0sjhx.gif) | ![가로모드 테스트](https://user-images.githubusercontent.com/73284068/198534965-dd10dc16-1aa1-429d-a65a-677417cafaba.gif) |    ![다이나믹타입 테스트](https://user-images.githubusercontent.com/73284068/198534983-3b28e844-0f04-4bf6-b2af-d9934d07726a.gif)
+ |
+
 
 ## ❓ 트러블 슈팅 & 어려웠던 점
 
@@ -308,6 +310,7 @@ self.navigationController?.pushViewController(itemDetailViewController, animated
 ---
 
 ## 📖 참고 링크
+
 [UITableView](https://developer.apple.com/documentation/uikit/uitableview)
 [Table Views](https://developer.apple.com/documentation/uikit/views_and_controls/table_views)
 [Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## 📖 목차
 
 1. [소개](#-소개)
-2. [Tree](#-tree)
-3. [고민한 점](#-고민한-점)
+2. [프로젝트 구조](#-프로젝트-구조)
+3. [구현 내용](#-구현-내용)
 4. [타임라인](#-타임라인)
 5. [실행 화면](#-실행-화면)
-6. [트러블 슈팅 & 어려웠던 점](#-트러블-슈팅--어려웠던-점)
+6. [트러블 슈팅 & 어려웠던 점](#-트러블-슈팅-&-어려웠던-점)
 7. [참고 링크](#-참고-링크)
 
 ## 🌱 소개
@@ -21,26 +21,35 @@
   - decodable
   - reuse cell
   - json
+  - Dynamic Type
 
 
-## 🌲 Tree
+## 🛠 프로젝트 구조
+### 📊 UML
+![](https://i.imgur.com/AMTpKL2.jpg)
 
+
+### 🌲 Tree
 
 ```
 <Expo1900>
-├── AppDelegate.swift
-├── Assets.xcassets
-├── Base.lproj
-│   └── LaunchScreen.storyboard
 ├── Controllers
+│   ├── ItemCell.swift
 │   ├── ItemDetailViewController.swift
 │   ├── KoreanItemsViewController.swift
-│   └── MainViewController.swift
+│   ├── MainViewController.swift
+│   └── NavigationController.swift
 ├── Info.plist
 ├── Models
 │   ├── Exposition.swift
 │   └── Item.swift
-├── SceneDelegate.swift
+├── NameSpace
+│   └── Converter.swift
+├── SupportingFiles
+│   ├── AppDelegate.swift
+│   ├── Base.lproj
+│   │   └── LaunchScreen.storyboard
+│   └── SceneDelegate.swift
 └── Views
     ├── Base.lproj
     │   └── Main.storyboard
@@ -48,51 +57,132 @@
 
 ```
 
-## 👀 고민한 점
+## 📌 구현 내용
 
-### 1. 프로젝트 디렉토리 정리
-- MVC별로 폴더를 정리할 때, appDelegate, sceneDelegate, Assets, LaunchScreen이건 어디에 넣어야 할지 고민했다.
+#### 화면 UI 구현
+화면 UI를 구현할 때, 스토리보드와 코드를 이용하여 구현
 
-### 2. json데이터 디코딩하는 함수 네이밍
-- exposition, item을 디코딩하려고 할 때 함수명을 fetch...() 혹은 decode...() 중 어떤 네이밍을 더 적절한지 고민했다.
- 
-### 3. 클로저를 사용해서 속성을 한번에 정의할지, 객체를 생성한 후 속성을 설정하는게 좋은지 고민했다.
+
+#### 화면전환의 방식
+프로젝트에서 `총 3개의 View`가 있어서 `2번의 화면전환`이 이루어지고  navigation방식을 통해 push,pop 된다.
+Segue를 쓰는 방식과 VC를 생성해서 push해주는 방식으로 구현
+
+- 메인 -> 한국의출품작 으로 화면이동할 땐 따로 데이터를 전달하지 않기 때문에 간단하게 버튼의 action에 `performSegue()`메서드를 넣어 segue를 통해 화면이 전환되게 구현
+- 한국의출품작 -> cell상세 뷰 로 화면이동을 할 때에는 `UITableViewDelegate`의 `tableView()`메서드 내부에서 VC의 인스턴스를 생성해주고, cell에 해당하는 데이터를 전달되게 구현
+
+
+#### 제네릭을 활용한 decode() 메서드 구현
+`[Item]` 혹은 `Exposition` 타입의 형태로 디코딩해주는 메서드 decode()를 jsonDecoder.decode()메서드처럼 제네릭을 통해 파일 명만 입력하면 파일에 맞는 리턴타입이 나오도록 구현
 
 ```swift
-let posterImageView: UIImageView = {
-    let imageView = UIImageView()
-    imageView.image = UIImage(named: "poster")
+// jsonDecoder.decode() 메서드 정의
+open func decode<T>(_ type: T.Type, from data: Data) throws -> T where T : Decodable
+```
+---
+
+위와 비슷한 방법으로 매개변수에 Model의 타입을 추가해준다면 Model 타입은 매개변수를 통해 결정
+```swift
+// 메서드 정의
+static func decode<Model: Decodable>(_ file: String) -> Model? {
+        guard let dataAsset: NSDataAsset = NSDataAsset(name: file) else { return nil }
+        
+        let model = try? Converter.jsonDecoder.decode(Model.self, from: dataAsset.data)
+        
+        return model
+    }
+
+// 메서드 사용
+exposition = Converter.decode(type: Exposition.self, "exposition_universelle_1900")
+```
+
+
+
+### 메인화면 세로로만 볼 수 있게 구현
+앱 딜리게이트를 이용하는 방법을 통해 첫 번째 화면만 세로로 볼 수 있게 구현했지만 `모든 뷰 컨트롤러에서 딜리게이트를 사용해야 한다는 점`, `앱 딜리게이트와 결합도가 높아지는 점`을 이유로 네비게이션 컨트롤러 클래스의 `supportedInterfaceOrientations` 프로퍼티를 활용하는 방법으로 구현
+
+
+1. 앱 딜리게이트를 이용하는 방법
+    - 화면 회전을 위해서 `AppDelegate`에서 아래처럼 `supportedInterfaceOrientation: bool` 값을 설정해서, true일 경우 모든 회전이 가능, false일 경우 세로만 가능하도록 설정
+
+``` swift
+var shouldSupportAllOrientation = true
+
+func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+    if supportedInterfaceOrientations {
+        return .all
+    }
     
-    return imageView
-}()
-
-let label = UILabel()
-label.text = text
-label.font = UIFont.preferredFont(forTextStyle: textStyle)
-label.numberOfLines = numberOfLines
-return label
-```
-### 4. 화면전환 과정에서의 Optional Binding 처리
-VC객체를 생성해서 화면전환을 할 때 보통 optional binding을 해주라고 하는데, 스토리보드상의 뷰컨트롤러를 쓰려고 하면 왜 옵셔널을 처리해주지 않아도 되는건지 궁금했다. `instantiateViewController()`메서드의 기능은 identifier에 해당하는 뷰컨트롤러를 찾아 생성한다. 해당 identifier를 가진 뷰컨트롤러가 존재하지 않을 가능성도 있기 때문에 옵셔널타입이고 이를 binding해준다고 생각했다.
-그럼 2번째 case처럼 UIStoryboard를 통해 인스턴스를 생성해줄 때, 그 안의 원하는 컨트롤러를 찾을 때에도 1번째 case와 마찬가지로 옵셔널 처리를 해주어야하지 않을까??
-
-```swift
-// 같은 스토리보드 내에서 VC를 생성해줄 때,
-// itemDetailViewController를 옵셔널 바인딩처리해줘야 함
-guard let itemDetailViewController = storyboard?.instantiateViewController(withIdentifier: "ItemDetailViewControllerID") else {
-    return 
+    return .portrait
 }
-self.navigationController?.pushViewController(itemDetailViewController, animated: true)
 ```
+ - 그리고 각 뷰컨트롤러에서 앱딜리게이트를 설정 및 뷰 라이프사이클에서 `appDelegate.shouldSupportAllOrientation` 변수를 true, false 하는 방법으로 메인화면은 세로방향 고정, 다른 뷰들은 모든방향이 가능하도록 설정
+
 
 ```swift
-// 다른 스토리보드 내에서 VC를 생성해줄 때,
-// storyboard, itemDetailViewController가 옵셔널 타입이 아님
-// 빌드는 문제없이 되지만, identifier를 잘못 입력할 경우 runtime 오류 발생
-let storyboard = UIStoryboard(name: "ItemDetail", bundle: Bundle.main)
-let itemDetailViewController = storyboard.instantiateViewController(withIdentifier: "ItemDetailViewControllerID")
-self.navigationController?.pushViewController(itemDetailViewController, animated: true)
+private var appDelegate = UIApplication.shared.delegate as! AppDelegate
+
+override func viewWillAppear(_ animated: Bool) {
+    appDelegate.shouldSupportAllOrientation = true또는 false
+}
+
 ```
+- 하지만 이런 방법은 모든 뷰 컨트롤러에서 앱딜리게이트와 라이프사이클을 설정해주어야 한다는 이슈가 있음. 그래서 2번째 네비게이션 컨트롤러를 이용하는 방법을 사용하여 구현
+
+2. 네비게이션 컨트롤러를 이용하는 방법
+    - 화면 회전을 위해서 `var supportedInterfaceOrientations: UIInterfaceOrientationMask` 변수를 오버라이딩하여 화면 회전 설정
+    - 네비게이션 컨트롤러가 하위 뷰를 아래와 같은 방법으로 메인뷰는 세로만, 나머지는 모든방향이 가능하도록 설정
+
+```swift
+class NavigationController: UINavigationController {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return self.topViewController as? MainViewController != nil ? .portrait : .all
+    }
+}
+```
+
+3. 실행화면
+
+| ![Oct-27-2022_10-29-13](https://user-images.githubusercontent.com/49301866/198180870-d84c0f63-925e-478e-83b9-68e737f52348.gif) |
+| :----------------------------------: |
+
+
+
+### 출품작 목록과 상세 두 화면 모두 가로로 회전했을 때도 정상적으로 표시될 수 있도록 구현
+
+기본타입 셀은 이미지뷰의 크기를 조절할 수 없어 autolayout을 설정해주기 어려웠음. 그래서 `ItemCell`이라는 custom 셀을 활용해 autolayout을 설정
+
+- 기본타입셀과 custom셀 화면 비교
+
+
+| 기본타입(subtitle) 셀   |  custom 셀        |
+| :------------------: | :--------------: | 
+| ![](https://i.imgur.com/ERzX7D4.jpg)| ![](https://i.imgur.com/EvAQr2w.png)
+
+
+- 계층구조
+
+imageView와 Label들을 stackView로 설정하여 가로,세로로 보여지는 동안 imageView 혹은 Label묶음의 크기변화에 모두 반응하는 cell을 구현
+|    ||
+| :------------------: | :--------------: | 
+| ![](https://i.imgur.com/JXdq3gU.png) | ![](https://i.imgur.com/ttKMjSK.png) |
+
+
+
+### 모든 화면에 Dynamic Type을 적용
+1. UI객체 Dynamic Type 설정
+    - UI객체들 Dynamic Type 적용하였습니다. 스토리보드에 있는 UI객체는 아래와 같이 인스펙터 창에서 Dynamic Type 체크 설정
+![](https://i.imgur.com/P5s29vy.png)
+    - 코드로 작성한 UI객체는 `adjustsFontForContentSizeCategory`프로퍼티를 `true`로 설정
+
+2. Label이 있는 UI객체 `numberOfLines`프로퍼티 0으로 설정
+    - 글씨가 커지는 경우 레이블 텍스트가 여러줄로 표현될 수 있도록 `numberOfLines`를 0으로 설정
+
+3. Label `lineBreak` 설정
+    - 텍스트가 화면을 넘어가 짤리는 경우 ...으로 표현되는 것을 방지하기 위해 `lineBreak`을 `TrunkCase`에서 `Word Wrap` 또는 `Character Wrap` 으로 설정
+    - 현재는 문자단위로 짤리는 `Character Wrap`으로 설정. 단어단위로 짤려야 하는게 좀 더 가독성이 좋은 경우는 `Word Wrap`을 사용할 예정
+
+4. 실행화면
+![](https://i.imgur.com/rI6fhk1.gif)
 
 
 ## ⏰ 타임라인
@@ -124,6 +214,10 @@ self.navigationController?.pushViewController(itemDetailViewController, animated
 - 221021: itemDetail 스토리보드 추가
     - itemDetail 뷰 구현 Autolayout 제약 추가
     - VC 인스턴스 생성을 통한 화면전환
+- 221025: Exposition모델의 가공된 프로퍼티 extension으로 분리
+- 221025: jsonDecoder, numberFormatter namespace화
+- 221025: decode() 메서드 제네릭을 활용해 통일
+    
     
 </div>
 </details>
@@ -132,35 +226,101 @@ self.navigationController?.pushViewController(itemDetailViewController, animated
 <summary>Step3 타임라인</summary>
 <div markdown="1">       
     
-- 
-- 
+- 221026: 커스텀 셀 itemCell 추가
+- 221026: autolayout 설정
+- 221026: NavigationController 클래스 추가
+    - 뷰별로 orientation 설정
+- 221026: 모든 화면에 DynamicType 적용
     
 </div>
 </details>
 
 
 ## 📱 실행 화면
-추후 작성 예정
+| 네비게이션 이동   |  가로 / 세로 모드        | 다이나믹 타입   | 
+| :------------------: | :--------------: | :--------------:  |
+| ![](https://i.imgur.com/IA0sjhx.gif) | ![](https://i.imgur.com/hW0KjFC.gif) |     ![](https://i.imgur.com/EyklbqE.gif) |
 
 ## ❓ 트러블 슈팅 & 어려웠던 점
 
+ 
+### 클로저를 사용해서 속성을 한번에 정의할지, 객체를 생성한 후 속성을 설정하는게 좋은지 고민
+> ### 💡 트러블슈팅
+> 자주 바뀌지 않은 하는 속성일 경우(폰트와 폰트 사이즈 등) 클로저를 사용하여 객체를 생성하고, 레이블처럼 나중에 변경될 경우가 있는 속성일 경우 클로저 밖에서 설정.
 
+```swift
+let label: UILable = {
+    let label = UILable()
+    label.font = UIFont.preferredFont(forTextStyle: textStyle)
+    
+    return label
+}()
+
+label.text = text
+```
+### 화면전환 과정에서의 Optional Binding 처리에 관한 의문
+VC객체를 생성해서 화면전환을 할 때 보통 optional binding을 해주라고 하는데, 스토리보드상의 뷰컨트롤러를 쓰려고 하면 왜 옵셔널을 처리해주지 않아도 되는건지 궁금했다. `instantiateViewController()`메서드의 기능은 identifier에 해당하는 뷰컨트롤러를 찾아 생성한다. 해당 identifier를 가진 뷰컨트롤러가 존재하지 않을 가능성도 있기 때문에 옵셔널타입이고 이를 binding해준다고 생각했다.
+그럼 2번째 case처럼 UIStoryboard를 통해 인스턴스를 생성해줄 때, 그 안의 원하는 컨트롤러를 찾을 때에도 1번째 case와 마찬가지로 옵셔널 처리를 해주어야하지 않을까??
+
+```swift
+// 같은 스토리보드 내에서 VC를 생성해줄 때,
+// itemDetailViewController를 옵셔널 바인딩처리해줘야 함
+guard let itemDetailViewController = storyboard?.instantiateViewController(withIdentifier: "ItemDetailViewControllerID") else {
+    return 
+}
+self.navigationController?.pushViewController(itemDetailViewController, animated: true)
+```
+
+```swift
+// 다른 스토리보드 내에서 VC를 생성해줄 때,
+// storyboard, itemDetailViewController가 옵셔널 타입이 아님
+// 빌드는 문제없이 되지만, identifier를 잘못 입력할 경우 runtime 오류 발생
+let storyboard = UIStoryboard(name: "ItemDetail", bundle: Bundle.main)
+let itemDetailViewController = storyboard.instantiateViewController(withIdentifier: "ItemDetailViewControllerID")
+self.navigationController?.pushViewController(itemDetailViewController, animated: true)
+```
+> ### 💡 트러블슈팅
+> 공식문서를 살펴보면 `instantiateViewController()`의 리턴타입은 `옵셔널이 아니다`. 그 말은 옵셔널 바인딩을 해주는 이유가 `instantiateViewController()`때문은 아니라는 말.
+>
+> 위의 case에서 보여지는 차이점은 storyboard가 옵셔널인지 아닌지의 차이 뿐이다. 결국 storyboard가 nil이라면, 하위 메서드인 `instantiateViewController()` 또한 nil이 되기 때문에 결국 옵셔널 바인딩을 해주는 이유는 storyboard가 nil일 가능성이 있기 때문이다.
+
+
+### 오토레이아웃 constraint 오류 발생
+테이블뷰 화면에서만 세로모드에서 가로모드로 변경할 때 콘솔창에 긴 메세지가 출력 시뮬레이터가 멈추거나 런타임오류가 발생하는 건 아니지만 에러메세지로 보여짐.
+![](https://i.imgur.com/ARg2ogz.gif)
+
+> ### 💡 트러블슈팅
+> 오류 메세지의 NSLayoutConstraint 을 복붙해서 [WTF Autolayout](https://www.wtfautolayout.com/) 에 넣어보고 어떤 오류인지 파악하기
+> ![](https://i.imgur.com/2GBFfKq.png)
+
+
+
+
+
+### tableCell을 선택해 상세페이지로 이동 후, 다시 tableView로 돌아왔을 때 여전히 회색으로 선택되어있는 문제
+> ### 💡 트러블슈팅
+> UITableViewDelegate에서 상세페이지로 넘어갈 때 해당 indexPath에 `deselectRow()`메서드를 호출
+
+| deselect 전   |    deselect 후      |
+| :------------------: | :--------------: | 
+| ![](https://i.imgur.com/VzprqjZ.gif)| ![](https://i.imgur.com/lUtAV0Z.gif)
 
 ---
 
 ## 📖 참고 링크
-[UITableView](https://developer.apple.com/documentation/uikit/uitableview) <br>
-[Table Views](https://developer.apple.com/documentation/uikit/views_and_controls/table_views) <br>
-[Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data) <br>
-[Configuring the Cells for Your Table](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/configuring_the_cells_for_your_table) <br>
-[JSON](https://ko.wikipedia.org/wiki/JSON) <br>
+[UITableView](https://developer.apple.com/documentation/uikit/uitableview)
+[Table Views](https://developer.apple.com/documentation/uikit/views_and_controls/table_views)
+[Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data)
+[Configuring the Cells for Your Table](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/configuring_the_cells_for_your_table)
+[JSON](https://ko.wikipedia.org/wiki/JSON)
 [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
-<br> - [Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
-<br> - [Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)
-[LLDB 정복하기](https://yagom.net/courses/start-lldb/) <br>
-[Swift Language Guide - Protocols](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html) <br>
-[Swift Language Guide - Extentions](https://docs.swift.org/swift-book/LanguageGuide/Extensions.html) <br>
-[Swift Language Guide - Closures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html) <br>
-[NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter) <br>
+- [Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
+- [Encoding and Decoding Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)
 
-[🔝 맨 위로 이동하기](#-만국박람회-)
+[LLDB 정복하기](https://yagom.net/courses/start-lldb/)
+[Swift Language Guide - Protocols](https://docs.swift.org/swift-book/LanguageGuide/Protocols.html)
+[Swift Language Guide - Extentions](https://docs.swift.org/swift-book/LanguageGuide/Extensions.html)
+[Swift Language Guide - Closures](https://docs.swift.org/swift-book/LanguageGuide/Closures.html)
+[NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)
+
+[🔝 맨 위로 이동하기](# -만국박람회- )


### PR DESCRIPTION
# 만국박람회 [STEP 3] PR


@stevenkim18
안녕하세요 스티븐 애종, 로빈입니다. 저번에 말씀해주신대로 저희가 전달하고자 하는 내용이 잘 담기도록 노력했습니다! 
스텝3 잘부탁드립니다~~

---
## 구현 내용
### 메인화면 세로로만 볼 수 있게 설정
처음에는 앱 딜리게이트를 이용하는 방법을 통해 첫 번째 화면만 세로로 볼 수 있게 구현했습니다.
하지만 `모든 뷰 컨트롤러에서 딜리게이트를 사용해야 한다는 점`, `앱 딜리게이트와 결합도가 높아지는 점`을 이유로 네비게이션 컨트롤러 클래스의 `supportedInterfaceOrientations` 프로퍼티를 활용하는 방법으로 수정했습니다.


1. 앱 딜리게이트를 이용하는 방법
    - 화면 회전을 위해서 `AppDelegate`에서 아래처럼 `supportedInterfaceOrientation: bool` 값을 설정해서, true일 경우 모든 회전이 가능, false일 경우 세로만 가능하도록 설정하였습니다. 

``` swift
var shouldSupportAllOrientation = true

func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
    if supportedInterfaceOrientations {
        return .all
    }
    
    return .portrait
}
```
 - 그리고 각 뷰컨트롤러에서 앱딜리게이트를 설정 및 뷰 라이프사이클에서 `appDelegate.shouldSupportAllOrientation` 변수를 true, false 하는 방법으로 메인화면은 세로방향 고정, 다른 뷰들은 모든방향이 가능하도록 설정하였습니다. 


```swift
private var appDelegate = UIApplication.shared.delegate as! AppDelegate

override func viewWillAppear(_ animated: Bool) {
    appDelegate.shouldSupportAllOrientation = true또는 false
}

```
- 하지만 이런 방법은 모든 뷰 컨트롤러에서 앱딜리게이트와 라이프사이클을 설정해주어야 한다는 것이 마음에 들지 않았습니다. 그래서 2번째 네비게이션 컨트롤러를 이용하는 방법을 사용했습니다.

2. 네비게이션 컨트롤러를 이용하는 방법
    - 화면 회전을 위해서 `var supportedInterfaceOrientations: UIInterfaceOrientationMask` 변수를 오버라이딩하면 가로, 세로로 설정해 준다는 것을 알았습니다.
    - 네비게이션 컨트롤러 클래스를 만들어서 하위에 뷰 컨트롤러들을 담고 있기 때문에 여기서 아래와 같은 방법으로 메인뷰는 세로만, 나머지는 모든방향이 가능하도록 설정하였습니다.

```swift
class NavigationController: UINavigationController {
    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return self.topViewController as? MainViewController != nil ? .portrait : .all
    }
}
```

3. 실행화면

| ![Oct-27-2022_10-29-13](https://user-images.githubusercontent.com/49301866/198180870-d84c0f63-925e-478e-83b9-68e737f52348.gif) |
| :----------------------------------: |



### 출품작 목록과 상세 두 화면 모두 가로로 회전했을 때도 정상적으로 표시될 수 있도록 구현

처음 테이블뷰의 셀은 기본타입인 *subtitle*스타일을 사용했습니다. 
하지만 기본타입 셀은 이미지뷰의 크기를 조절할 수 없어 autolayout을 설정해주기 어려웠습니다. 그래서 `ItemCell`이라는 custom 셀을 활용해 autolayout을 잡아주었습니다.

- 기본타입셀과 custom셀 화면 비교


| 기본타입(subtitle) 셀   |  custom 셀        |
| :------------------: | :--------------: | 
| ![](https://i.imgur.com/ERzX7D4.jpg)| ![](https://i.imgur.com/EvAQr2w.png)


- 계층구조

imageView와 Label들을 stackView로 묶어주었습니다. 이로써 가로,세로로 보여지는 동안 imageView 혹은 Label묶음의 크기변화에 모두 반응하는 cell을 구현했습니다.
실행되는 동안 콘솔에 메세지들이 뜨는 부분은 아래 해결되지 않은 점에서 써보겠습니다.
|    ||
| :------------------: | :--------------: | 
| ![](https://i.imgur.com/JXdq3gU.png) | ![](https://i.imgur.com/ttKMjSK.png) |



### 모든 화면에 Dynamic Type을 적용
1. UI객체 Dynamic Type 설정
    - UI객체들 Dynamic Type 적용하였습니다. 스토리보드에 있는 UI객체는 아래와 같이 인스펙터 창에서 Dynamic Type 체크를 해주었습니다.
![](https://i.imgur.com/P5s29vy.png)
    - 코드로 작성한 UI객체는 `adjustsFontForContentSizeCategory`프로퍼티를 `true`로 설정하였습니다.

2. Label이 있는 UI객체 `numberOfLines`프로퍼티 0으로 설정
    - 글씨가 커지는 경우 레이블 텍스트가 여러줄로 표현될 수 있도록 `numberOfLines`를 0으로 설정하였습니다.

3. Label `lineBreak` 설정
    - 텍스트가 화면을 넘어가 짤리는 경우 ...으로 표현되는 것을 방지하기 위해 `lineBreak`을 `TrunkCase`에서 `Word Wrap` 또는 `Character Wrap` 으로 설정하였습니다.
    - 현재는 문자단위로 짤리는 `Character Wrap`으로 설정을 했는데, 단어단위로 짤려야 하는게 좀 더 가독성이 좋은 경우는 `Word Wrap`을 사용해야 겠다고 생각했습니다.

4. 실행화면
![](https://i.imgur.com/rI6fhk1.gif)


---
## 해결되지 않은 부분 / 조언받고 싶은 부분

### 테이블뷰 화면에서 가로로 변경할 때 메세지가 뜨는 문제
테이블뷰 화면에서만 세로모드에서 가로모드로 변경할 때 콘솔창에 긴 메세지가 출력됩니다. 시뮬레이터가 멈추거나 런타임오류가 발생하는 건 아니지만 에러메세지로 보여집니다.
![](https://i.imgur.com/ARg2ogz.gif)

- 메세지 내용
```
Expo1900[68298:27285039] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
해석: 제약조건을 만족시키지 못한다. 네가 원하지 않는 제약조건이 하나 있을 것이다. 
    각 제약을 둘러보고 원하지 않은 제약이 추가되어있다면 수정해주어라.
```

메세지를 본 후 imageView에 걸어준 `Aspect Ratio`가 원인인 것 까진 알아냈습니다. 하지만 Aspect Ratio를 풀어주면 imageView의 사이즈를 통일시킬 수 없어 현재 해결방법을 못 찾고 있는 상태입니다.


### ios버전에 따른 supportedInterfaceOrientations 설정 문제
저희가 Xcode 버전이 다르다보니 시뮬레이터의 iOS 버전이 다른채로 테스트 하다가 아래와 같은 문제점을 발견했습니다.

두 번째 화면에서 첫 번째 화면으로 돌아갈 때, 15.5 버전은 `supportedInterfaceOrientations` 의 .portrait가 리턴되지 않아 landscape된 상태로 보여집니다. 그 상태로 다시 화면을 회전하면 정상적으로 `supportedInterfaceOrientations`가 반영되는 것은 확인했습니다.

breakpoint를 걸어주며 확인한 결과 15.5버전과 16버전이 화면 전환할 때 `supportedInterfaceOrientations`에서 breakpoint가 걸리는 횟수에 차이가 있었습니다. 이런 버전과 관련해서 구현이 달라지는 문제는 어떻게 해결하는게 좋은지 궁금합니다!

|  15.5                |  16              |
| :------------------: | :--------------: | 
| ![](https://i.imgur.com/dP0dJup.gif)  | ![QuickTime movie](https://user-images.githubusercontent.com/49301866/198181457-f6fe1d28-5f9b-444d-a3c6-174c9b08f2fd.gif) |

### imageView의 DynamicType 적용 문제
imageView에도 `Accessibility`항목과 `imageView.adjustsImageSizeForAccessibilityContentSizeCategory` 프로퍼티를 통해 Dynamic Type을 적용할 수 있다고 알게 되었습니다. 

Label의 경우 Font 크기가 변하고 Label자체크기는 변하지는 않지만 imageView의 경우 뷰 자체크기가 변하기 때문에 autolayout 제약이 걸려있는 경우 DynamicType이 적용되지 않는 현상을 발견했습니다. 

 imageView과 같이 뷰 자체의 크기가 변해야하는 UI들에 어떻게 DynamicType을 적용시킬 수 있는지 궁금합니다!