### PR TITLE
만국박람회 [Step3] Kyo, 토털이

### DIFF
--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -32,7 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
 
-        if let navigationController = application.windows[0].rootViewController as? UINavigationController {
+        if let navigationController = application.windows.first?.rootViewController as? UINavigationController {
 
             if navigationController.visibleViewController is ExpoViewController {
                 return UIInterfaceOrientationMask.portrait

--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -30,6 +30,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
 
+        if let navigationController = application.windows[0].rootViewController as? UINavigationController {
+
+            if navigationController.visibleViewController is ExpoViewController {
+                return UIInterfaceOrientationMask.portrait
+            }
+            else {
+                return UIInterfaceOrientationMask.all
+            }
+        }
+        
+        return UIInterfaceOrientationMask.portrait
+    }
 }
 

--- a/Expo1900/Expo1900/Controllers/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/DetailViewController.swift
@@ -36,15 +36,15 @@ final class DetailViewController: UIViewController {
         return itemImageView
     }()
     
-    private let textView: UITextView = {
-        let textView = UITextView()
-        textView.font = UIFont.preferredFont(forTextStyle: .body)
-        textView.textColor = UIColor.black
-        textView.adjustsFontForContentSizeCategory = true
-        textView.isEditable = false
-        textView.isScrollEnabled = false
-        textView.translatesAutoresizingMaskIntoConstraints = false
-        return textView
+    private let descriptionLabel: UILabel = {
+        let textLabel = UILabel()
+        textLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        textLabel.textColor = UIColor.black
+        textLabel.numberOfLines = 0
+        textLabel.lineBreakMode = .byWordWrapping
+        textLabel.adjustsFontForContentSizeCategory = true
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        return textLabel
     }()
     
     private let stackView: UIStackView = {
@@ -94,7 +94,7 @@ extension DetailViewController {
     private func setData() {
         guard let item = koreaItem else { return }
         itemImageView.image = UIImage(named: item.imageName)
-        textView.text = item.description
+        descriptionLabel.text = item.description
     }
     
     private func setViews() {
@@ -102,7 +102,7 @@ extension DetailViewController {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         stackView.addSubview(itemImageView)
-        stackView.addSubview(textView)
+        stackView.addSubview(descriptionLabel)
     }
     
     private func setupScrollView() {
@@ -133,10 +133,10 @@ extension DetailViewController {
             itemImageView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
             itemImageView.topAnchor.constraint(equalTo: stackView.topAnchor, constant: Constant.imageViewTopConstraint),
             itemImageView.heightAnchor.constraint(equalToConstant: Constant.imageViewHeight),
-            textView.topAnchor.constraint(equalTo: itemImageView.bottomAnchor, constant: Constant.textViewTopConstraint),
-            textView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor, constant: Constant.textViewLeadingConstraint),
-            textView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: Constant.textViewTrailingConstraint),
-            textView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
+            descriptionLabel.topAnchor.constraint(equalTo: itemImageView.bottomAnchor, constant: Constant.textViewTopConstraint),
+            descriptionLabel.leadingAnchor.constraint(equalTo: stackView.leadingAnchor, constant: Constant.textViewLeadingConstraint),
+            descriptionLabel.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: Constant.textViewTrailingConstraint),
+            descriptionLabel.bottomAnchor.constraint(equalTo: stackView.bottomAnchor)
         ])
     }
 }

