### PR TITLE
만국박람회 [STEP 3] baem, woong

### DIFF
--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -9,6 +9,16 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    var shouldSupportAllOrientation = true
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if shouldSupportAllOrientation == true {
+            return UIInterfaceOrientationMask.all
+        }
+        
+        return UIInterfaceOrientationMask.portrait
+        
+    }
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/Expo1900/Expo1900/Controller/PosterViewController.swift
+++ b/Expo1900/Expo1900/Controller/PosterViewController.swift
@@ -7,6 +7,7 @@
 import UIKit
 
 class PosterViewController: UIViewController {
+    let appDelegate = UIApplication.shared.delegate as? AppDelegate
     var expositionParis: ExpositionParis?
     
     @IBOutlet weak var titleLabel: UILabel!
@@ -18,6 +19,14 @@ class PosterViewController: UIViewController {
     
     @IBOutlet weak var leftFlagImageView: UIImageView!
     @IBOutlet weak var rightFlagImageView: UIImageView!
+    
+    override func viewWillAppear(_ animated: Bool) {
+        appDelegate?.shouldSupportAllOrientation = false
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        appDelegate?.shouldSupportAllOrientation = true
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aXp-OT-7DT">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="8"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -21,79 +22,79 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L0Y-YB-lDO">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="489.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="599.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="jlB-D9-evE">
-                                                <rect key="frame" x="15" y="15" width="384" height="474.5"/>
+                                                <rect key="frame" x="15" y="15" width="384" height="584.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7MG-t9-J5q">
-                                                        <rect key="frame" x="172" y="0.0" width="40" height="30"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7MG-t9-J5q">
+                                                        <rect key="frame" x="158.5" y="0.0" width="67.5" height="51.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ufW-iP-i4e">
-                                                        <rect key="frame" x="120" y="44" width="144" height="200"/>
+                                                        <rect key="frame" x="120" y="65.5" width="144" height="200"/>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="UKL-rj-fIH">
-                                                        <rect key="frame" x="119.5" y="258" width="145" height="30"/>
+                                                        <rect key="frame" x="54.5" y="279.5" width="275" height="51.5"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Chw-4f-NHp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Chw-4f-NHp">
+                                                                <rect key="frame" x="0.0" y="0.0" width="130.5" height="51.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UIk-0j-cb2">
-                                                                <rect key="frame" x="90.5" y="0.0" width="54.5" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UIk-0j-cb2">
+                                                                <rect key="frame" x="144.5" y="0.0" width="130.5" height="51.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="4e6-Qn-bIu">
-                                                        <rect key="frame" x="116.5" y="302" width="151" height="30"/>
+                                                        <rect key="frame" x="54.5" y="345" width="275" height="51.5"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ivo-ju-AgS">
-                                                                <rect key="frame" x="0.0" y="0.0" width="76.5" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ivo-ju-AgS">
+                                                                <rect key="frame" x="0.0" y="0.0" width="130.5" height="51.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hoM-lF-QgD">
-                                                                <rect key="frame" x="90.5" y="0.0" width="60.5" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hoM-lF-QgD">
+                                                                <rect key="frame" x="144.5" y="0.0" width="130.5" height="51.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="WUS-3d-Ctk">
-                                                        <rect key="frame" x="101.5" y="346" width="181" height="30"/>
+                                                        <rect key="frame" x="8" y="410.5" width="368" height="51.5"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6v-Al-SWR">
-                                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6v-Al-SWR">
+                                                                <rect key="frame" x="0.0" y="0.0" width="177" height="51.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mHt-PD-SuJ">
-                                                                <rect key="frame" x="117.5" y="0.0" width="63.5" height="30"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mHt-PD-SuJ">
+                                                                <rect key="frame" x="191" y="0.0" width="177" height="51.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                         </subviews>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOa-Iq-ZBY">
-                                                        <rect key="frame" x="149.5" y="390" width="85.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <rect key="frame" x="104" y="476" width="176.5" height="44.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="xba-34-xZ9">
-                                                        <rect key="frame" x="45.5" y="424.5" width="293" height="50"/>
+                                                        <rect key="frame" x="2" y="534.5" width="380" height="50"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RF5-x6-l8I">
                                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -103,15 +104,17 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVg-4g-2KI">
-                                                                <rect key="frame" x="70" y="0.0" width="153" height="50"/>
+                                                                <rect key="frame" x="70" y="0.0" width="240" height="50"/>
                                                                 <state key="normal" title="Button"/>
-                                                                <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
+                                                                <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기">
+                                                                    <fontDescription key="titleFontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                </buttonConfiguration>
                                                                 <connections>
                                                                     <segue destination="64t-RW-s0d" kind="push" id="9Sz-fO-ZHw"/>
                                                                 </connections>
                                                             </button>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="srw-pI-CHQ">
-                                                                <rect key="frame" x="243" y="0.0" width="50" height="50"/>
+                                                                <rect key="frame" x="330" y="0.0" width="50" height="50"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="50" id="R3F-kO-aUP"/>
                                                                     <constraint firstAttribute="height" constant="50" id="h8c-qr-47o"/>
@@ -181,33 +184,33 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="entryTableViewCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryTableViewCell" id="EhJ-Tu-qaI" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="87"/>
+                                        <rect key="frame" x="0.0" y="72.5" width="414" height="133"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EhJ-Tu-qaI" id="72H-OB-7za">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="87"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="133"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9jq-yp-uGg">
-                                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="87"/>
+                                                    <rect key="frame" x="10" y="10" width="354" height="113"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="FNn-NA-wQk">
-                                                            <rect key="frame" x="0.0" y="0.0" width="86.5" height="87"/>
+                                                            <rect key="frame" x="0.0" y="17" width="79.5" height="79"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="FNn-NA-wQk" secondAttribute="height" id="oit-R3-s5e"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="ykM-sD-nwe">
-                                                            <rect key="frame" x="96.5" y="0.0" width="289" height="87"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ykM-sD-nwe">
+                                                            <rect key="frame" x="89.5" y="0.5" width="264.5" height="112"/>
                                                             <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sid-eu-68R">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="73.5" height="37"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sid-eu-68R">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="112" height="57.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mRi-S5-Nzh">
-                                                                    <rect key="frame" x="0.0" y="66.5" width="41.5" height="20.5"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <rect key="frame" x="0.0" y="67.5" width="87" height="44.5"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
@@ -220,11 +223,11 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="9jq-yp-uGg" secondAttribute="trailing" id="3ip-Nc-0uq"/>
-                                                <constraint firstItem="9jq-yp-uGg" firstAttribute="top" secondItem="72H-OB-7za" secondAttribute="top" id="Bpx-9J-l4i"/>
-                                                <constraint firstItem="9jq-yp-uGg" firstAttribute="leading" secondItem="72H-OB-7za" secondAttribute="leading" id="GED-me-koO"/>
-                                                <constraint firstAttribute="height" secondItem="ykM-sD-nwe" secondAttribute="height" id="WxD-As-zDR"/>
-                                                <constraint firstAttribute="bottom" secondItem="9jq-yp-uGg" secondAttribute="bottom" id="jPO-Lk-tYT"/>
+                                                <constraint firstAttribute="trailing" secondItem="9jq-yp-uGg" secondAttribute="trailing" constant="10" id="3ip-Nc-0uq"/>
+                                                <constraint firstItem="9jq-yp-uGg" firstAttribute="top" secondItem="72H-OB-7za" secondAttribute="top" constant="10" id="Bpx-9J-l4i"/>
+                                                <constraint firstItem="9jq-yp-uGg" firstAttribute="leading" secondItem="72H-OB-7za" secondAttribute="leading" constant="10" id="GED-me-koO"/>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" secondItem="ykM-sD-nwe" secondAttribute="height" id="WxD-As-zDR"/>
+                                                <constraint firstAttribute="bottom" secondItem="9jq-yp-uGg" secondAttribute="bottom" constant="10" id="jPO-Lk-tYT"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -267,10 +270,10 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Po4-xz-N6Z">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="272.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="296.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="V2h-eg-hfm">
-                                                <rect key="frame" x="8" y="8" width="398" height="256.5"/>
+                                                <rect key="frame" x="8" y="8" width="398" height="280.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZSd-eJ-gfg">
                                                         <rect key="frame" x="94" y="0.0" width="210" height="210"/>
@@ -279,8 +282,8 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VHO-XP-7Xy">
-                                                        <rect key="frame" x="178.5" y="236" width="41.5" height="20.5"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <rect key="frame" x="155.5" y="236" width="87" height="44.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -181,42 +181,50 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="entryTableViewCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryTableViewCell" id="EhJ-Tu-qaI" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="59"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="87"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EhJ-Tu-qaI" id="72H-OB-7za">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="59"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="87"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="FNn-NA-wQk">
-                                                    <rect key="frame" x="5" y="0.0" width="84.5" height="59"/>
-                                                </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="ykM-sD-nwe">
-                                                    <rect key="frame" x="99.5" y="0.0" width="281" height="59"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9jq-yp-uGg">
+                                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="87"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sid-eu-68R">
-                                                            <rect key="frame" x="0.0" y="0.0" width="73.5" height="37"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mRi-S5-Nzh">
-                                                            <rect key="frame" x="0.0" y="38.5" width="41.5" height="20.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="FNn-NA-wQk">
+                                                            <rect key="frame" x="0.0" y="0.0" width="86.5" height="87"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" secondItem="FNn-NA-wQk" secondAttribute="height" id="oit-R3-s5e"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="ykM-sD-nwe">
+                                                            <rect key="frame" x="96.5" y="0.0" width="289" height="87"/>
+                                                            <subviews>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sid-eu-68R">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="73.5" height="37"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mRi-S5-Nzh">
+                                                                    <rect key="frame" x="0.0" y="66.5" width="41.5" height="20.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
                                                     </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="FNn-NA-wQk" firstAttribute="width" secondItem="ykM-sD-nwe" secondAttribute="width" multiplier="0.3" id="h9u-27-Vq7"/>
+                                                    </constraints>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="FNn-NA-wQk" firstAttribute="width" secondItem="ykM-sD-nwe" secondAttribute="width" multiplier="0.3" id="4Ei-Og-pLG"/>
-                                                <constraint firstItem="FNn-NA-wQk" firstAttribute="leading" secondItem="72H-OB-7za" secondAttribute="leading" constant="5" id="DE0-c6-Klb"/>
-                                                <constraint firstAttribute="bottom" secondItem="ykM-sD-nwe" secondAttribute="bottom" id="TQa-ml-tzM"/>
-                                                <constraint firstAttribute="trailing" secondItem="ykM-sD-nwe" secondAttribute="trailing" constant="5" id="Uc6-N2-rIu"/>
-                                                <constraint firstAttribute="bottom" secondItem="FNn-NA-wQk" secondAttribute="bottom" id="Z3f-WG-lVq"/>
-                                                <constraint firstItem="ykM-sD-nwe" firstAttribute="top" secondItem="72H-OB-7za" secondAttribute="top" id="dek-ht-Glb"/>
-                                                <constraint firstItem="ykM-sD-nwe" firstAttribute="leading" secondItem="FNn-NA-wQk" secondAttribute="trailing" constant="10" id="n0K-AI-QRB"/>
-                                                <constraint firstItem="FNn-NA-wQk" firstAttribute="top" secondItem="72H-OB-7za" secondAttribute="top" id="ooT-da-grT"/>
+                                                <constraint firstAttribute="trailing" secondItem="9jq-yp-uGg" secondAttribute="trailing" id="3ip-Nc-0uq"/>
+                                                <constraint firstItem="9jq-yp-uGg" firstAttribute="top" secondItem="72H-OB-7za" secondAttribute="top" id="Bpx-9J-l4i"/>
+                                                <constraint firstItem="9jq-yp-uGg" firstAttribute="leading" secondItem="72H-OB-7za" secondAttribute="leading" id="GED-me-koO"/>
+                                                <constraint firstAttribute="height" secondItem="ykM-sD-nwe" secondAttribute="height" id="WxD-As-zDR"/>
+                                                <constraint firstAttribute="bottom" secondItem="9jq-yp-uGg" secondAttribute="bottom" id="jPO-Lk-tYT"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -259,16 +267,19 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Po4-xz-N6Z">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="135.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="272.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="V2h-eg-hfm">
-                                                <rect key="frame" x="8" y="8" width="398" height="119.5"/>
+                                                <rect key="frame" x="8" y="8" width="398" height="256.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZSd-eJ-gfg">
-                                                        <rect key="frame" x="94" y="0.0" width="210" height="73"/>
+                                                        <rect key="frame" x="94" y="0.0" width="210" height="210"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="ZSd-eJ-gfg" secondAttribute="height" id="CZL-G6-KMn"/>
+                                                        </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VHO-XP-7Xy">
-                                                        <rect key="frame" x="178.5" y="99" width="41.5" height="20.5"/>
+                                                        <rect key="frame" x="178.5" y="236" width="41.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aXp-OT-7DT">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
-    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="8"/>
+    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="2"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -22,79 +22,92 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L0Y-YB-lDO">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="599.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="502"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="jlB-D9-evE">
-                                                <rect key="frame" x="15" y="15" width="384" height="584.5"/>
+                                                <rect key="frame" x="15" y="15" width="384" height="487"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7MG-t9-J5q">
-                                                        <rect key="frame" x="158.5" y="0.0" width="67.5" height="51.5"/>
+                                                        <rect key="frame" x="170.5" y="0.0" width="43" height="32.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ufW-iP-i4e">
-                                                        <rect key="frame" x="120" y="65.5" width="144" height="200"/>
+                                                        <rect key="frame" x="120" y="46.5" width="144" height="200"/>
                                                     </imageView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="UKL-rj-fIH">
-                                                        <rect key="frame" x="54.5" y="279.5" width="275" height="51.5"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="sJ6-MK-Zd1">
+                                                        <rect key="frame" x="10" y="260.5" width="364" height="125.5"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Chw-4f-NHp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="130.5" height="51.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UIk-0j-cb2">
-                                                                <rect key="frame" x="144.5" y="0.0" width="130.5" height="51.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="UKL-rj-fIH">
+                                                                <rect key="frame" x="0.0" y="0.0" width="364" height="32.5"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객 :" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Chw-4f-NHp">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="175" height="32.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UIk-0j-cb2">
+                                                                        <rect key="frame" x="189" y="0.0" width="175" height="32.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="4e6-Qn-bIu">
+                                                                <rect key="frame" x="0.0" y="46.5" width="364" height="32.5"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ivo-ju-AgS">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="175" height="32.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hoM-lF-QgD">
+                                                                        <rect key="frame" x="189" y="0.0" width="175" height="32.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="WUS-3d-Ctk">
+                                                                <rect key="frame" x="0.0" y="93" width="364" height="32.5"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6v-Al-SWR">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="175" height="32.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mHt-PD-SuJ">
+                                                                        <rect key="frame" x="189" y="0.0" width="175" height="32.5"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
                                                         </subviews>
-                                                    </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="4e6-Qn-bIu">
-                                                        <rect key="frame" x="54.5" y="345" width="275" height="51.5"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지 :" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ivo-ju-AgS">
-                                                                <rect key="frame" x="0.0" y="0.0" width="130.5" height="51.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hoM-lF-QgD">
-                                                                <rect key="frame" x="144.5" y="0.0" width="130.5" height="51.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                        </subviews>
-                                                    </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="WUS-3d-Ctk">
-                                                        <rect key="frame" x="8" y="410.5" width="368" height="51.5"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간 :" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p6v-Al-SWR">
-                                                                <rect key="frame" x="0.0" y="0.0" width="177" height="51.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mHt-PD-SuJ">
-                                                                <rect key="frame" x="191" y="0.0" width="177" height="51.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                        </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="trailing" secondItem="WUS-3d-Ctk" secondAttribute="trailing" id="41P-vS-2IP"/>
+                                                            <constraint firstItem="4e6-Qn-bIu" firstAttribute="leading" secondItem="sJ6-MK-Zd1" secondAttribute="leading" id="XuQ-h8-QI8"/>
+                                                            <constraint firstItem="WUS-3d-Ctk" firstAttribute="leading" secondItem="sJ6-MK-Zd1" secondAttribute="leading" id="akZ-fj-38Q"/>
+                                                            <constraint firstAttribute="trailing" secondItem="4e6-Qn-bIu" secondAttribute="trailing" id="lid-td-FZ5"/>
+                                                            <constraint firstItem="UKL-rj-fIH" firstAttribute="leading" secondItem="sJ6-MK-Zd1" secondAttribute="leading" id="mki-QT-k5b"/>
+                                                            <constraint firstAttribute="trailing" secondItem="UKL-rj-fIH" secondAttribute="trailing" id="ror-R3-5hb"/>
+                                                        </constraints>
                                                     </stackView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOa-Iq-ZBY">
-                                                        <rect key="frame" x="104" y="476" width="176.5" height="44.5"/>
+                                                        <rect key="frame" x="144.5" y="400" width="95" height="23"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="xba-34-xZ9">
-                                                        <rect key="frame" x="2" y="534.5" width="380" height="50"/>
+                                                        <rect key="frame" x="23" y="437" width="338" height="50"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RF5-x6-l8I">
                                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -104,7 +117,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVg-4g-2KI">
-                                                                <rect key="frame" x="70" y="0.0" width="240" height="50"/>
+                                                                <rect key="frame" x="70" y="0.0" width="198" height="50"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기">
                                                                     <fontDescription key="titleFontDescription" style="UICTFontTextStyleTitle3"/>
@@ -114,7 +127,7 @@
                                                                 </connections>
                                                             </button>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="srw-pI-CHQ">
-                                                                <rect key="frame" x="330" y="0.0" width="50" height="50"/>
+                                                                <rect key="frame" x="288" y="0.0" width="50" height="50"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="50" id="R3F-kO-aUP"/>
                                                                     <constraint firstAttribute="height" constant="50" id="h8c-qr-47o"/>
@@ -123,6 +136,10 @@
                                                         </subviews>
                                                     </stackView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="sJ6-MK-Zd1" firstAttribute="leading" secondItem="jlB-D9-evE" secondAttribute="leading" constant="10" id="AUv-oR-Y00"/>
+                                                    <constraint firstAttribute="trailing" secondItem="sJ6-MK-Zd1" secondAttribute="trailing" constant="10" id="cRa-7C-i2a"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -184,32 +201,32 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="entryTableViewCell" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="entryTableViewCell" id="EhJ-Tu-qaI" customClass="EntryTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="72.5" width="414" height="133"/>
+                                        <rect key="frame" x="0.0" y="49" width="414" height="102"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EhJ-Tu-qaI" id="72H-OB-7za">
-                                            <rect key="frame" x="0.0" y="0.0" width="374" height="133"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="384" height="102"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9jq-yp-uGg">
-                                                    <rect key="frame" x="10" y="10" width="354" height="113"/>
+                                                    <rect key="frame" x="10" y="10" width="364" height="82"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="FNn-NA-wQk">
-                                                            <rect key="frame" x="0.0" y="17" width="79.5" height="79"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="81.5" height="82"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="FNn-NA-wQk" secondAttribute="height" id="oit-R3-s5e"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ykM-sD-nwe">
-                                                            <rect key="frame" x="89.5" y="0.5" width="264.5" height="112"/>
+                                                            <rect key="frame" x="91.5" y="5" width="272.5" height="72.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sid-eu-68R">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="112" height="57.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="78" height="39.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mRi-S5-Nzh">
-                                                                    <rect key="frame" x="0.0" y="67.5" width="87" height="44.5"/>
+                                                                    <rect key="frame" x="0.0" y="49.5" width="46" height="23"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -270,10 +287,10 @@
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Po4-xz-N6Z">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="296.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="275"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="26" translatesAutoresizingMaskIntoConstraints="NO" id="V2h-eg-hfm">
-                                                <rect key="frame" x="8" y="8" width="398" height="280.5"/>
+                                                <rect key="frame" x="8" y="8" width="398" height="259"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ZSd-eJ-gfg">
                                                         <rect key="frame" x="94" y="0.0" width="210" height="210"/>
@@ -282,7 +299,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VHO-XP-7Xy">
-                                                        <rect key="frame" x="155.5" y="236" width="87" height="44.5"/>
+                                                        <rect key="frame" x="176" y="236" width="46" height="23"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>


### PR DESCRIPTION
@Monsteel
안녕하세요 토니!
세 번째 PR을 보냅니다!
### 구현한 내용
- 특정 뷰컨트롤러 세로모드 고정
- 가로회전에도 정상적으로 표시되도록 구현
- 모든 화면의 기기별 호환
- Dynamic Type 적용

### 해결못한내용


👀 고민한 점

- 현재 상태
![](https://i.imgur.com/5a5g0ir.png)
- 구현하고 싶은 방향
![](https://i.imgur.com/c4q9WhX.png)


현재의 계층구조는 아래와 같습니다.

```
.
└── ScrollView  /
    ├── View
    └── .../
        └── stackView/
            ├── stackView/
            │   ├── Label:방문객
            │   └── Label:visitors data
            ├── stackView/
            │   ├── Label:개최지
            │   └── Label:location data
            └── stackView/
                ├── Label:개최 기간
                └── Label:duration data
```

"방문객" "visitors"를 Stackview로 묶어 사용 하였습니다.
중앙을 기점으로visitors의 길이가 길어져도 vistor의 위치가 고정되는 현상을 해결하지 못했습니다.
-> [구현하고 싶은 방향] 와 같이 ``방문객 : 48,130,330명`` 이 한번에 중앙정렬을 해야하는데
-> [현재 상태] 처럼``방문객 :`` ``48,130,330명`` 각각의 Label이 중앙을 기점으로 나누어 져 있습니다.

### 계속해서 고민했지만 마땅한 해결책이 나오지 않아 질문드립니다😭

Attribute를 사용해서 라벨을 따로 나누지 않고 한번에 사용하여 `방문객 :` 부분만 글씨 크기를 다르게 해줄 수 있는 방법도 확인하였지만, 스텍뷰를 잘 활용하면 충분히 해결이 가능할 것 같아 계속해서 고민해 보았습니다.