### PR TITLE
만국박람회 [STEP 3] 써니쿠키, Wonbi

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
+		E36C5A45290A398A00985638 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36C5A44290A398A00985638 /* String+Extension.swift */; };
 		E393FC5B28FE44A000492CBA /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = E393FC5A28FE44A000492CBA /* Entry.swift */; };
 		E39B56562900F55900C224DF /* EntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39B56552900F55900C224DF /* EntryViewController.swift */; };
 		E39B565A29013F4600C224DF /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E39B565929013F4600C224DF /* DetailViewController.swift */; };
@@ -45,6 +46,7 @@
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C79FF4C22589F404005FB0FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E36C5A44290A398A00985638 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		E393FC5A28FE44A000492CBA /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		E39B56552900F55900C224DF /* EntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewController.swift; sourceTree = "<group>"; };
 		E39B565929013F4600C224DF /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 			isa = PBXGroup;
 			children = (
 				E3B485C928FF8FD50033EF3C /* JSONDecoder+Extension.swift */,
+				E36C5A44290A398A00985638 /* String+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -259,6 +262,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				41CBE88E2906C5C500E4615E /* EntryTableViewCell.swift in Sources */,
+				E36C5A45290A398A00985638 /* String+Extension.swift in Sources */,
 				E3B485CA28FF8FD50033EF3C /* JSONDecoder+Extension.swift in Sources */,
 				E393FC5B28FE44A000492CBA /* Entry.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpoMainViewController.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4107340F29078EA800D16649 /* ExpoNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4107340E29078EA800D16649 /* ExpoNavigationController.swift */; };
 		41B91B2628FE440900EEBF73 /* ExpoInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B91B2528FE440900EEBF73 /* ExpoInformation.swift */; };
 		41CBE88E2906C5C500E4615E /* EntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CBE88D2906C5C500E4615E /* EntryTableViewCell.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4107340E29078EA800D16649 /* ExpoNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoNavigationController.swift; sourceTree = "<group>"; };
 		41B91B2528FE440900EEBF73 /* ExpoInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoInformation.swift; sourceTree = "<group>"; };
 		41CBE88D2906C5C500E4615E /* EntryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTableViewCell.swift; sourceTree = "<group>"; };
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -94,6 +96,7 @@
 				E39B56552900F55900C224DF /* EntryViewController.swift */,
 				41CBE88D2906C5C500E4615E /* EntryTableViewCell.swift */,
 				E39B565929013F4600C224DF /* DetailViewController.swift */,
+				4107340E29078EA800D16649 /* ExpoNavigationController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 				E393FC5B28FE44A000492CBA /* Entry.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpoMainViewController.swift in Sources */,
 				E39B56562900F55900C224DF /* EntryViewController.swift in Sources */,