--- a/Expo1900/Expo1900/Controllers/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/DetailViewController.swift
@@ -86,6 +86,7 @@ extension DetailViewController {
     private func setNavigationBar() {
         self.title = koreaItem?.name
         let appearance = UINavigationBarAppearance()
+        
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
     }

--- a/Expo1900/Expo1900/Controllers/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controllers/DetailViewController.swift
@@ -38,8 +38,9 @@ final class DetailViewController: UIViewController {
     
     private let textView: UITextView = {
         let textView = UITextView()
-        textView.font = UIFont.systemFont(ofSize: 15)
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
         textView.textColor = UIColor.black
+        textView.adjustsFontForContentSizeCategory = true
         textView.isEditable = false
         textView.isScrollEnabled = false
         textView.translatesAutoresizingMaskIntoConstraints = false

--- a/Expo1900/Expo1900/Controllers/ExpoViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpoViewController.swift
@@ -18,7 +18,7 @@ final class ExpoViewController: UIViewController {
     @IBOutlet private weak var visitorLabel: UILabel!
     @IBOutlet private weak var placeLabel: UILabel!
     @IBOutlet private weak var timeLabel: UILabel!
-    @IBOutlet private weak var descriptionTextView: UITextView!
+    @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private var buttonImage: [UIImageView]!
     @IBOutlet private weak var nextButton: UIButton!
     
@@ -72,8 +72,9 @@ final class ExpoViewController: UIViewController {
         visitorLabel.text = expoData?.visitorNumberDescription
         placeLabel.text = expoData?.locationDescription
         timeLabel.text = expoData?.durationDescription
-        descriptionTextView.text = expoData?.description
-        descriptionTextView.isEditable = false
+        descriptionLabel.text = expoData?.description
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.lineBreakMode = .byWordWrapping
         buttonImage.forEach { button in
             button.image = UIImage(named: AssetName.flagButtonImage)
         }

--- a/Expo1900/Expo1900/Controllers/ExpoViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpoViewController.swift
@@ -10,6 +10,7 @@ final class ExpoViewController: UIViewController {
 
     enum Constant {
         static let nextButtonTitle = "한국의 출품작 보러가기"
+        static let navigationBackButtonTitle = "메인"
     }
     
     @IBOutlet private weak var titleLabel: UILabel!
@@ -27,6 +28,7 @@ final class ExpoViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setData()
+        setupNavigationBar()
         setupElementWithData()
     }
 
@@ -38,6 +40,12 @@ final class ExpoViewController: UIViewController {
         guard let koreaItemsViewController = storyboard?.instantiateViewController(withIdentifier: KoreaItemsViewController.koreaItemsVCIdentifier) as? KoreaItemsViewController else { return }
         
         navigationController?.pushViewController(koreaItemsViewController, animated: true)
+    }
+    
+    private func setupNavigationBar() {
+        let backItem = UIBarButtonItem()
+        backItem.title = Constant.navigationBackButtonTitle
+        navigationItem.backBarButtonItem = backItem
     }
     
     private func setData() {

--- a/Expo1900/Expo1900/Controllers/ExpoViewController.swift
+++ b/Expo1900/Expo1900/Controllers/ExpoViewController.swift
@@ -59,7 +59,7 @@ final class ExpoViewController: UIViewController {
     }
     
     private func setupElementWithData() {
-        titleLabel.text = expoData?.title
+        titleLabel.text = expoData?.titleDescription
         mainImage.image = UIImage(named: AssetName.expoImage)
         visitorLabel.text = expoData?.visitorNumberDescription
         placeLabel.text = expoData?.locationDescription

--- a/Expo1900/Expo1900/Controllers/KoreaItemsViewController.swift
+++ b/Expo1900/Expo1900/Controllers/KoreaItemsViewController.swift
@@ -13,6 +13,7 @@ final class KoreaItemsViewController: UIViewController {
     
     enum Constant {
         static let koreaItemsNavigationTitle = "한국의 출품작"
+        static let navigationBackButtonTitle = "출품작"
     }
 
     @IBOutlet private weak var koreanItemsTable: UITableView!
@@ -22,7 +23,7 @@ final class KoreaItemsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setData()
-        setNavigationBar()
+        setupNavigationBar()
         setTableView()
     }
     
@@ -53,7 +54,10 @@ final class KoreaItemsViewController: UIViewController {
         koreanItemsTable.dataSource = self
     }
     
-    private func setNavigationBar() {
+    private func setupNavigationBar() {
+        let backItem = UIBarButtonItem()
+        backItem.title = Constant.navigationBackButtonTitle
+        navigationItem.backBarButtonItem = backItem
         navigationController?.navigationBar.tintColor = .black
         self.title = Constant.koreaItemsNavigationTitle
     }

--- a/Expo1900/Expo1900/Models/ExpositionIntroduction.swift
+++ b/Expo1900/Expo1900/Models/ExpositionIntroduction.swift
@@ -18,6 +18,10 @@ struct ExpositionIntroduction: Decodable {
         case visitorNumber = "visitors"
     }
     
+    var titleDescription: String {
+        return self.title.replacingOccurrences(of: "(", with: "\n(")
+    }
+    
     var visitorNumberDescription: String {
         return String(format: "방문객 : %@ 명", self.visitorNumber.formattedWithSeparator)
     }

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -59,16 +59,16 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-hn-YyW">
-                                                <rect key="frame" x="20" y="478.5" width="374" height="383.5"/>
+                                                <rect key="frame" x="10" y="478.5" width="394" height="383.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OJT-aw-lzn">
-                                                        <rect key="frame" x="0.0" y="166" width="51" height="51.5"/>
+                                                        <rect key="frame" x="0.0" y="164.5" width="54" height="54.5"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="OJT-aw-lzn" secondAttribute="height" multiplier="1:1" id="NeD-NN-btv"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1FF-tS-thy">
-                                                        <rect key="frame" x="56" y="176.5" width="262" height="31"/>
+                                                        <rect key="frame" x="59" y="176.5" width="276" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -78,7 +78,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p5x-ug-plH">
-                                                        <rect key="frame" x="323" y="166" width="51" height="51.5"/>
+                                                        <rect key="frame" x="340" y="164.5" width="54" height="54.5"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="p5x-ug-plH" secondAttribute="height" multiplier="1:1" id="5gg-bG-cDb"/>
                                                         </constraints>
@@ -94,14 +94,14 @@
                                             <constraint firstAttribute="bottom" secondItem="UbJ-hn-YyW" secondAttribute="bottom" id="6O4-sh-aSF"/>
                                             <constraint firstItem="pqo-vN-GHY" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="10" id="7dN-m2-aJs"/>
                                             <constraint firstAttribute="trailing" secondItem="pqo-vN-GHY" secondAttribute="trailing" constant="10" id="7hM-47-HZc"/>
-                                            <constraint firstItem="UbJ-hn-YyW" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="20" id="ALH-Wc-iZL"/>
+                                            <constraint firstItem="UbJ-hn-YyW" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="10" id="ALH-Wc-iZL"/>
                                             <constraint firstItem="tse-PA-CkA" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="DFL-cd-J0w"/>
                                             <constraint firstItem="MsQ-iM-aJM" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="G2O-bF-LwF"/>
                                             <constraint firstItem="Gxj-Ej-gbI" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="ao8-e4-GqG"/>
                                             <constraint firstAttribute="trailing" secondItem="MsQ-iM-aJM" secondAttribute="trailing" constant="20" id="dZW-CX-IWt"/>
                                             <constraint firstItem="ruC-q1-WKz" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="jhQ-vd-Vla"/>
                                             <constraint firstItem="MsQ-iM-aJM" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="20" id="kHQ-rD-Xn0"/>
-                                            <constraint firstAttribute="trailing" secondItem="UbJ-hn-YyW" secondAttribute="trailing" constant="20" id="oqG-Ox-rGu"/>
+                                            <constraint firstAttribute="trailing" secondItem="UbJ-hn-YyW" secondAttribute="trailing" constant="10" id="oqG-Ox-rGu"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,34 +24,34 @@
                                         <rect key="frame" x="0.0" y="20" width="414" height="862"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="titleLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MsQ-iM-aJM">
-                                                <rect key="frame" x="20" y="0.0" width="374" height="26.5"/>
+                                                <rect key="frame" x="20" y="0.0" width="374" height="23"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Jaw-K8-fQT">
-                                                <rect key="frame" x="0.0" y="36.5" width="414" height="128"/>
+                                                <rect key="frame" x="0.0" y="33" width="414" height="128"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
-                                                <rect key="frame" x="157" y="174.5" width="100.5" height="24"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
+                                                <rect key="frame" x="163.5" y="171" width="87.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="placeLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tse-PA-CkA">
-                                                <rect key="frame" x="159.5" y="208.5" width="95.5" height="24"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="placeLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tse-PA-CkA">
+                                                <rect key="frame" x="166" y="201.5" width="82.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ruC-q1-WKz">
-                                                <rect key="frame" x="164" y="242.5" width="86" height="24"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ruC-q1-WKz">
+                                                <rect key="frame" x="170" y="232" width="74.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pqo-vN-GHY" userLabel="Description Text View">
-                                                <rect key="frame" x="10" y="276.5" width="394" height="525.5"/>
+                                                <rect key="frame" x="10" y="262.5" width="394" height="539.5"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -147,14 +147,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sX6-fD-5XJ">
-                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreaItemTableViewCell" rowHeight="145" id="fn9-zW-TxE" customClass="KoreaItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="414" height="145"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="145"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fn9-zW-TxE" id="zVy-bi-5gB">
-                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="145"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="145"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -185,7 +185,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wlq-k0-Afv" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1pW-pn-79u">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -200,7 +200,7 @@
     </scenes>
     <resources>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,51 +24,49 @@
                                         <rect key="frame" x="0.0" y="20" width="414" height="862"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="titleLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MsQ-iM-aJM">
-                                                <rect key="frame" x="20" y="0.0" width="374" height="23"/>
+                                                <rect key="frame" x="20" y="0.0" width="374" height="26.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Jaw-K8-fQT">
-                                                <rect key="frame" x="102" y="33" width="210" height="128"/>
+                                                <rect key="frame" x="102" y="36.5" width="210" height="128"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
-                                                <rect key="frame" x="163.5" y="171" width="87.5" height="20.5"/>
+                                                <rect key="frame" x="157" y="174.5" width="100.5" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="placeLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tse-PA-CkA">
-                                                <rect key="frame" x="166" y="201.5" width="82.5" height="20.5"/>
+                                                <rect key="frame" x="159.5" y="208.5" width="95.5" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ruC-q1-WKz">
-                                                <rect key="frame" x="170" y="232" width="74.5" height="20.5"/>
+                                                <rect key="frame" x="164" y="242.5" width="86" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pqo-vN-GHY" userLabel="Description Text View">
-                                                <rect key="frame" x="10" y="262.5" width="394" height="206"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                                <color key="textColor" systemColor="labelColor"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="descriptionLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LL0-0v-0th">
+                                                <rect key="frame" x="10" y="276.5" width="394" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-hn-YyW">
-                                                <rect key="frame" x="10" y="478.5" width="394" height="383.5"/>
+                                                <rect key="frame" x="10" y="307" width="394" height="555"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OJT-aw-lzn">
-                                                        <rect key="frame" x="0.0" y="164.5" width="54" height="54.5"/>
+                                                        <rect key="frame" x="0.0" y="250.5" width="54" height="54"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="OJT-aw-lzn" secondAttribute="height" multiplier="1:1" id="NeD-NN-btv"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1FF-tS-thy">
-                                                        <rect key="frame" x="59" y="176.5" width="276" height="31"/>
+                                                        <rect key="frame" x="59" y="260.5" width="276" height="34.5"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -78,7 +76,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p5x-ug-plH">
-                                                        <rect key="frame" x="340" y="164.5" width="54" height="54.5"/>
+                                                        <rect key="frame" x="340" y="250.5" width="54" height="54"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="p5x-ug-plH" secondAttribute="height" multiplier="1:1" id="5gg-bG-cDb"/>
                                                         </constraints>
@@ -92,16 +90,16 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="bottom" secondItem="UbJ-hn-YyW" secondAttribute="bottom" id="6O4-sh-aSF"/>
-                                            <constraint firstItem="pqo-vN-GHY" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="10" id="7dN-m2-aJs"/>
-                                            <constraint firstAttribute="trailing" secondItem="pqo-vN-GHY" secondAttribute="trailing" constant="10" id="7hM-47-HZc"/>
                                             <constraint firstItem="UbJ-hn-YyW" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="10" id="ALH-Wc-iZL"/>
                                             <constraint firstItem="tse-PA-CkA" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="DFL-cd-J0w"/>
                                             <constraint firstItem="MsQ-iM-aJM" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="G2O-bF-LwF"/>
                                             <constraint firstItem="Gxj-Ej-gbI" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="ao8-e4-GqG"/>
+                                            <constraint firstItem="LL0-0v-0th" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="10" id="dY0-aU-IA9"/>
                                             <constraint firstAttribute="trailing" secondItem="MsQ-iM-aJM" secondAttribute="trailing" constant="20" id="dZW-CX-IWt"/>
                                             <constraint firstItem="ruC-q1-WKz" firstAttribute="centerX" secondItem="tVH-QD-Kpo" secondAttribute="centerX" id="jhQ-vd-Vla"/>
                                             <constraint firstItem="MsQ-iM-aJM" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="20" id="kHQ-rD-Xn0"/>
                                             <constraint firstAttribute="trailing" secondItem="UbJ-hn-YyW" secondAttribute="trailing" constant="10" id="oqG-Ox-rGu"/>
+                                            <constraint firstAttribute="trailing" secondItem="LL0-0v-0th" secondAttribute="trailing" constant="10" id="zHz-CG-nQy"/>
                                         </constraints>
                                     </stackView>
                                 </subviews>
@@ -128,7 +126,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="05D-1W-Ql5"/>
                     <connections>
-                        <outlet property="descriptionTextView" destination="pqo-vN-GHY" id="yjA-Lv-KGn"/>
+                        <outlet property="descriptionLabel" destination="LL0-0v-0th" id="ou7-Op-l4P"/>
                         <outlet property="mainImage" destination="Jaw-K8-fQT" id="4XE-Eb-QyC"/>
                         <outlet property="nextButton" destination="1FF-tS-thy" id="Q3A-CQ-CLU"/>
                         <outlet property="placeLabel" destination="tse-PA-CkA" id="0VV-XW-Zv6"/>
@@ -152,14 +150,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sX6-fD-5XJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreaItemTableViewCell" rowHeight="145" id="fn9-zW-TxE" customClass="KoreaItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="145"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="145"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fn9-zW-TxE" id="zVy-bi-5gB">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="145"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="145"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -190,7 +188,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wlq-k0-Afv" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1pW-pn-79u">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -204,9 +202,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,48 +18,48 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iFz-y6-E7y">
-                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="tVH-QD-Kpo">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
+                                        <rect key="frame" x="0.0" y="20" width="414" height="862"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="titleLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MsQ-iM-aJM">
-                                                <rect key="frame" x="20" y="0.0" width="374" height="29"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="titleLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MsQ-iM-aJM">
+                                                <rect key="frame" x="20" y="0.0" width="374" height="26.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Jaw-K8-fQT">
-                                                <rect key="frame" x="0.0" y="39" width="414" height="128"/>
+                                                <rect key="frame" x="0.0" y="36.5" width="414" height="128"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
-                                                <rect key="frame" x="163.5" y="177" width="87.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
+                                                <rect key="frame" x="157" y="174.5" width="100.5" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="placeLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tse-PA-CkA">
-                                                <rect key="frame" x="166" y="207.5" width="82.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="placeLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tse-PA-CkA">
+                                                <rect key="frame" x="159.5" y="208.5" width="95.5" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ruC-q1-WKz">
-                                                <rect key="frame" x="170" y="238" width="74.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ruC-q1-WKz">
+                                                <rect key="frame" x="164" y="242.5" width="86" height="24"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="pqo-vN-GHY" userLabel="Description Text View">
-                                                <rect key="frame" x="10" y="268.5" width="394" height="445.5"/>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pqo-vN-GHY" userLabel="Description Text View">
+                                                <rect key="frame" x="10" y="276.5" width="394" height="525.5"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-hn-YyW">
-                                                <rect key="frame" x="20" y="724" width="374" height="50"/>
+                                                <rect key="frame" x="20" y="812" width="374" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OJT-aw-lzn">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -105,7 +105,7 @@
                                     <constraint firstAttribute="bottom" secondItem="tVH-QD-Kpo" secondAttribute="bottom" id="FGs-Bb-npk"/>
                                     <constraint firstItem="tVH-QD-Kpo" firstAttribute="width" secondItem="iFz-y6-E7y" secondAttribute="width" id="JJl-Sa-0Wr"/>
                                     <constraint firstItem="tVH-QD-Kpo" firstAttribute="height" secondItem="lJW-xX-3vA" secondAttribute="height" priority="250" id="YN6-vM-iIO"/>
-                                    <constraint firstItem="tVH-QD-Kpo" firstAttribute="top" secondItem="iFz-y6-E7y" secondAttribute="top" id="iao-TV-Hbx"/>
+                                    <constraint firstItem="tVH-QD-Kpo" firstAttribute="top" secondItem="iFz-y6-E7y" secondAttribute="top" constant="20" id="iao-TV-Hbx"/>
                                     <constraint firstAttribute="trailing" secondItem="tVH-QD-Kpo" secondAttribute="trailing" id="wOo-qz-bdt"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="AYz-3O-0yA"/>
@@ -117,7 +117,7 @@
                         <constraints>
                             <constraint firstItem="iFz-y6-E7y" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="BmK-bx-KNa"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="iFz-y6-E7y" secondAttribute="trailing" id="k74-K9-joF"/>
-                            <constraint firstItem="iFz-y6-E7y" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="tcl-hY-WQL"/>
+                            <constraint firstItem="iFz-y6-E7y" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="tcl-hY-WQL"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="iFz-y6-E7y" secondAttribute="bottom" id="z67-f0-TWu"/>
                         </constraints>
                     </view>
@@ -147,14 +147,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sX6-fD-5XJ">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreaItemTableViewCell" rowHeight="145" id="fn9-zW-TxE" customClass="KoreaItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="145"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="145"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fn9-zW-TxE" id="zVy-bi-5gB">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="145"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="145"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -185,7 +185,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wlq-k0-Afv" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1pW-pn-79u">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -200,7 +200,7 @@
     </scenes>
     <resources>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wlq-k0-Afv">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,49 +24,49 @@
                                         <rect key="frame" x="0.0" y="20" width="414" height="862"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="titleLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MsQ-iM-aJM">
-                                                <rect key="frame" x="20" y="0.0" width="374" height="26.5"/>
+                                                <rect key="frame" x="20" y="0.0" width="374" height="23"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Jaw-K8-fQT">
-                                                <rect key="frame" x="102" y="36.5" width="210" height="128"/>
+                                                <rect key="frame" x="102" y="33" width="210" height="128"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
-                                                <rect key="frame" x="157" y="174.5" width="100.5" height="24"/>
+                                                <rect key="frame" x="163.5" y="171" width="87.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="placeLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tse-PA-CkA">
-                                                <rect key="frame" x="159.5" y="208.5" width="95.5" height="24"/>
+                                                <rect key="frame" x="166" y="201.5" width="82.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="timeLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ruC-q1-WKz">
-                                                <rect key="frame" x="164" y="242.5" width="86" height="24"/>
+                                                <rect key="frame" x="170" y="232" width="74.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="descriptionLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LL0-0v-0th">
-                                                <rect key="frame" x="10" y="276.5" width="394" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="descriptionLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LL0-0v-0th">
+                                                <rect key="frame" x="10" y="262.5" width="394" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-hn-YyW">
-                                                <rect key="frame" x="10" y="307" width="394" height="555"/>
+                                                <rect key="frame" x="10" y="289.5" width="394" height="572.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OJT-aw-lzn">
-                                                        <rect key="frame" x="0.0" y="250.5" width="54" height="54"/>
+                                                        <rect key="frame" x="0.0" y="259" width="54" height="54.5"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="OJT-aw-lzn" secondAttribute="height" multiplier="1:1" id="NeD-NN-btv"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1FF-tS-thy">
-                                                        <rect key="frame" x="59" y="260.5" width="276" height="34.5"/>
+                                                        <rect key="frame" x="59" y="271" width="276" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Button">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -76,7 +76,7 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p5x-ug-plH">
-                                                        <rect key="frame" x="340" y="250.5" width="54" height="54"/>
+                                                        <rect key="frame" x="340" y="259" width="54" height="54.5"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="p5x-ug-plH" secondAttribute="height" multiplier="1:1" id="5gg-bG-cDb"/>
                                                         </constraints>
@@ -150,14 +150,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="sX6-fD-5XJ">
-                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KoreaItemTableViewCell" rowHeight="145" id="fn9-zW-TxE" customClass="KoreaItemTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="414" height="145"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="145"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fn9-zW-TxE" id="zVy-bi-5gB">
-                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="145"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="145"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -188,7 +188,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wlq-k0-Afv" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1pW-pn-79u">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Views/Base.lproj/Main.storyboard
@@ -30,7 +30,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Jaw-K8-fQT">
-                                                <rect key="frame" x="0.0" y="33" width="414" height="128"/>
+                                                <rect key="frame" x="102" y="33" width="210" height="128"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitorLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gxj-Ej-gbI">
                                                 <rect key="frame" x="163.5" y="171" width="87.5" height="20.5"/>
@@ -51,42 +51,47 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pqo-vN-GHY" userLabel="Description Text View">
-                                                <rect key="frame" x="10" y="262.5" width="394" height="539.5"/>
+                                                <rect key="frame" x="10" y="262.5" width="394" height="206"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-hn-YyW">
-                                                <rect key="frame" x="20" y="812" width="374" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="UbJ-hn-YyW">
+                                                <rect key="frame" x="20" y="478.5" width="374" height="383.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OJT-aw-lzn">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="0.0" y="166" width="51" height="51.5"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="50" id="3Ez-TM-afi"/>
-                                                            <constraint firstAttribute="height" constant="50" id="Uy0-Sa-IHC"/>
+                                                            <constraint firstAttribute="width" secondItem="OJT-aw-lzn" secondAttribute="height" multiplier="1:1" id="NeD-NN-btv"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="100" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1FF-tS-thy">
-                                                        <rect key="frame" x="60" y="0.0" width="254" height="50"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="100" horizontalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1FF-tS-thy">
+                                                        <rect key="frame" x="56" y="176.5" width="262" height="31"/>
                                                         <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Button">
+                                                            <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
+                                                        </buttonConfiguration>
                                                         <connections>
                                                             <action selector="nextButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Xgb-cA-dfv"/>
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="p5x-ug-plH">
-                                                        <rect key="frame" x="324" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="323" y="166" width="51" height="51.5"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="50" id="QN2-xb-3qn"/>
-                                                            <constraint firstAttribute="height" constant="50" id="daq-dm-0Cc"/>
+                                                            <constraint firstAttribute="width" secondItem="p5x-ug-plH" secondAttribute="height" multiplier="1:1" id="5gg-bG-cDb"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="1FF-tS-thy" firstAttribute="width" secondItem="UbJ-hn-YyW" secondAttribute="width" multiplier="0.7" id="1F8-jE-Sse"/>
+                                                    <constraint firstItem="1FF-tS-thy" firstAttribute="centerX" secondItem="UbJ-hn-YyW" secondAttribute="centerXWithinMargins" id="hWN-Ck-h6v"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="UbJ-hn-YyW" secondAttribute="bottom" id="6O4-sh-aSF"/>
                                             <constraint firstItem="pqo-vN-GHY" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="10" id="7dN-m2-aJs"/>
                                             <constraint firstAttribute="trailing" secondItem="pqo-vN-GHY" secondAttribute="trailing" constant="10" id="7hM-47-HZc"/>
                                             <constraint firstItem="UbJ-hn-YyW" firstAttribute="leading" secondItem="tVH-QD-Kpo" secondAttribute="leading" constant="20" id="ALH-Wc-iZL"/>
@@ -101,12 +106,12 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="tVH-QD-Kpo" firstAttribute="leading" secondItem="iFz-y6-E7y" secondAttribute="leading" id="3GM-Lz-ZES"/>
-                                    <constraint firstAttribute="bottom" secondItem="tVH-QD-Kpo" secondAttribute="bottom" id="FGs-Bb-npk"/>
+                                    <constraint firstItem="tVH-QD-Kpo" firstAttribute="leading" secondItem="AYz-3O-0yA" secondAttribute="leading" id="3GM-Lz-ZES"/>
+                                    <constraint firstItem="AYz-3O-0yA" firstAttribute="bottom" secondItem="tVH-QD-Kpo" secondAttribute="bottom" id="FGs-Bb-npk"/>
                                     <constraint firstItem="tVH-QD-Kpo" firstAttribute="width" secondItem="iFz-y6-E7y" secondAttribute="width" id="JJl-Sa-0Wr"/>
                                     <constraint firstItem="tVH-QD-Kpo" firstAttribute="height" secondItem="lJW-xX-3vA" secondAttribute="height" priority="250" id="YN6-vM-iIO"/>
                                     <constraint firstItem="tVH-QD-Kpo" firstAttribute="top" secondItem="iFz-y6-E7y" secondAttribute="top" constant="20" id="iao-TV-Hbx"/>
-                                    <constraint firstAttribute="trailing" secondItem="tVH-QD-Kpo" secondAttribute="trailing" id="wOo-qz-bdt"/>
+                                    <constraint firstItem="AYz-3O-0yA" firstAttribute="trailing" secondItem="tVH-QD-Kpo" secondAttribute="trailing" id="wOo-qz-bdt"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="AYz-3O-0yA"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="lJW-xX-3vA"/>

--- a/Expo1900/Expo1900/Views/KoreaItemTableViewCell.swift
+++ b/Expo1900/Expo1900/Views/KoreaItemTableViewCell.swift
@@ -29,6 +29,7 @@ final class KoreaItemTableViewCell: UITableViewCell {
     
     public let titleLabel: UILabel = {
         let label = UILabel()
+        label.numberOfLines = 0
         label.font = UIFont.preferredFont(forTextStyle: .title2)
         label.translatesAutoresizingMaskIntoConstraints = false
         return label

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 
 | 첫번째 화면 portrait 고정 및 상세화면 가로 지원|
 |:---:|
-|![](https://i.imgur.com/O9fM7ua.gif)|
+|<img src = "https://i.imgur.com/O9fM7ua.gif" width=68% height=68%>|
 
 ## 🎯 트러블 슈팅 및 고민
 

--- a/README.md
+++ b/README.md
@@ -5,20 +5,19 @@
 2. [개발환경 및 라이브러리](#-개발환경-및-라이브러리)
 3. [팀원](#-팀원)
 4. [타임라인](#-타임라인)
-5. [파일트리](#-파일-트리)
-6. [실행화면](#-실행-화면)
-7. [트러블 슈팅 및 고민](#-트러블-슈팅-및-고민)
-8. [참고링크](#-참고-링크)
+5. [실행화면](#-실행-화면)
+6. [트러블 슈팅 및 고민](#-트러블-슈팅-및-고민)
+7. [참고링크](#-참고-링크)
 
 
 ## 👋 소개
-[Kyo](https://github.com/KyoPak)와 [토털이](https://github.com/tottalE)가 구현한 Exposition-universelle Step-2 입니다.
+[Kyo](https://github.com/KyoPak)와 [토털이](https://github.com/tottalE)가 구현한 Exposition-universelle Step-3 입니다.
 만국 박람회 앱으로 expo를 소개하는 앱입니다. 
-`Decoding`, `ScrollView`, `TableView`를 중점적으로 학습하며 프로젝트를 진행해나갔습니다.
+`Decoding`, `ScrollView`, `TableView`, `Dynamic Type`를 중점적으로 학습하며 프로젝트를 진행해나갔습니다.
 
 ## 💻 개발환경 및 라이브러리
 [![swift](https://img.shields.io/badge/swift-5.6-orange)]()
-[![xcode](https://img.shields.io/badge/Xcode-13.4.1-blue)]()
+[![xcode](https://img.shields.io/badge/Xcode-13.4.1-blue)]() [![xcode](https://img.shields.io/badge/Xcode-14.0.1-blue)]()
 
 
 ## 🧑 팀원 
@@ -32,49 +31,61 @@
 ### Step - 1 : 2022.10.17 ~ 10.18
 - JSON의 Decodable 모델 생성
 
-### Step - 2 : 2022.10.18 ~ 10.21
+### Step - 2 : 2022.10.18 ~ 10.26
 - 메인 화면의 `Scrollview` 생성
 - 메인 화면의 JSON 데이터 `Decoding` 및 배치
 - 한국 박람회 화면의 `TableView` 생성
 - 한국 박람회 화면의 `TableViewCell` 설정 
 - 한국 박람회 아이템 상세 화면의 `ScrollView` 설정
 - 한국 박람회 아이템 상세 화면의 `ScrollView` 내 `Decode`된 데이터 배치
+- 리뷰에 따른 Code Refactor 
+
+### Step - 3 : 2022.10.26 ~ 10.28
+- AutoLayout을 적용하여 다양한 기기에 대응, 가로 화면 지원
+- Word Wrapping, Line Break 방식 도입
+- 메인 화면 Landscape Mode 제한
+- Dynamic Types를 통해 텍스트 접근성 향상
 
 ## 🌲 파일 트리
 
 ```
 ├── Expo1900
-│   ├── AppDelegate.swift
-│   ├── SceneDelegate.swift
-│   ├── Assets.xcassets
-│   ├── Base.lproj
-│   │   └── LaunchScreen.storyboard
-│   ├── Common
-│   │   ├── AssetName.swift
-│   │   ├── Constant.swift
-│   │   ├── DataError.swift
-│   │   └── Identifier.swift
-│   ├── Controllers
-│   │   ├── DetailViewController.swift
-│   │   ├── ExpoViewController.swift
-│   │   └── KoreaItemsViewController.swift
-│   ├── Info.plist
-│   ├── Models
-│   │   ├── DataManager.swift
-│   │   ├── ExpositionIntroduction.swift
-│   │   └── KoreaItem.swift
-│   └── Views
-│       └── Base.lproj
-│           └── Main.storyboard
+│   ├── Expo1900
+│   │   ├── AppDelegate.swift
+│   │   ├── SceneDelegate.swift
+│   │   ├── Common
+│   │   │   ├── AssetName.swift
+│   │   │   ├── DataError.swift
+│   │   │   └── Extensions
+│   │   │       ├── Formatter+Extensions.swift
+│   │   │       └── Int+Extensions.swift
+│   │   ├── Models
+│   │   │   ├── DecodeManger.swift
+│   │   │   ├── ExpositionIntroduction.swift
+│   │   │   └── KoreaItem.swift
+│   │   └── Views
+│   │       ├── Base.lproj
+│   │       │   └── Main.storyboard
+│   │       └── KoreaItemTableViewCell.swift
+│   │   ├── Controllers
+│   │   │   ├── DetailViewController.swift
+│   │   │   ├── ExpoViewController.swift
+│   │   │   └── KoreaItemsViewController.swift
+│   │   ├── Base.lproj
+│   │   │   └── LaunchScreen.storyboard
+│   │   ├── Assets.xcassets
+│   │   ├── Info.plist
+└── README.md
 ```
 
-
 ## 💻 실행 화면 
+|Main 화면|Expo 화면|Dynamic Type 적용|
+|:---:|:---:|:---:|
+|<img src = "https://i.imgur.com/pCDrwOe.gif" > |<img src = "https://user-images.githubusercontent.com/66786418/197134476-0ee7c273-d265-4cc6-862c-cc584f4429ca.gif" >|<img src = "https://i.imgur.com/CaMqqIq.gif" width=68% height=68%>|
 
-
-|Main 화면|Expo 화면|
-|:---:|:---:|
-|<img src = "https://i.imgur.com/pCDrwOe.gif" width=50% height=50%> |<img src = "https://user-images.githubusercontent.com/66786418/197134476-0ee7c273-d265-4cc6-862c-cc584f4429ca.gif" width=50% height=50%>|
+| 첫번째 화면 portrait 고정 및 상세화면 가로 지원|
+|:---:|
+|![](https://i.imgur.com/O9fM7ua.gif)|
 
 ## 🎯 트러블 슈팅 및 고민
 
@@ -91,8 +102,28 @@
 - cell내의 content를 `defaultContentConfiguration`를 통해 받아온 후, 여러 프로퍼티를 설정해 준 후에, cell의 `contentConfiguration`에 content의 `configuration`에 할당하여 cell을 커스텀으로 만들어주지 않고도 셀의 이미지와 텍스트 등등을 조정해 줄 수 있었습니다.
 
 ---
+## Step-3
+
+### 1. Expo메인 화면의 하단 버튼에 Dynamic Type을 적용하여 폰트의 크키가 커졌을 때 위의 text영역을 침범하는 이슈
+오토레이아웃을 잘못 설정해 주어서 일어난 이슈라, 오토레이아웃을 새롭게 적용해 주었습니다. 텍스트 뷰(현재는 Label)와 이미지 뷰에 ratio를 주어서 기능하도록 만들어 주었습니다.
+
+### 2. TextView에서 word wrapping이 한글이 되지 않는 문제
+TextView대신 Label을 사용하여 일단 문제를 해결해 주었지만, 아직 완벽히 해결되지 않아 추후 리팩토링을 진행할 예정입니다.
+
+### 3. `visibleViewController`와 `topViewController`,`presentedViewController` 의 차이
+- `topViewController` 
+    - UINavigationController의 pushViewController(_:animated:) 메서드를 사용하여 UINavigationController에 push된 마지막 ViewController입니다. 
+- `presentedViewController`  
+    - 다른 ViewController 위에 표시되는 ViewController(NavigationController를 사용하지 않았을 때, VC는 기본적으로 다른 뷰컨트롤러를 push하는 대신 덮어줍니다).
+    - UINavigationController의 pushViewController(_:animated:) 대신 UIViewController의 present(_:animated:completion:) 메서드를 사용합니다. 
+    - 참고: 제시된 뷰 컨트롤러를 모달 뷰 컨트롤러라고도 하며, 내비게이션 컨트롤러 없이 사용할 수 있습니다.
+- `visibleViewController` 
+    - topViewController 또는 presentViewController와 같을 수 있습니다. 
+    - UINavigation Controller에 마지막으로 push할 경우 topViewController와 동일합니다.
+    - 마지막으로 UIViewController에 대해 설명하는 경우 표시된 ViewController와 동일합니다.
+
 
     
 ## 📚 참고 링크
-<br>[NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)<br>[오토레이아웃 정복하기 - 야곰닷넷](https://yagom.net/courses/autolayout/)
-[Easier Scrolling With Layout Guides](https://useyourloaf.com/blog/easier-scrolling-with-layout-guides/)<br>[Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data)<br>[Configuring the Cells for Your Table](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/configuring_the_cells_for_your_table)<br>[JSON](https://ko.wikipedia.org/wiki/JSON)<br>[JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
+[NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)<br>[오토레이아웃 정복하기 - 야곰닷넷](https://yagom.net/courses/autolayout/)
+[Easier Scrolling With Layout Guides](https://useyourloaf.com/blog/easier-scrolling-with-layout-guides/)<br>[Filling a Table with Data](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/filling_a_table_with_data)<br>[Configuring the Cells for Your Table](https://developer.apple.com/documentation/uikit/views_and_controls/table_views/configuring_the_cells_for_your_table)<br>[JSON](https://ko.wikipedia.org/wiki/JSON)<br>[JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)<br>[DynamicType](https://developer.apple.com/documentation/uikit/uifont/scaling_fonts_automatically)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@
 ## 💻 실행 화면 
 |Main 화면|Expo 화면|Dynamic Type 적용|
 |:---:|:---:|:---:|
-|<img src = "https://i.imgur.com/pCDrwOe.gif" > |<img src = "https://user-images.githubusercontent.com/66786418/197134476-0ee7c273-d265-4cc6-862c-cc584f4429ca.gif" >|<img src = "https://i.imgur.com/CaMqqIq.gif" width=68% height=68%>|
+|<img src = "https://i.imgur.com/pCDrwOe.gif" > |<img src = "https://user-images.githubusercontent.com/66786418/197134476-0ee7c273-d265-4cc6-862c-cc584f4429ca.gif" >|<img src = "https://user-images.githubusercontent.com/66786418/198507030-2f5ae8c3-a8d5-46a1-a50a-cef22da789a6.gif" width=68% height=68%>|
 
 | 첫번째 화면 portrait 고정 및 상세화면 가로 지원|
 |:---:|


### PR DESCRIPTION
@lina0322 
엘림! step3 완료하고 PR 드립니다! 이번에도 잘 부탁드립니다 :)

### 진행 단계 : Step3
## ⭐️ 구현한 기능
- 내비게이션 컨트롤러를 활용한 화면 전환
    - 내비게이션 컨트롤러를 이용하여 화면전환을 구현하였습니다.
    - `UIBarButtonItem`의 `title`을 지정하였습니다.
- 오토 레이아웃을 적용하여 다양한 기기에 대응
    - 오토레이아웃을 적용하여 iPod touch7세대 기기까지 적용 확인하였습니다.
- Dynamic Types를 통해 텍스트 접근성 향상
    - 모든 `Label`에 Dynamaic Type을 적용하였습니다.
- Word Wrapping 사용
    - `Decription Label`에 Word Wrapping을 사용하여 단어 별로 개행이 되게끔 구현하였습니다.
- portrait 화면 첫 화면에만 적용하기
    - `appdelegate`에서 `application` 메서드에 기능 구현
```swift
func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {

        if let navigationController = application.windows[0].rootViewController as? UINavigationController {

            if navigationController.visibleViewController is ExpoViewController {
                return UIInterfaceOrientationMask.portrait
            }
            else {
                return UIInterfaceOrientationMask.all
            }
        }
        
        return UIInterfaceOrientationMask.portrait
    }
```


## ⭐️ 코드를 작성할 때 고민되었던 점
### 1. Expo메인 화면의 하단 버튼에 Dynamic Type을 적용하여 폰트의 크키가 커졌을 때 위의 text영역을 침범하는 이슈
- 오토레이아웃을 잘못 설정해 주어서 일어난 이슈라, 오토레이아웃을 새롭게 적용해 주었습니다. 텍스트 뷰(현재는 Label)와 이미지 뷰에 ratio를 주어서 기능하도록 만들어 주었습니다. 

### 2. visibleViewController와 topViewController의 차이
- portrait 화면을 만들어 주는 과정에서 스택의 제일 상단의 뷰를 불러와야 하는데 그 방법으로 `visibleViewController`를 불러오는 방법과 `topViewController`를 불러오는 방법이 있었는데 정확한 차이를 이해하기 어려웠습니다. 
- `topViewController`는 `navigationController`에서 push된 VC들을, 
- `visibleViewController`는 
    - `navigationController`나 push된 VC나 
    - 일반 VC에서 present된 뷰 컨트롤러 스택의 가장 상단 값을 가져오는 것으로 이해했는데 잘 이해한 것이 맞을까요?

## ⭐️ 해결이 되지 않은 점
### 1. Text View에서 Word Wrapping을 사용하고 싶었습니다. 
- 하지만 Text View에서 한글 Word Wrapping을 지원하지 않는 것인지 동작하지 않아서 일단 해당 Text View를 Label로 바꿔서 Wrapping을 적용하였습니다.


### 2. LandScape모드에서 앱 구동시 두번째 화면의 LandScape모드가 구동되지 않습니다.
  - 두번째 화면에서 LandScape모드로 바꾸고 전 화면으로 돌아가게 될때 portraiot모드만 적용되어야 할 화면이 LandScape모드로 돌아가게 됩니다.
- 위의 문제들이 Xcode 버전 13.4.1에서는 발생하였고, 신규 14.0.1 버전에서는 발생하지 않았습니다. 버전의 문제라고 생각됩니다.
    
## ⭐️ 조언을 얻고 싶은 부분

### 1. Dynamic Type을 실제로 모든 Label, Button등 에 적용을 하는지 궁금합니다!
- 내용적인 부분들을 Dynamic Type을 적용하는 것은 이용자의 편의성과 접근성을 높혀줄 수 있다고 생각합니다. 하지만 Title이나 버튼 같은 부분에도 실제로 Dynamic Type을 적용하면 약간 App의 전체적인 AutoLayout이 무너지는 느낌을 받았습니다. 실제로 현업에서는 Dynamic Type에 대한 기준을 정할때 어떤 기준을 가지고 Dynamic Type을 적용하는지 궁금합니다.


### 2. Dynamic Type 적용시 Navigation Bar 부분에 AutoLayout이 깨지는 문제
![](https://i.imgur.com/sUEh767.png)
- WTF AutoLayout을 돌려준 결과 상단과 같이 나오는데 네비게이션 바 관련한 오토 레이아웃도 잡아주어야 하는지 궁금합니다!