+				4107340F29078EA800D16649 /* ExpoNavigationController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				41B91B2628FE440900EEBF73 /* ExpoInformation.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -32,6 +32,7 @@ final class DetailViewController: UIViewController {
     private func buildNavigationBar() {
         navigationController?.navigationBar.isHidden = false
         title = entry.name
+        navigationController?.navigationBar.topItem?.backButtonTitle = "출품작"
     }
     
     private func buildDetailView() {

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -29,24 +29,26 @@ final class DetailViewController: UIViewController {
         configureAttribute()
         configureImageViewConstraints()
     }
-    
-    private func buildNavigationBar() {
+}
+
+private extension DetailViewController {
+    func buildNavigationBar() {
         navigationController?.navigationBar.isHidden = false
         title = entry.name
         navigationController?.navigationBar.topItem?.backButtonTitle = "출품작"
     }
     
-    private func buildDetailView() {
+    func buildDetailView() {
         detailImage.image = UIImage(named: entry.imageName)
         descriptionTextView.text = entry.description
     }
     
-    private func configureAttribute() {
+    func configureAttribute() {
         descriptionTextView.font = .preferredFont(forTextStyle: .body)
         descriptionTextView.adjustsFontForContentSizeCategory = true
     }
     
-    private func configureImageViewConstraints() {
+    func configureImageViewConstraints() {
         guard let image = detailImage.image else { return }
         
         detailImage.translatesAutoresizingMaskIntoConstraints = false

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -13,6 +13,7 @@ final class DetailViewController: UIViewController {
     
     init?(entry: Entry, coder: NSCoder) {
         self.entry = entry
+        
         super.init(coder: coder)
     }
     
@@ -28,7 +29,7 @@ final class DetailViewController: UIViewController {
         configureAttribute()
         configureImageViewConstraints()
     }
-
+    
     private func buildNavigationBar() {
         navigationController?.navigationBar.isHidden = false
         title = entry.name
@@ -55,7 +56,7 @@ final class DetailViewController: UIViewController {
         ).isActive = true
         detailImage.heightAnchor.constraint(
             equalTo: detailImage.widthAnchor,
-             multiplier: image.size.height / image.size.width
+            multiplier: image.size.height / image.size.width
         ).isActive = true
     }
 }

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -25,6 +25,8 @@ final class DetailViewController: UIViewController {
         
         buildNavigationBar()
         buildDetailView()
+        configureAttribute()
+        configureImageViewConstraints()
     }
 
     private func buildNavigationBar() {
@@ -35,5 +37,24 @@ final class DetailViewController: UIViewController {
     private func buildDetailView() {
         detailImage.image = UIImage(named: entry.imageName)
         descriptionTextView.text = entry.description
+    }
+    
+    private func configureAttribute() {
+        descriptionTextView.font = .preferredFont(forTextStyle: .body)
+        descriptionTextView.adjustsFontForContentSizeCategory = true
+    }
+    
+    private func configureImageViewConstraints() {
+        guard let image = detailImage.image else { return }
+        
+        detailImage.translatesAutoresizingMaskIntoConstraints = false
+        detailImage.widthAnchor.constraint(
+            equalTo: view.widthAnchor,
+            multiplier: 0.6
+        ).isActive = true
+        detailImage.heightAnchor.constraint(
+            equalTo: detailImage.widthAnchor,
+             multiplier: image.size.height / image.size.width
+        ).isActive = true
     }
 }

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -40,7 +40,7 @@ private extension DetailViewController {
     
     func buildDetailView() {
         detailImage.image = UIImage(named: entry.imageName)
-        descriptionTextView.text = entry.description
+        descriptionTextView.attributedText = entry.description.applyHangulAttribute()
     }
     
     func configureAttribute() {

--- a/Expo1900/Expo1900/Controller/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewCell.swift
@@ -11,7 +11,7 @@ class EntryTableViewCell: UITableViewCell {
     @IBOutlet weak var entryimageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptLabel: UILabel!
-
+    
     func buildCell(from entry: Entry) {
         entryimageView.image = UIImage(named: entry.imageName)
         titleLabel.text = entry.name

--- a/Expo1900/Expo1900/Controller/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewCell.swift
@@ -21,7 +21,16 @@ class EntryTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
+        configureAttribute()
+    }
+    
+    func configureAttribute() {
+        titleLabel.font = .preferredFont(forTextStyle: .title2)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 0
+        
+        descriptLabel.adjustsFontForContentSizeCategory = true
+        descriptLabel.font = .preferredFont(forTextStyle: .subheadline)
         descriptLabel.numberOfLines = 0
-        titleLabel.font = .preferredFont(forTextStyle: .title1)
     }
 }

--- a/Expo1900/Expo1900/Controller/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/Controller/EntryTableViewCell.swift
@@ -1,30 +1,30 @@
 //
-//  DetailTableViewCell.swift
-//  Expo1900
-//
-//  Created by 맹선아 on 2022/10/24.
+//  EntryTableViewCell.swift
+//  Created by sunnyCookie, Wonbi
 //
 
 import UIKit
 
-class EntryTableViewCell: UITableViewCell {
+final class EntryTableViewCell: UITableViewCell {
     @IBOutlet weak var entryimageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptLabel: UILabel!
-    
-    func buildCell(from entry: Entry) {
-        entryimageView.image = UIImage(named: entry.imageName)
-        titleLabel.text = entry.name
-        descriptLabel.text = entry.shortDescription
-    }
     
     override func awakeFromNib() {
         super.awakeFromNib()
         
         configureAttribute()
     }
+}
+
+extension EntryTableViewCell {
+    func buildCell(from entry: Entry) {
+        entryimageView.image = UIImage(named: entry.imageName)
+        titleLabel.text = entry.name
+        descriptLabel.text = entry.shortDescription
+    }
     
-    func configureAttribute() {
+    private func configureAttribute() {
         titleLabel.font = .preferredFont(forTextStyle: .title2)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.numberOfLines = 0

--- a/Expo1900/Expo1900/Controller/EntryViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryViewController.swift
@@ -18,14 +18,6 @@ final class EntryViewController: UIViewController {
         super.init(coder: coder)
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        let orientation = UIDevice.current.orientation.rawValue
-        
-        UIDevice.current.setValue(orientation, forKey: "orientation")
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -35,7 +27,17 @@ final class EntryViewController: UIViewController {
         buildNavigationBar()
     }
     
-    private func buildNavigationBar() {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let orientation = UIDevice.current.orientation.rawValue
+        
+        UIDevice.current.setValue(orientation, forKey: "orientation")
+    }
+}
+
+private extension EntryViewController {
+    func buildNavigationBar() {
         navigationController?.navigationBar.isHidden = false
         title = "한국의 출품작"
     }

--- a/Expo1900/Expo1900/Controller/EntryViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryViewController.swift
@@ -17,6 +17,14 @@ final class EntryViewController: UIViewController {
         super.init(coder: coder)
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let orientation = UIDevice.current.orientation.rawValue
+        UIDevice.current.setValue(orientation, forKey: "orientation")
+        UINavigationController.attemptRotationToDeviceOrientation()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/Expo1900/Expo1900/Controller/EntryViewController.swift
+++ b/Expo1900/Expo1900/Controller/EntryViewController.swift
@@ -12,6 +12,7 @@ final class EntryViewController: UIViewController {
     
     required init?(coder: NSCoder) {
         guard let entries = JSONDecoder.decode([Entry].self, from: "items") else { return nil }
+        
         self.entries = entries
         
         super.init(coder: coder)
@@ -21,8 +22,8 @@ final class EntryViewController: UIViewController {
         super.viewWillAppear(animated)
         
         let orientation = UIDevice.current.orientation.rawValue
+        
         UIDevice.current.setValue(orientation, forKey: "orientation")
-        UINavigationController.attemptRotationToDeviceOrientation()
     }
     
     override func viewDidLoad() {
@@ -68,6 +69,7 @@ extension EntryViewController: UITableViewDataSource {
             for: indexPath) as? EntryTableViewCell else { return UITableViewCell() }
         
         cell.buildCell(from: entries[indexPath.row])
+        
         return cell
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
@@ -30,7 +30,23 @@ final class ExpoMainViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
         buildNavigationBar()
+        
+        let portrait = UIInterfaceOrientation.portrait.rawValue
+        let orientation = UIDevice.current.orientation.rawValue 
+        UIDevice.current.setValue(portrait, forKey: "orientation")
+        UIDevice.current.setValue(orientation, forKey: "orientation")
+        
+        UIDevice().endGeneratingDeviceOrientationNotifications()
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        let orientation = UIDevice.current.orientation.rawValue
+        UIDevice.current.setValue(orientation, forKey: "orientation")
     }
     
     private func buildNavigationBar() {

--- a/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
@@ -25,6 +25,7 @@ final class ExpoMainViewController: UIViewController {
         ) else { return }
         
         expoInformation = expoInformationData
+        configureAttribute()
         buildExpoMainView()
     }
     
@@ -37,24 +38,42 @@ final class ExpoMainViewController: UIViewController {
         title = "메인"
     }
     
+    private func configureAttribute() {
+        titleLabel.numberOfLines = 0
+        titleLabel.font = .preferredFont(forTextStyle: .title1)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.textAlignment = .center
+        titleLabel.lineBreakMode = .byWordWrapping
+        
+        visitorLabel.numberOfLines = 0
+        visitorLabel.font = .preferredFont(forTextStyle: .title3)
+        visitorLabel.adjustsFontForContentSizeCategory = true
+        visitorLabel.lineBreakMode = .byWordWrapping
+        
+        localeLabel.numberOfLines = 0
+        localeLabel.font = .preferredFont(forTextStyle: .title3)
+        localeLabel.adjustsFontForContentSizeCategory = true
+        localeLabel.lineBreakMode = .byWordWrapping
+        
+        periodLabel.numberOfLines = 0
+        periodLabel.font = .preferredFont(forTextStyle: .title3)
+        periodLabel.adjustsFontForContentSizeCategory = true
+        periodLabel.lineBreakMode = .byWordWrapping
+        
+        descriptionTextView.font = .preferredFont(forTextStyle: .body)
+        descriptionTextView.adjustsFontForContentSizeCategory = true
+        descriptionTextView.textContainer.lineBreakMode = .byWordWrapping
+    }
+    
     private func buildExpoMainView() {
         guard let expoInformation = expoInformation else { return }
         
         titleLabel.text = expoInformation.mainTitle
-        titleLabel.numberOfLines = 0
-        titleLabel.font = .preferredFont(forTextStyle: .title1)
-        titleLabel.textAlignment = .center
-
         posterImage.image = UIImage(named: "poster")
-        
         visitorLabel.text = "\(expoInformation.decimalVisitor) 명"
-        
         localeLabel.text = expoInformation.location
-        
         periodLabel.text = expoInformation.duration
-        
         descriptionTextView.text = expoInformation.description
-        descriptionTextView.font = .preferredFont(forTextStyle: .body)
         
         flagImages.forEach { flagImage in
             flagImage.image = UIImage(named: "flag")

--- a/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
@@ -40,17 +40,17 @@ final class ExpoMainViewController: UIViewController {
         buildNavigationBar()
         
         let portrait = UIInterfaceOrientation.portrait.rawValue
-        let orientation = UIDevice.current.orientation.rawValue 
+        let orientation = UIDevice.current.orientation.rawValue
+        
         UIDevice.current.setValue(portrait, forKey: "orientation")
         UIDevice.current.setValue(orientation, forKey: "orientation")
-        
-        UIDevice().endGeneratingDeviceOrientationNotifications()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         let orientation = UIDevice.current.orientation.rawValue
+        
         UIDevice.current.setValue(orientation, forKey: "orientation")
     }
     
@@ -93,7 +93,6 @@ final class ExpoMainViewController: UIViewController {
         localeLabel.text = expoInformation.location
         periodLabel.text = expoInformation.duration
         descriptionTextView.text = expoInformation.description
-        
         flagImages.forEach { flagImage in
             flagImage.image = UIImage(named: "flag")
         }

--- a/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
@@ -97,7 +97,7 @@ private extension ExpoMainViewController {
         visitorLabel.text = "\(expoInformation.decimalVisitor) 명"
         localeLabel.text = expoInformation.location
         periodLabel.text = expoInformation.duration
-        descriptionTextView.text = expoInformation.description
+        descriptionTextView.attributedText = expoInformation.description.applyHangulAttribute()
         flagImages.forEach { flagImage in
             flagImage.image = UIImage(named: "flag")
         }

--- a/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 final class ExpoMainViewController: UIViewController {
-    private var expoInformation: ExpoInformation?
+    private let expoInformation: ExpoInformation
     
     @IBOutlet weak private var titleLabel: UILabel!
     @IBOutlet weak private var posterImage: UIImageView!
@@ -16,15 +16,20 @@ final class ExpoMainViewController: UIViewController {
     @IBOutlet weak private var descriptionTextView: UITextView!
     @IBOutlet private var flagImages: [UIImageView]!
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
+    required init?(coder: NSCoder) {
         guard let expoInformationData = JSONDecoder.decode(
             ExpoInformation.self,
             from: "exposition_universelle_1900"
-        ) else { return }
+        ) else { return nil }
         
         expoInformation = expoInformationData
+        
+        super.init(coder: coder)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
         configureAttribute()
         buildExpoMainView()
     }
@@ -82,8 +87,6 @@ final class ExpoMainViewController: UIViewController {
     }
     
     private func buildExpoMainView() {
-        guard let expoInformation = expoInformation else { return }
-        
         titleLabel.text = expoInformation.mainTitle
         posterImage.image = UIImage(named: "poster")
         visitorLabel.text = "\(expoInformation.decimalVisitor) 명"

--- a/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoMainViewController.swift
@@ -54,12 +54,17 @@ final class ExpoMainViewController: UIViewController {
         UIDevice.current.setValue(orientation, forKey: "orientation")
     }
     
-    private func buildNavigationBar() {
-        navigationController?.navigationBar.isHidden = true
-        title = "메인"
+    @IBAction func tapEntryButton(_ sender: UIButton) {
+        guard let entryViewController = storyboard?.instantiateViewController(
+            withIdentifier: "EntryViewController"
+        ) as? EntryViewController else { return }
+        
+        navigationController?.pushViewController(entryViewController, animated: true)
     }
+}
     
-    private func configureAttribute() {
+private extension ExpoMainViewController {
+    func configureAttribute() {
         titleLabel.numberOfLines = 0
         titleLabel.font = .preferredFont(forTextStyle: .title1)
         titleLabel.adjustsFontForContentSizeCategory = true
@@ -86,7 +91,7 @@ final class ExpoMainViewController: UIViewController {
         descriptionTextView.textContainer.lineBreakMode = .byWordWrapping
     }
     
-    private func buildExpoMainView() {
+    func buildExpoMainView() {
         titleLabel.text = expoInformation.mainTitle
         posterImage.image = UIImage(named: "poster")
         visitorLabel.text = "\(expoInformation.decimalVisitor) 명"
@@ -98,11 +103,8 @@ final class ExpoMainViewController: UIViewController {
         }
     }
     
-    @IBAction func tapEntryButton(_ sender: UIButton) {
-        guard let entryViewController = storyboard?.instantiateViewController(
-            withIdentifier: "EntryViewController"
-        ) as? EntryViewController else { return }
-        
-        navigationController?.pushViewController(entryViewController, animated: true)
+    func buildNavigationBar() {
+        navigationController?.navigationBar.isHidden = true
+        title = "메인"
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpoNavigationController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoNavigationController.swift
@@ -1,0 +1,12 @@
+//
+//  ExpoNavigationController.swift
+//  Created by sunnyCookie, Wonbi
+//
+ 
+import UIKit
+
+class ExpoNavigationController: UINavigationController {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return (topViewController as? ExpoMainViewController) != nil ? .portrait : .all
+    }
+}

--- a/Expo1900/Expo1900/Controller/ExpoNavigationController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoNavigationController.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-class ExpoNavigationController: UINavigationController {
+final class ExpoNavigationController: UINavigationController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return (topViewController as? ExpoMainViewController) != nil ? .portrait : .all
     }

--- a/Expo1900/Expo1900/Controller/ExpoNavigationController.swift
+++ b/Expo1900/Expo1900/Controller/ExpoNavigationController.swift
@@ -2,7 +2,7 @@
 //  ExpoNavigationController.swift
 //  Created by sunnyCookie, Wonbi
 //
- 
+
 import UIKit
 
 class ExpoNavigationController: UINavigationController {

--- a/Expo1900/Expo1900/Info.plist
+++ b/Expo1900/Expo1900/Info.plist
@@ -54,6 +54,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/Expo1900/Expo1900/Model/Extension/String+Extension.swift
+++ b/Expo1900/Expo1900/Model/Extension/String+Extension.swift
@@ -1,0 +1,23 @@
+//
+//  String+Extension.swift
+//  Created by sunnyCookie, Wonbi
+//
+
+import UIKit
+
+extension String {
+    func applyHangulAttribute() -> NSAttributedString {
+        let paragraphStyle = NSMutableParagraphStyle()
+        
+        if #available(iOS 14.0, *) {
+            paragraphStyle.lineBreakStrategy = .hangulWordPriority
+        }
+        
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.preferredFont(forTextStyle: .body),
+            .paragraphStyle: paragraphStyle
+        ]
+        
+        return NSAttributedString(string: self, attributes: attributes)
+    }
+}

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -35,7 +35,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="pRD-2g-RBJ">
                                                 <rect key="frame" x="157" y="168.5" width="100" height="418"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3rx-Sl-zOl">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3rx-Sl-zOl">
                                                         <rect key="frame" x="0.0" y="397.5" width="53.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
@@ -52,7 +52,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DzZ-oe-oJB">
                                                 <rect key="frame" x="157" y="596.5" width="100" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoO-9y-izL">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoO-9y-izL">
                                                         <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
@@ -69,7 +69,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="SMl-7e-a5T">
                                                 <rect key="frame" x="147.5" y="627" width="119" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVE-w1-jwb">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVE-w1-jwb">
                                                         <rect key="frame" x="0.0" y="0.0" width="72.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -307,10 +307,10 @@
             </objects>
             <point key="canvasLocation" x="2694.202898550725" y="116.51785714285714"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Expo Navigation Controller-->
         <scene sceneID="b7R-Rc-Hbd">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="l6V-TY-78d" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="l6V-TY-78d" customClass="ExpoNavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="UaA-iE-yvK">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -175,20 +175,23 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCell" id="b9C-QF-lRN" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="66.5"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="113"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="b9C-QF-lRN" id="uCI-Gn-WSU">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="66.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="113"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="waH-md-pu0">
-                                                    <rect key="frame" x="10" y="10" width="365.5" height="46.5"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="waH-md-pu0">
+                                                    <rect key="frame" x="10" y="10" width="365.5" height="93"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="O7R-S9-vLS">
-                                                            <rect key="frame" x="0.0" y="0.0" width="92.5" height="46.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="92.5" height="93"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" secondItem="O7R-S9-vLS" secondAttribute="height" id="lJy-zJ-rJ0"/>
+                                                            </constraints>
                                                         </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="jPU-BU-7A8">
-                                                            <rect key="frame" x="110.5" y="0.0" width="255" height="46.5"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="jPU-BU-7A8">
+                                                            <rect key="frame" x="110.5" y="23.5" width="255" height="46"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T4G-X4-jlM">
                                                                     <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
@@ -197,7 +200,7 @@
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GhJ-0j-DRI">
-                                                                    <rect key="frame" x="0.0" y="25.5" width="41.5" height="21"/>
+                                                                    <rect key="frame" x="0.0" y="25.5" width="41.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="l6V-TY-78d">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -14,35 +14,35 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="ExpoMainViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cwg-Jj-g2E">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                                <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="93W-52-cR8">
-                                        <rect key="frame" x="0.0" y="15" width="414" height="896"/>
+                                        <rect key="frame" x="0.0" y="15" width="428" height="926"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ULX-bY-vJb">
-                                                <rect key="frame" x="186.5" y="0.0" width="41.5" height="20.5"/>
+                                                <rect key="frame" x="193.33333333333334" y="0.0" width="41.333333333333343" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="mez-uf-R9J">
-                                                <rect key="frame" x="15" y="30.5" width="384" height="128"/>
+                                                <rect key="frame" x="22" y="30.333333333333343" width="384" height="128"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="pRD-2g-RBJ">
-                                                <rect key="frame" x="157" y="168.5" width="100" height="418"/>
+                                                <rect key="frame" x="164.33333333333334" y="168.33333333333334" width="99.666666666666657" height="465.33333333333326"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3rx-Sl-zOl">
-                                                        <rect key="frame" x="0.0" y="397.5" width="53.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="445" width="53.333333333333336" height="20.333333333333314"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SyN-bO-t8k">
-                                                        <rect key="frame" x="58.5" y="397.5" width="41.5" height="20.5"/>
+                                                        <rect key="frame" x="58.333333333333314" y="445" width="41.333333333333343" height="20.333333333333314"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -50,16 +50,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DzZ-oe-oJB">
-                                                <rect key="frame" x="157" y="596.5" width="100" height="20.5"/>
+                                                <rect key="frame" x="164.33333333333334" y="643.66666666666663" width="99.666666666666657" height="20.333333333333371"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoO-9y-izL">
-                                                        <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="53.333333333333336" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BwM-2t-jqO">
-                                                        <rect key="frame" x="58.5" y="0.0" width="41.5" height="20.5"/>
+                                                        <rect key="frame" x="58.333333333333314" y="0.0" width="41.333333333333343" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -67,16 +67,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="SMl-7e-a5T">
-                                                <rect key="frame" x="147.5" y="627" width="119" height="20.5"/>
+                                                <rect key="frame" x="154.66666666666666" y="674" width="118.66666666666666" height="20.333333333333371"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVE-w1-jwb">
-                                                        <rect key="frame" x="0.0" y="0.0" width="72.5" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="72.333333333333329" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Eib-7o-4WV">
-                                                        <rect key="frame" x="77.5" y="0.0" width="41.5" height="20.5"/>
+                                                        <rect key="frame" x="77.333333333333343" y="0.0" width="41.333333333333343" height="20.333333333333332"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -84,7 +84,7 @@
                                                 </subviews>
                                             </stackView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RCu-ZD-dGs">
-                                                <rect key="frame" x="12" y="657.5" width="390" height="183.5"/>
+                                                <rect key="frame" x="12" y="704.33333333333337" width="404" height="166.66666666666663"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -92,7 +92,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="pna-Z6-6qK">
-                                                <rect key="frame" x="70.5" y="851" width="273" height="45"/>
+                                                <rect key="frame" x="77.666666666666686" y="881" width="273" height="45"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0nu-f8-pVS">
                                                         <rect key="frame" x="0.0" y="0.0" width="45" height="45"/>
@@ -167,40 +167,40 @@
             <objects>
                 <viewController storyboardIdentifier="EntryViewController" id="kJ7-hx-cdd" customClass="EntryViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="fcB-kX-nNA">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Hd5-Zd-iGY">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="44" width="428" height="848"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryCell" id="b9C-QF-lRN" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="113"/>
+                                        <rect key="frame" x="0.0" y="44.666666030883789" width="428" height="107.33333587646484"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="b9C-QF-lRN" id="uCI-Gn-WSU">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="113"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="399.33333333333331" height="107.33333587646484"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="waH-md-pu0">
-                                                    <rect key="frame" x="10" y="10" width="365.5" height="93"/>
+                                                    <rect key="frame" x="10" y="10" width="379.33333333333331" height="87.333333333333329"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="O7R-S9-vLS">
-                                                            <rect key="frame" x="0.0" y="0.0" width="92.5" height="93"/>
+                                                            <rect key="frame" x="0.0" y="0.3333333333333357" width="96" height="87"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="width" secondItem="O7R-S9-vLS" secondAttribute="height" id="lJy-zJ-rJ0"/>
+                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" secondItem="O7R-S9-vLS" secondAttribute="height" id="lJy-zJ-rJ0"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="jPU-BU-7A8">
-                                                            <rect key="frame" x="110.5" y="23.5" width="255" height="46"/>
+                                                            <rect key="frame" x="114" y="20.999999999999996" width="265.33333333333331" height="45.666666666666657"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T4G-X4-jlM">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="20.333333333333332"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GhJ-0j-DRI">
-                                                                    <rect key="frame" x="0.0" y="25.5" width="41.5" height="20.5"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GhJ-0j-DRI">
+                                                                    <rect key="frame" x="0.0" y="25.333333333333336" width="41.333333333333336" height="20.333333333333336"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -250,20 +250,20 @@
             <objects>
                 <viewController storyboardIdentifier="DetailViewController" id="478-jk-paC" customClass="DetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5Uq-NN-qXh">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q96-QM-M0Q">
-                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
+                                <rect key="frame" x="0.0" y="44" width="428" height="882"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="rQO-cf-7Kb">
-                                        <rect key="frame" x="0.0" y="15" width="414" height="852"/>
+                                        <rect key="frame" x="0.0" y="15" width="428" height="882"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qsV-N3-4Qd">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="646"/>
+                                                <rect key="frame" x="19" y="0.0" width="390" height="646"/>
                                             </imageView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="sMi-Go-keB">
-                                                <rect key="frame" x="12" y="656" width="390" height="196"/>
+                                                <rect key="frame" x="12" y="656" width="404" height="226"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                 <color key="textColor" systemColor="labelColor"/>
@@ -313,7 +313,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="l6V-TY-78d" customClass="ExpoNavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="UaA-iE-yvK">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="428" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -35,7 +35,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="pRD-2g-RBJ">
                                                 <rect key="frame" x="157" y="168.5" width="100" height="418"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3rx-Sl-zOl">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3rx-Sl-zOl">
                                                         <rect key="frame" x="0.0" y="397.5" width="53.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
@@ -52,7 +52,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DzZ-oe-oJB">
                                                 <rect key="frame" x="157" y="596.5" width="100" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoO-9y-izL">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LoO-9y-izL">
                                                         <rect key="frame" x="0.0" y="0.0" width="53.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
@@ -69,7 +69,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="SMl-7e-a5T">
                                                 <rect key="frame" x="147.5" y="627" width="119" height="20.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVE-w1-jwb">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVE-w1-jwb">
                                                         <rect key="frame" x="0.0" y="0.0" width="72.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -91,7 +91,7 @@
                                                 <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="pna-Z6-6qK">
+                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="pna-Z6-6qK">
                                                 <rect key="frame" x="77.666666666666686" y="881" width="273" height="45"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0nu-f8-pVS">
@@ -102,7 +102,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ly-LK-lG2">
-                                                        <rect key="frame" x="60" y="0.0" width="153" height="45"/>
+                                                        <rect key="frame" x="60" y="7" width="153" height="31"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>


### PR DESCRIPTION
@SungPyo 
안녕하세요 웨더! 🙇🏻‍♀️🙇
Step3에서 오토레이아웃과 DynamicType적용,
화면전환을 설정해보았습니다.
더 공부했으면하는 내용이나 수정이 필요해보이는 부분이 보이시면
가감없는 코멘트 부탁드리겠습니다 ㅎㅎ!

## 📝 STEP 진행 중 경험하고 배운 것
- 오토 레이아웃을 적용하여 다양한 기기에 대응
     ☑️ StackView의 Distribution, alignment 속성을 이용한 오토레이아웃적용
     ☑️ imageView의 원본비율 유지하는 오토레이아웃 적용하기
     ☑️ 오토레이아웃 제약을 코드로 구현하기
- 뷰 컨트롤러 사이의 데이터 전달
     ☑️ 뷰컨의 이니셜라이저를 통한 데이터전달
- Dynamic Types를 통해 텍스트 접근성 향상
     ☑️ labe, textView의 FontSize에 Dynamic Types적용

## ⚒️ 코드 구현내용 
### 1️⃣ ExpoMainViewController
- `init?(coder:)`
    - `expoInformation`프로퍼티의 데이터를 `JSONDecoder`통해 가져와 초기화 시킵니다.

- `viewWillAppear(_:)`
    - `portrait`상수를 통해 뷰가 나타날 때의 상태를 세로모드로 고정합니다.
    - `orientation`상수를 통해 현재 화면의 모드를 결정해 적용합니다. 

- `viewWillDisappear(_:)`
    - `orientation`상수를 통해 뷰가 사라지기 전 현재 현재 화면의 모드를 결정해 적용합니다. 

- `configureAttribute()`
    - 뷰의 각 구성요소들의 속성을 코드를 통해 정의합니다.

- `buildExpoMainView()`
    - 뷰의 구성요소들에 `expoInformation`프로퍼티의 데이터를 주입합니다.

### 2️⃣ EntryViewController
- `init?(coder:)`
    - `entries`프로퍼티의 데이터를 `JSONDecoder`통해 가져와 초기화 시킵니다.

- `viewWillAppear(_:)` 
    - `orientation`상수를 통해 뷰가 나타날 때의 화면 모드를 결정해 적용합니다. 

- `tableView(_:, didSelectRowAt:)` 메서드
    - `instantiateViewController(identifier:, creator:)` 메서드를 이용해 스토리보드의 뷰컨트롤러를 커스텀 이니셜라이저를 이용해 초기화합니다.

### 3️⃣ EntryTableViewCell
- `configureAttribute` 메서드
    - 셀의 각 구성요소들의 속성을 코드를 통해 정의합니다.

### 4️⃣ DetailViewController
- `init?(entry:, coder:)`
    - `Entry` 타입의 데이터를 매개변수로 받아 `entry`프로퍼티의 데이터를 초기화 시킵니다.

- `init?(coder:)`
    - `fatalError()` 메서드를 이용해 사용하지 않는 이니셜라이저 임을 명시합니다. 

- `configureAttribute` 메서드
    - 뷰의 구성요소들의 속성을 코드를 통해 정의합니다.

- `configureImageViewConstraints` 메서드
    - 이미지 뷰의 오토레이아웃 제약조건을 코드를 통해 정의합니다.

### 5️⃣ ExpoNavigationController
- `supportedInterfaceOrientations` 프로퍼티
    - 지원하는 가로세로 모드를 첫화면에서만 세로모드가 되도록 오버라이딩 합니다.

## 💭 고민한 부분
### Dynamic Type 적용 시 Button의 실제 사이즈는 커지지않고 Title이 담기는 라벨 사이즈만 커지는 문제 

<details>
    <summary> [click] </summary>

| 문제의 화면 | <img width = 250, src= "https://i.imgur.com/ow41i2L.png"> |<img width = 250, src= "https://i.imgur.com/sbONiCH.png">|
| -------- | -------- | -------- |
| 수정 후 화면     | <img width = 250, src= "https://i.imgur.com/3qPtXGh.png">    |<img width = 250, src= "https://i.imgur.com/Y91IzRf.png">     |

첫번째 `ExpoMainView`에서 Dynamic Type의 가장 큰 글씨크기를 적용 했을 때 버튼관련한 문제가 있었습니다. Button의 Title도 그에 맞게 가장 큰 글씨가 적용될 때 위의 문제의 화면과 같이 실제의 버튼 높이는 커지지 않고 버튼의 TextLabel만 커져서 위의 TextView의 영역을 침범하는 문제였습니다.

해결은 버튼이 담긴 스택뷰의 alignment속성을 변경하여 해결했습니다. 버튼은 양 옆의 국기 이미지뷰와 함께 세로 스택뷰로 구성되어있습니다. 이 스택뷰의 alignment 속성을 fill에서 center로 수정해 문제를 해결했습니다.
</details>

### 뷰를 세모로드로 고정했지만 navigationBar의 BackButton으로 돌아올 때는 뷰가 세로로 고정되어있지 않고 가로모드로 보여지는 문제

<details>
    <summary> [click] </summary>
첫번째 뷰(ExpoMainView)를 세로로 고정하는 코드를 구현하면서 여러 문제를 만났습니다.

우선 첫번째 뷰의 방향만 `portrait`으로 고정해주기 위해 `NavigationController`의 `supportedInterfaceOrientations`프로퍼티를 이용해 다음과 같은 코드를 구현했습니다.
```swift
class ExpoNavigationController: UINavigationController {
    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return (topViewController as? ExpoMainViewController) != nil ? .portrait : .all
    }
}
```
- 👻❗️발생한 문제(1)
두번째, 세번째 뷰에서 가로모드로 방향전환 후 그 상태로 navigationBar의 BackButton으로 첫번째 뷰로 다시 돌아올 때는 뷰가 세로로 고정되어있지 않고 가로모드로 보여지는 문제였습니다.

#### 1️⃣번시도 : supportedInterfaceOrientations 값 추가하기
첫번째 뷰의 viewController에서 `supportedInterfaceOrientations`프로퍼티를 이용해 `portrait`으로 고정해 줘 보았습니다.
```swift
  override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return .portrait
    }
```
위에서 언급한 (1)번 문제는 해결되었지만 다른 문제가 생겼습니다.
- 👻❗️발생한 문제(2)
두번째 뷰에서 가로모드 후 첫번째 뷰로갔다가 방향전환없이 다시 두번째뷰로 가면 네비게이션바가 정상작동하지 않는 문제
 <img width = 400, src = "https://i.imgur.com/PLeITKh.png">
- 이 문제의 이유는 네비게이션 바는 가로방향으로 인식하고 있기 때문이었습니다.

#### 2️⃣번시도: 노티피케이션
(2)번 문제를 해결해보기 위해 방향을 알려주기위해 `UIDevice`에 구현되어 있는 `beginGeneratingDeviceOrientationNotifications()` 메서드를 사용해보았습니다
 ```swift
UIDevice.current.beginGeneratingDeviceOrientationNotifications()
```
- 👻❗️ 별 다른 변화없이 같은 문제가 반복되었습니다.

#### 3️⃣번시도: Appdelegate에서 orientation 설정해주기
컨셉을 바꿔 `NavigationController`에서 화면방향을 설정해주지 않고 Appdelegate에서 설정해주는 방법을 적용해 보았습니다. 
```swift
//앱딜리게이트에 구현
    var shouldSupportAllOrientation = true

    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
        return shouldSupportAllOrientation ? .all : .portrait
    }

// 세로고정하고싶은 뷰컨에서 구현

let appDelegate = UIApplication.shared.delegate as! AppDelegate

override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    appDelegate.shouldSupportAllOrientation = false
}

override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    appDelegate.shouldSupportAllOrientation = true
}
```
- 👻❗️발생한 문제 
    1. 가로로 시작하는 시뮬레이터에서는 세로모드지원되지않음 (즉 가로모드로 동작시작)
    2. 두번째뷰에서 가로로 화면전환 후 backButton으로 돌아올 때 세로모드 지원되지않음
        (위의 (1)번 문제상황과 같은현상)
 
### 🔫 해결
```swift
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
 
        let portrait = UIInterfaceOrientation.portrait.rawValue
        
        UIDevice.current.setValue(portrait, forKey: "orientation")
    }
```
ExpoMainView의 `ViewWillAppear`메서드 내부에서 현재 디바이스의 방향을 portrait으로 지정해줘서 navigationBar의 backButton으로 화면이 나타날 때고 세로모드로 보이도록 수정했습니다. 

</details>

### textView에서 lineBreak 적용되지 않는 문제
<details>
    <summary> [click] </summary>
> 이유: textView의 lineBreak 설정이 한글 지원을 완벽하게 하지 않음 

- `UITextView`대신 `UILabel` 사용을 고려해봤습니다.
    - HIG에 따르면 다음과 같이 서술하고 있습니다.
    > Use a text view when you need to display text that’s long, editable, or in a special format. If you need to display a small amount of text, it’s simpler to use a label instead or a text field if the text is editable.

    - 이러한 이유로 긴 문장을 `UILabel`로 보여주는 것은 좋은 방법이 아니라 판단하여 적용하지 않았습니다.

- `NSAttributedString`사용하기
    ```swift
    extension String {
        func applyHangulAttribute() -> NSAttributedString {
            let paragraphStyle = NSMutableParagraphStyle()

            if #available(iOS 14.0, *) {
                paragraphStyle.lineBreakStrategy = .hangulWordPriority
            }

            let attributes: [NSAttributedString.Key: Any] = [
                .font: UIFont.preferredFont(forTextStyle: .body),
                .paragraphStyle: paragraphStyle
            ]

            return NSAttributedString(string: self, attributes: attributes)
        }
    }
    ```
    - `NSAttributedString`는 `String`에 텍스트의 속성을 저장하여 사용할 수 있는 구조체입니다.
    - 이 구조체를 활용하여 iOS 14버전 부터 사용 가능한 한글 줄바꿈 속성을 적용하여 textView에 보여지도록 구현해 보았습니다.

</details>
