### PR TITLE
만국박람회 [STEP 3] 리지, Rowan

### DIFF
--- a/Expo1900/Expo1900/App/AppDelegate.swift
+++ b/Expo1900/Expo1900/App/AppDelegate.swift
@@ -8,12 +8,6 @@ import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-    var shouldSupportAllOrientation = true
-
-    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        shouldSupportAllOrientation == true ? .all : .portrait
-    }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/Expo1900/Expo1900/App/AppDelegate.swift
+++ b/Expo1900/Expo1900/App/AppDelegate.swift
@@ -1,6 +1,6 @@
 //
 //  Expo1900 - AppDelegate.swift
-//  Created by yagom. 
+//  Created by 리지, Rowan. 
 //  Copyright © yagom academy. All rights reserved.
 // 
 

--- a/Expo1900/Expo1900/App/AppDelegate.swift
+++ b/Expo1900/Expo1900/App/AppDelegate.swift
@@ -9,8 +9,12 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    var shouldSupportAllOrientation = true
 
-
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        shouldSupportAllOrientation == true ? .all : .portrait
+    }
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true

--- a/Expo1900/Expo1900/App/SceneDelegate.swift
+++ b/Expo1900/Expo1900/App/SceneDelegate.swift
@@ -1,6 +1,6 @@
 //
 //  Expo1900 - SceneDelegate.swift
-//  Created by yagom. 
+//  Created by 리지, Rowan. 
 //  Copyright © yagom academy. All rights reserved.
 // 
 

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -275,24 +275,24 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oqd-oU-SiR" userLabel="Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="190.33333333333334"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="197.66666666666666"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="BRU-hU-B5y">
-                                                <rect key="frame" x="16" y="10" width="361" height="170.33333333333334"/>
+                                                <rect key="frame" x="16" y="10" width="361" height="177.66666666666666"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="U6f-6h-USM">
-                                                        <rect key="frame" x="0.0" y="0.0" width="361" height="150"/>
+                                                        <rect key="frame" x="102" y="0.0" width="157" height="157.33333333333334"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="U6f-6h-USM" secondAttribute="height" multiplier="1:1" id="ibX-3o-YHr"/>
+                                                        </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qBR-Yi-pWa">
-                                                        <rect key="frame" x="160" y="150" width="41.333333333333343" height="20.333333333333343"/>
+                                                        <rect key="frame" x="160" y="157.33333333333334" width="41.333333333333343" height="20.333333333333343"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <constraints>
-                                                    <constraint firstItem="qBR-Yi-pWa" firstAttribute="top" secondItem="BRU-hU-B5y" secondAttribute="top" constant="150" id="SwL-UH-GnB"/>
-                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -310,6 +310,7 @@
                                     <constraint firstAttribute="trailing" secondItem="Oqd-oU-SiR" secondAttribute="trailing" id="Axf-YK-4cr"/>
                                     <constraint firstItem="Oqd-oU-SiR" firstAttribute="width" secondItem="a6Y-Pe-Mec" secondAttribute="width" id="JhF-lW-LQS"/>
                                     <constraint firstItem="Oqd-oU-SiR" firstAttribute="leading" secondItem="a6Y-Pe-Mec" secondAttribute="leading" id="RNk-vH-hRp"/>
+                                    <constraint firstItem="U6f-6h-USM" firstAttribute="width" secondItem="7Cm-Yz-kTK" secondAttribute="width" multiplier="0.4" id="yhj-KC-TTp"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="2aY-cc-Dz2"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="7Cm-Yz-kTK"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3g0-y9-iKk" userLabel="Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="376"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="365"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7qN-Hg-b0n">
                                                 <rect key="frame" x="15" y="19.999999999999996" width="363" height="33.666666666666657"/>
@@ -32,14 +32,26 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="240" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="KY1-z0-bEJ">
                                                 <rect key="frame" x="76" y="73.666666666666671" width="241" height="100.00000000000001"/>
                                             </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gzY-ke-7EF">
+                                                <rect key="frame" x="176" y="183.66666666666666" width="41.333333333333343" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fjy-oX-M1K">
+                                                <rect key="frame" x="176" y="244.33333333333334" width="41.333333333333343" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3u4-nM-V6p">
-                                                <rect key="frame" x="15" y="285.66666666666669" width="363" height="20.333333333333314"/>
+                                                <rect key="frame" x="15" y="274.66666666666669" width="363" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="NnT-H9-F62">
-                                                <rect key="frame" x="56.666666666666657" y="316" width="280" height="50"/>
+                                                <rect key="frame" x="56.666666666666657" y="305" width="280" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="rQt-TA-Yqx">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -67,82 +79,37 @@
                                                     <constraint firstItem="uGg-de-mjI" firstAttribute="leading" secondItem="NnT-H9-F62" secondAttribute="leading" constant="50" id="uxw-Xm-4Tm"/>
                                                 </constraints>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="mWQ-J8-VBn">
-                                                <rect key="frame" x="152" y="183.66666666666666" width="89.333333333333314" height="24"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="justified" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sEH-Ui-AgH">
-                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gzY-ke-7EF">
-                                                        <rect key="frame" x="48" y="0.0" width="41.333333333333343" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="wTp-yf-jTv">
-                                                <rect key="frame" x="152" y="217.66666666666666" width="89.333333333333314" height="24"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="justified" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bnJ-BI-xvg">
-                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ocm-DF-zfz">
-                                                        <rect key="frame" x="48" y="0.0" width="41.333333333333343" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="7wV-pm-rbD">
-                                                <rect key="frame" x="152" y="251.66666666666663" width="89.333333333333314" height="24"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="justified" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" showsExpansionTextWhenTruncated="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg7-uZ-j3v">
-                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fjy-oX-M1K">
-                                                        <rect key="frame" x="48" y="0.0" width="41.333333333333343" height="24"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ocm-DF-zfz">
+                                                <rect key="frame" x="176" y="214" width="41.333333333333343" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="KY1-z0-bEJ" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="4t2-RM-vmr"/>
-                                            <constraint firstItem="7wV-pm-rbD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="10" id="APJ-U9-Qwz"/>
-                                            <constraint firstItem="mWQ-J8-VBn" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="COh-Lv-Fjl"/>
+                                            <constraint firstItem="gzY-ke-7EF" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="6ys-sI-OTG"/>
+                                            <constraint firstItem="fjy-oX-M1K" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="15" id="AVI-LY-nhh"/>
+                                            <constraint firstItem="fjy-oX-M1K" firstAttribute="top" secondItem="Ocm-DF-zfz" secondAttribute="bottom" constant="10" id="Eih-Bw-hrA"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="Ga8-xB-SkO"/>
-                                            <constraint firstItem="wTp-yf-jTv" firstAttribute="top" secondItem="mWQ-J8-VBn" secondAttribute="bottom" constant="10" id="NVn-gf-HVf"/>
+                                            <constraint firstItem="gzY-ke-7EF" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="15" id="J8L-cc-cfj"/>
                                             <constraint firstItem="NnT-H9-F62" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="PyQ-90-nsK"/>
-                                            <constraint firstItem="wTp-yf-jTv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="10" id="Vws-ED-4Qj"/>
+                                            <constraint firstItem="3u4-nM-V6p" firstAttribute="top" secondItem="fjy-oX-M1K" secondAttribute="bottom" constant="10" id="XU6-Dq-2XD"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="top" secondItem="3g0-y9-iKk" secondAttribute="top" constant="20" id="Y5g-Di-Cz4"/>
                                             <constraint firstItem="KY1-z0-bEJ" firstAttribute="leading" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="76" id="ZgI-yJ-Fh8"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="ac7-QX-8EU"/>
                                             <constraint firstAttribute="bottom" secondItem="NnT-H9-F62" secondAttribute="bottom" constant="10" id="aja-GX-C28"/>
-                                            <constraint firstItem="mWQ-J8-VBn" firstAttribute="top" secondItem="KY1-z0-bEJ" secondAttribute="bottom" constant="10" id="b4A-2d-h3Z"/>
-                                            <constraint firstItem="wTp-yf-jTv" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="dxw-9d-7rO"/>
+                                            <constraint firstItem="gzY-ke-7EF" firstAttribute="top" secondItem="KY1-z0-bEJ" secondAttribute="bottom" constant="10" id="hcG-9e-O5s"/>
                                             <constraint firstItem="KY1-z0-bEJ" firstAttribute="top" secondItem="7qN-Hg-b0n" secondAttribute="bottom" constant="20" id="k9f-Lm-VP4"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="leading" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="15" id="mMk-cY-hXW"/>
-                                            <constraint firstItem="7wV-pm-rbD" firstAttribute="top" secondItem="wTp-yf-jTv" secondAttribute="bottom" constant="10" id="n5a-kM-vLd"/>
+                                            <constraint firstItem="Ocm-DF-zfz" firstAttribute="top" secondItem="gzY-ke-7EF" secondAttribute="bottom" constant="10" id="mqP-fx-BB5"/>
                                             <constraint firstItem="NnT-H9-F62" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leadingMargin" constant="10" id="q3f-pB-Iff"/>
-                                            <constraint firstItem="7wV-pm-rbD" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="rAp-eC-BcG"/>
-                                            <constraint firstItem="3u4-nM-V6p" firstAttribute="top" secondItem="7wV-pm-rbD" secondAttribute="bottom" constant="10" id="tGU-zc-uAe"/>
+                                            <constraint firstItem="fjy-oX-M1K" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="rmH-9g-kWv"/>
+                                            <constraint firstItem="Ocm-DF-zfz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="15" id="tMU-gc-lRe"/>
                                             <constraint firstItem="3u4-nM-V6p" firstAttribute="leading" secondItem="7qN-Hg-b0n" secondAttribute="leading" id="uYs-IO-eyZ"/>
+                                            <constraint firstItem="Ocm-DF-zfz" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="vyU-bH-Qr9"/>
                                             <constraint firstItem="3u4-nM-V6p" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="xik-KX-xXf"/>
-                                            <constraint firstItem="mWQ-J8-VBn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="10" id="xt8-Xt-GjD"/>
                                             <constraint firstItem="NnT-H9-F62" firstAttribute="top" secondItem="3u4-nM-V6p" secondAttribute="bottom" constant="10" id="yF6-lS-Z5v"/>
                                         </constraints>
                                     </view>
@@ -171,21 +138,18 @@
                     <connections>
                         <outlet property="descriptionLabel" destination="3u4-nM-V6p" id="gDq-Vw-qVW"/>
                         <outlet property="durationLabel" destination="fjy-oX-M1K" id="fQQ-Zi-Kl8"/>
-                        <outlet property="durationSubtitileLabel" destination="Lg7-uZ-j3v" id="jY9-3e-mjS"/>
                         <outlet property="goButton" destination="uGg-de-mjI" id="P32-d3-ItY"/>
                         <outlet property="locationLabel" destination="Ocm-DF-zfz" id="axA-lX-6YJ"/>
-                        <outlet property="locationSubtitleLabel" destination="bnJ-BI-xvg" id="M89-uC-nSr"/>
                         <outlet property="numberOfVisitorsLabel" destination="gzY-ke-7EF" id="yiC-19-72G"/>
                         <outlet property="posterImageView" destination="KY1-z0-bEJ" id="71s-NM-orz"/>
                         <outlet property="titleLabel" destination="7qN-Hg-b0n" id="tax-yY-7Tf"/>
-                        <outlet property="visitorSubtitleLabel" destination="sEH-Ui-AgH" id="Rv4-Rh-wgC"/>
                         <outletCollection property="flagImageViews" destination="Oj9-eg-5Wm" collectionClass="NSMutableArray" id="SPG-ON-hPy"/>
                         <outletCollection property="flagImageViews" destination="rQt-TA-Yqx" collectionClass="NSMutableArray" id="Duf-Ek-Z4k"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2805.3435114503814" y="-35.211267605633807"/>
+            <point key="canvasLocation" x="2803.8167938931297" y="-35.211267605633807"/>
         </scene>
         <!--Item Entry View Controller-->
         <scene sceneID="Pth-eF-zaB">

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -242,19 +242,16 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oqd-oU-SiR" userLabel="Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="197.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="420"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="BRU-hU-B5y">
-                                                <rect key="frame" x="16" y="10" width="361" height="177.66666666666666"/>
+                                                <rect key="frame" x="16" y="10" width="361" height="400"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="U6f-6h-USM">
-                                                        <rect key="frame" x="102" y="0.0" width="157" height="157.33333333333334"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" secondItem="U6f-6h-USM" secondAttribute="height" multiplier="1:1" id="ibX-3o-YHr"/>
-                                                        </constraints>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="275" placeholderIntrinsicHeight="379.66666666666669" translatesAutoresizingMaskIntoConstraints="NO" id="U6f-6h-USM">
+                                                        <rect key="frame" x="43" y="0.0" width="275" height="379.66666666666669"/>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qBR-Yi-pWa">
-                                                        <rect key="frame" x="160" y="157.33333333333334" width="41.333333333333343" height="20.333333333333343"/>
+                                                        <rect key="frame" x="160" y="379.66666666666669" width="41.333333333333343" height="20.333333333333314"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -277,7 +274,8 @@
                                     <constraint firstAttribute="trailing" secondItem="Oqd-oU-SiR" secondAttribute="trailing" id="Axf-YK-4cr"/>
                                     <constraint firstItem="Oqd-oU-SiR" firstAttribute="width" secondItem="a6Y-Pe-Mec" secondAttribute="width" id="JhF-lW-LQS"/>
                                     <constraint firstItem="Oqd-oU-SiR" firstAttribute="leading" secondItem="a6Y-Pe-Mec" secondAttribute="leading" id="RNk-vH-hRp"/>
-                                    <constraint firstItem="U6f-6h-USM" firstAttribute="width" secondItem="7Cm-Yz-kTK" secondAttribute="width" multiplier="0.4" id="yhj-KC-TTp"/>
+                                    <constraint firstItem="U6f-6h-USM" firstAttribute="height" relation="lessThanOrEqual" secondItem="7Cm-Yz-kTK" secondAttribute="height" multiplier="0.5" id="bp9-Xh-aHd"/>
+                                    <constraint firstItem="U6f-6h-USM" firstAttribute="width" relation="lessThanOrEqual" secondItem="7Cm-Yz-kTK" secondAttribute="width" multiplier="0.7" id="yhj-KC-TTp"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="2aY-cc-Dz2"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="7Cm-Yz-kTK"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -197,32 +197,32 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="redraw" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="customCell" id="usu-Ao-8oo" customClass="CustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="50" width="393" height="122.33333587646484"/>
+                                <rect key="frame" x="0.0" y="50" width="393" height="90.333335876464844"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="usu-Ao-8oo" id="YAC-3K-AnH">
-                                    <rect key="frame" x="0.0" y="0.0" width="393" height="122.33333587646484"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="90.333335876464844"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="g6x-3J-I7j">
-                                            <rect key="frame" x="20" y="10" width="363" height="102.33333333333333"/>
+                                            <rect key="frame" x="20" y="10" width="363" height="70.333333333333329"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="Hzm-jt-80o">
-                                                    <rect key="frame" x="0.0" y="16.333333333333329" width="70" height="70"/>
+                                                    <rect key="frame" x="0.0" y="0.3333333333333357" width="70" height="70"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="Hzm-jt-80o" secondAttribute="height" multiplier="1:1" id="8gI-S2-z9e"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleAspectFit" verticalHuggingPriority="300" verticalCompressionResistancePriority="1000" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="eC6-bN-b01">
-                                                    <rect key="frame" x="80" y="0.3333333333333357" width="283" height="102"/>
+                                                    <rect key="frame" x="80" y="8.3333333333333286" width="283" height="54"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dfdfdsfdsfsdfsdfsdfs" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="if3-3g-AnI">
-                                                            <rect key="frame" x="0.0" y="0.0" width="283" height="81.666666666666671"/>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dfdfdsfdsfsdf" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="if3-3g-AnI">
+                                                            <rect key="frame" x="0.0" y="0.0" width="283" height="33.666666666666664"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4v-ns-1S8">
-                                                            <rect key="frame" x="0.0" y="81.666666666666671" width="283" height="20.333333333333329"/>
+                                                            <rect key="frame" x="0.0" y="33.666666666666671" width="283" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -231,7 +231,6 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="Hzm-jt-80o" firstAttribute="centerY" secondItem="eC6-bN-b01" secondAttribute="centerY" id="0HL-bW-YOS"/>
                                                 <constraint firstItem="eC6-bN-b01" firstAttribute="leading" secondItem="g6x-3J-I7j" secondAttribute="leading" constant="80" id="ygw-Yf-dV7"/>
                                             </constraints>
                                         </stackView>
@@ -276,30 +275,32 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Oqd-oU-SiR" userLabel="Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="348.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="190.33333333333334"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="240" placeholderIntrinsicHeight="128" translatesAutoresizingMaskIntoConstraints="NO" id="U6f-6h-USM">
-                                                <rect key="frame" x="50" y="15" width="293" height="293"/>
+                                            <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="BRU-hU-B5y">
+                                                <rect key="frame" x="16" y="10" width="361" height="170.33333333333334"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="U6f-6h-USM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="361" height="150"/>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qBR-Yi-pWa">
+                                                        <rect key="frame" x="160" y="150" width="41.333333333333343" height="20.333333333333343"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" secondItem="U6f-6h-USM" secondAttribute="height" multiplier="1:1" id="hzL-mp-a6E"/>
+                                                    <constraint firstItem="qBR-Yi-pWa" firstAttribute="top" secondItem="BRU-hU-B5y" secondAttribute="top" constant="150" id="SwL-UH-GnB"/>
                                                 </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qBR-Yi-pWa">
-                                                <rect key="frame" x="20" y="318" width="353" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstItem="qBR-Yi-pWa" firstAttribute="top" secondItem="U6f-6h-USM" secondAttribute="bottom" constant="10" id="Oa3-LW-ec9"/>
-                                            <constraint firstItem="U6f-6h-USM" firstAttribute="top" secondItem="Oqd-oU-SiR" secondAttribute="top" constant="15" id="VIQ-Q3-aPU"/>
-                                            <constraint firstItem="qBR-Yi-pWa" firstAttribute="leading" secondItem="Oqd-oU-SiR" secondAttribute="leading" constant="20" id="VL7-WW-gYz"/>
-                                            <constraint firstItem="U6f-6h-USM" firstAttribute="leading" secondItem="Oqd-oU-SiR" secondAttribute="leading" constant="50" id="g0j-sL-TW8"/>
-                                            <constraint firstItem="U6f-6h-USM" firstAttribute="centerX" secondItem="Oqd-oU-SiR" secondAttribute="centerX" id="hQw-Z5-sfg"/>
-                                            <constraint firstItem="qBR-Yi-pWa" firstAttribute="centerX" secondItem="Oqd-oU-SiR" secondAttribute="centerX" id="owL-ul-CtD"/>
-                                            <constraint firstAttribute="bottom" secondItem="qBR-Yi-pWa" secondAttribute="bottom" constant="10" id="xRM-pl-CLm"/>
+                                            <constraint firstItem="BRU-hU-B5y" firstAttribute="leading" secondItem="Oqd-oU-SiR" secondAttribute="leading" constant="16" id="EoL-qb-N9T"/>
+                                            <constraint firstItem="BRU-hU-B5y" firstAttribute="top" secondItem="Oqd-oU-SiR" secondAttribute="top" constant="10" id="NVU-R3-d7c"/>
+                                            <constraint firstItem="BRU-hU-B5y" firstAttribute="centerX" secondItem="Oqd-oU-SiR" secondAttribute="centerX" id="cAr-3j-Km1"/>
+                                            <constraint firstAttribute="bottom" secondItem="BRU-hU-B5y" secondAttribute="bottom" constant="10" id="tFY-8j-IpK"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -326,7 +327,7 @@
                     <connections>
                         <outlet property="DescriptionScrollView" destination="a6Y-Pe-Mec" id="nj5-5p-dkr"/>
                         <outlet property="descriptionLabel" destination="qBR-Yi-pWa" id="0vM-wa-jSo"/>
-                        <outlet property="itemImage" destination="U6f-6h-USM" id="DtP-NK-so5"/>
+                        <outlet property="itemImageView" destination="U6f-6h-USM" id="DtP-NK-so5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nRL-Aj-tCQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -210,6 +210,9 @@
                                     <outlet property="itemImageView" destination="Hzm-jt-80o" id="Bzt-qK-RVr"/>
                                     <outlet property="itemNameLabel" destination="if3-3g-AnI" id="1E5-g1-33p"/>
                                     <outlet property="shortDescriptionLabel" destination="W4v-ns-1S8" id="FNe-kD-UPo"/>
+                                    <outletCollection property="contents" destination="if3-3g-AnI" collectionClass="NSMutableArray" id="eIF-au-cso"/>
+                                    <outletCollection property="contents" destination="W4v-ns-1S8" collectionClass="NSMutableArray" id="gEz-qJ-fls"/>
+                                    <outletCollection property="contents" destination="Hzm-jt-80o" collectionClass="NSMutableArray" id="fAe-9D-F7a"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -21,43 +21,25 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3g0-y9-iKk" userLabel="Contents View">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="361.66666666666669"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="376"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7qN-Hg-b0n">
-                                                <rect key="frame" x="15" y="20" width="363" height="30.333333333333329"/>
-                                                <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="26"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7qN-Hg-b0n">
+                                                <rect key="frame" x="15" y="19.999999999999996" width="363" height="33.666666666666657"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="240" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="KY1-z0-bEJ">
-                                                <rect key="frame" x="76" y="70.333333333333329" width="240" height="99.999999999999986"/>
+                                                <rect key="frame" x="76" y="73.666666666666671" width="241" height="100.00000000000001"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bnJ-BI-xvg">
-                                                <rect key="frame" x="15" y="180.33333333333334" width="363" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sEH-Ui-AgH">
-                                                <rect key="frame" x="15" y="210.66666666666666" width="363" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg7-uZ-j3v">
-                                                <rect key="frame" x="15" y="241" width="363" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3u4-nM-V6p">
-                                                <rect key="frame" x="15" y="271.33333333333331" width="363" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3u4-nM-V6p">
+                                                <rect key="frame" x="15" y="285.66666666666669" width="363" height="20.333333333333314"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="NnT-H9-F62">
-                                                <rect key="frame" x="48" y="301.66666666666669" width="297" height="50"/>
+                                                <rect key="frame" x="56.666666666666657" y="316" width="280" height="50"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="rQt-TA-Yqx">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
@@ -66,7 +48,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uGg-de-mjI">
-                                                        <rect key="frame" x="50" y="8" width="197" height="34.333333333333336"/>
+                                                        <rect key="frame" x="50" y="8" width="180" height="34.333333333333336"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
@@ -74,37 +56,93 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="Oj9-eg-5Wm">
-                                                        <rect key="frame" x="247" y="0.0" width="50" height="50"/>
+                                                        <rect key="frame" x="230.00000000000003" y="0.0" width="49.999999999999972" height="50"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="Oj9-eg-5Wm" secondAttribute="height" multiplier="1:1" id="Gru-sl-d2d"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="Oj9-eg-5Wm" firstAttribute="width" secondItem="rQt-TA-Yqx" secondAttribute="width" id="PrC-xl-cj2"/>
+                                                    <constraint firstItem="uGg-de-mjI" firstAttribute="leading" secondItem="NnT-H9-F62" secondAttribute="leading" constant="50" id="uxw-Xm-4Tm"/>
+                                                </constraints>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="mWQ-J8-VBn">
+                                                <rect key="frame" x="152" y="183.66666666666666" width="89.333333333333314" height="24"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="justified" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sEH-Ui-AgH">
+                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gzY-ke-7EF">
+                                                        <rect key="frame" x="48" y="0.0" width="41.333333333333343" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="wTp-yf-jTv">
+                                                <rect key="frame" x="152" y="217.66666666666666" width="89.333333333333314" height="24"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="justified" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bnJ-BI-xvg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ocm-DF-zfz">
+                                                        <rect key="frame" x="48" y="0.0" width="41.333333333333343" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleAspectFit" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="7wV-pm-rbD">
+                                                <rect key="frame" x="152" y="251.66666666666663" width="89.333333333333314" height="24"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Label" textAlignment="justified" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" showsExpansionTextWhenTruncated="YES" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lg7-uZ-j3v">
+                                                        <rect key="frame" x="0.0" y="0.0" width="48" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fjy-oX-M1K">
+                                                        <rect key="frame" x="48" y="0.0" width="41.333333333333343" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
                                             </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstItem="3u4-nM-V6p" firstAttribute="top" secondItem="Lg7-uZ-j3v" secondAttribute="bottom" constant="10" id="14Q-HS-92f"/>
+                                            <constraint firstItem="KY1-z0-bEJ" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="4t2-RM-vmr"/>
+                                            <constraint firstItem="7wV-pm-rbD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="10" id="APJ-U9-Qwz"/>
+                                            <constraint firstItem="mWQ-J8-VBn" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="COh-Lv-Fjl"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="Ga8-xB-SkO"/>
-                                            <constraint firstItem="Lg7-uZ-j3v" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="HvE-w8-HQi"/>
-                                            <constraint firstItem="sEH-Ui-AgH" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="IWI-Pp-gpr"/>
-                                            <constraint firstAttribute="trailing" secondItem="KY1-z0-bEJ" secondAttribute="trailing" constant="77" id="Nw4-oN-SZ2"/>
-                                            <constraint firstItem="Lg7-uZ-j3v" firstAttribute="leading" secondItem="7qN-Hg-b0n" secondAttribute="leading" id="P9s-LR-5Q5"/>
-                                            <constraint firstItem="Lg7-uZ-j3v" firstAttribute="top" secondItem="sEH-Ui-AgH" secondAttribute="bottom" constant="10" id="Pc6-S1-2n4"/>
+                                            <constraint firstItem="wTp-yf-jTv" firstAttribute="top" secondItem="mWQ-J8-VBn" secondAttribute="bottom" constant="10" id="NVn-gf-HVf"/>
                                             <constraint firstItem="NnT-H9-F62" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="PyQ-90-nsK"/>
+                                            <constraint firstItem="wTp-yf-jTv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="10" id="Vws-ED-4Qj"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="top" secondItem="3g0-y9-iKk" secondAttribute="top" constant="20" id="Y5g-Di-Cz4"/>
                                             <constraint firstItem="KY1-z0-bEJ" firstAttribute="leading" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="76" id="ZgI-yJ-Fh8"/>
-                                            <constraint firstItem="sEH-Ui-AgH" firstAttribute="leading" secondItem="7qN-Hg-b0n" secondAttribute="leading" id="abN-3d-7PQ"/>
+                                            <constraint firstItem="7qN-Hg-b0n" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="ac7-QX-8EU"/>
                                             <constraint firstAttribute="bottom" secondItem="NnT-H9-F62" secondAttribute="bottom" constant="10" id="aja-GX-C28"/>
-                                            <constraint firstItem="sEH-Ui-AgH" firstAttribute="top" secondItem="bnJ-BI-xvg" secondAttribute="bottom" constant="10" id="b93-U1-4Bo"/>
-                                            <constraint firstItem="bnJ-BI-xvg" firstAttribute="leading" secondItem="7qN-Hg-b0n" secondAttribute="leading" id="eGi-1x-VsB"/>
-                                            <constraint firstItem="bnJ-BI-xvg" firstAttribute="top" secondItem="KY1-z0-bEJ" secondAttribute="bottom" constant="10" id="iSb-j9-Ll0"/>
+                                            <constraint firstItem="mWQ-J8-VBn" firstAttribute="top" secondItem="KY1-z0-bEJ" secondAttribute="bottom" constant="10" id="b4A-2d-h3Z"/>
+                                            <constraint firstItem="wTp-yf-jTv" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="dxw-9d-7rO"/>
                                             <constraint firstItem="KY1-z0-bEJ" firstAttribute="top" secondItem="7qN-Hg-b0n" secondAttribute="bottom" constant="20" id="k9f-Lm-VP4"/>
                                             <constraint firstItem="7qN-Hg-b0n" firstAttribute="leading" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="15" id="mMk-cY-hXW"/>
-                                            <constraint firstItem="NnT-H9-F62" firstAttribute="leading" secondItem="3g0-y9-iKk" secondAttribute="leadingMargin" constant="40" id="q3f-pB-Iff"/>
+                                            <constraint firstItem="7wV-pm-rbD" firstAttribute="top" secondItem="wTp-yf-jTv" secondAttribute="bottom" constant="10" id="n5a-kM-vLd"/>
+                                            <constraint firstItem="NnT-H9-F62" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leadingMargin" constant="10" id="q3f-pB-Iff"/>
+                                            <constraint firstItem="7wV-pm-rbD" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="rAp-eC-BcG"/>
+                                            <constraint firstItem="3u4-nM-V6p" firstAttribute="top" secondItem="7wV-pm-rbD" secondAttribute="bottom" constant="10" id="tGU-zc-uAe"/>
                                             <constraint firstItem="3u4-nM-V6p" firstAttribute="leading" secondItem="7qN-Hg-b0n" secondAttribute="leading" id="uYs-IO-eyZ"/>
-                                            <constraint firstItem="bnJ-BI-xvg" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="vxu-tc-PK9"/>
                                             <constraint firstItem="3u4-nM-V6p" firstAttribute="centerX" secondItem="3g0-y9-iKk" secondAttribute="centerX" id="xik-KX-xXf"/>
+                                            <constraint firstItem="mWQ-J8-VBn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3g0-y9-iKk" secondAttribute="leading" constant="10" id="xt8-Xt-GjD"/>
                                             <constraint firstItem="NnT-H9-F62" firstAttribute="top" secondItem="3u4-nM-V6p" secondAttribute="bottom" constant="10" id="yF6-lS-Z5v"/>
                                         </constraints>
                                     </view>
@@ -131,13 +169,16 @@
                     </view>
                     <navigationItem key="navigationItem" id="AH6-Q6-6YN"/>
                     <connections>
-                        <outlet property="descriptionLabel" destination="3u4-nM-V6p" id="iux-uY-VC2"/>
-                        <outlet property="durationLabel" destination="Lg7-uZ-j3v" id="tyY-4U-MFk"/>
+                        <outlet property="descriptionLabel" destination="3u4-nM-V6p" id="gDq-Vw-qVW"/>
+                        <outlet property="durationLabel" destination="fjy-oX-M1K" id="fQQ-Zi-Kl8"/>
+                        <outlet property="durationSubtitileLabel" destination="Lg7-uZ-j3v" id="jY9-3e-mjS"/>
                         <outlet property="goButton" destination="uGg-de-mjI" id="P32-d3-ItY"/>
-                        <outlet property="locationLabel" destination="sEH-Ui-AgH" id="dOz-AC-zqd"/>
-                        <outlet property="numberOfVisitorLabel" destination="bnJ-BI-xvg" id="PE2-TW-SL5"/>
+                        <outlet property="locationLabel" destination="Ocm-DF-zfz" id="axA-lX-6YJ"/>
+                        <outlet property="locationSubtitleLabel" destination="bnJ-BI-xvg" id="M89-uC-nSr"/>
+                        <outlet property="numberOfVisitorsLabel" destination="gzY-ke-7EF" id="yiC-19-72G"/>
                         <outlet property="posterImageView" destination="KY1-z0-bEJ" id="71s-NM-orz"/>
                         <outlet property="titleLabel" destination="7qN-Hg-b0n" id="tax-yY-7Tf"/>
+                        <outlet property="visitorSubtitleLabel" destination="sEH-Ui-AgH" id="Rv4-Rh-wgC"/>
                         <outletCollection property="flagImageViews" destination="Oj9-eg-5Wm" collectionClass="NSMutableArray" id="SPG-ON-hPy"/>
                         <outletCollection property="flagImageViews" destination="rQt-TA-Yqx" collectionClass="NSMutableArray" id="Duf-Ek-Z4k"/>
                     </connections>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -197,32 +197,32 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="redraw" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="customCell" id="usu-Ao-8oo" customClass="CustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="50" width="393" height="90.333335876464844"/>
+                                <rect key="frame" x="0.0" y="50" width="393" height="93"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="usu-Ao-8oo" id="YAC-3K-AnH">
-                                    <rect key="frame" x="0.0" y="0.0" width="393" height="90.333335876464844"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="93"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="g6x-3J-I7j">
-                                            <rect key="frame" x="20" y="10" width="363" height="70.333333333333329"/>
+                                            <rect key="frame" x="20" y="10" width="363" height="73"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="Hzm-jt-80o">
-                                                    <rect key="frame" x="0.0" y="0.3333333333333357" width="70" height="70"/>
+                                                    <rect key="frame" x="0.0" y="0.3333333333333357" width="72.666666666666671" height="72.333333333333314"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" secondItem="Hzm-jt-80o" secondAttribute="height" multiplier="1:1" id="8gI-S2-z9e"/>
                                                     </constraints>
                                                 </imageView>
                                                 <stackView opaque="NO" contentMode="scaleAspectFit" verticalHuggingPriority="300" verticalCompressionResistancePriority="1000" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="eC6-bN-b01">
-                                                    <rect key="frame" x="80" y="8.3333333333333286" width="283" height="54"/>
+                                                    <rect key="frame" x="82.666666666666657" y="9.6666666666666714" width="280.33333333333337" height="54"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dfdfdsfdsfsdf" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="if3-3g-AnI">
-                                                            <rect key="frame" x="0.0" y="0.0" width="283" height="33.666666666666664"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="280.33333333333331" height="33.666666666666664"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4v-ns-1S8">
-                                                            <rect key="frame" x="0.0" y="33.666666666666671" width="283" height="20.333333333333329"/>
+                                                            <rect key="frame" x="0.0" y="33.666666666666671" width="280.33333333333331" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -231,7 +231,7 @@
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="eC6-bN-b01" firstAttribute="leading" secondItem="g6x-3J-I7j" secondAttribute="leading" constant="80" id="ygw-Yf-dV7"/>
+                                                <constraint firstItem="Hzm-jt-80o" firstAttribute="width" secondItem="g6x-3J-I7j" secondAttribute="width" multiplier="0.2" id="ZW6-RK-Uov"/>
                                             </constraints>
                                         </stackView>
                                     </subviews>

--- a/Expo1900/Expo1900/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/Base.lproj/Main.storyboard
@@ -197,51 +197,50 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="redraw" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="customCell" id="usu-Ao-8oo" customClass="CustomTableViewCell" customModule="Expo1900" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="50" width="393" height="120.33333587646484"/>
+                                <rect key="frame" x="0.0" y="50" width="393" height="122.33333587646484"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="usu-Ao-8oo" id="YAC-3K-AnH">
-                                    <rect key="frame" x="0.0" y="0.0" width="393" height="120.33333587646484"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="122.33333587646484"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="Hzm-jt-80o">
-                                            <rect key="frame" x="10" y="10" width="100" height="100.33333333333333"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" secondItem="Hzm-jt-80o" secondAttribute="height" multiplier="1:1" id="gd6-6C-VdM"/>
-                                            </constraints>
-                                        </imageView>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="eC6-bN-b01">
-                                            <rect key="frame" x="120" y="10" width="263" height="100.33333333333333"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="g6x-3J-I7j">
+                                            <rect key="frame" x="20" y="10" width="363" height="102.33333333333333"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dfdfdsfdsfsdfsdfsdfs" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="if3-3g-AnI">
-                                                    <rect key="frame" x="0.0" y="0.0" width="263" height="20.333333333333332"/>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="100" placeholderIntrinsicHeight="100" translatesAutoresizingMaskIntoConstraints="NO" id="Hzm-jt-80o">
+                                                    <rect key="frame" x="0.0" y="16.333333333333329" width="70" height="70"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="20.333333333333332" id="ZaB-OK-EHd"/>
+                                                        <constraint firstAttribute="width" secondItem="Hzm-jt-80o" secondAttribute="height" multiplier="1:1" id="8gI-S2-z9e"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4v-ns-1S8">
-                                                    <rect key="frame" x="0.0" y="25.333333333333336" width="263" height="75"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleAspectFit" verticalHuggingPriority="300" verticalCompressionResistancePriority="1000" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="eC6-bN-b01">
+                                                    <rect key="frame" x="80" y="0.3333333333333357" width="283" height="102"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="dfdfdsfdsfsdfsdfsdfs" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="if3-3g-AnI">
+                                                            <rect key="frame" x="0.0" y="0.0" width="283" height="81.666666666666671"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4v-ns-1S8">
+                                                            <rect key="frame" x="0.0" y="81.666666666666671" width="283" height="20.333333333333329"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="W4v-ns-1S8" firstAttribute="top" secondItem="if3-3g-AnI" secondAttribute="bottom" constant="5" id="RuL-oH-4UW"/>
+                                                <constraint firstItem="Hzm-jt-80o" firstAttribute="centerY" secondItem="eC6-bN-b01" secondAttribute="centerY" id="0HL-bW-YOS"/>
+                                                <constraint firstItem="eC6-bN-b01" firstAttribute="leading" secondItem="g6x-3J-I7j" secondAttribute="leading" constant="80" id="ygw-Yf-dV7"/>
                                             </constraints>
                                         </stackView>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="Hzm-jt-80o" secondAttribute="bottom" constant="10" id="3sf-Ew-iom"/>
-                                        <constraint firstItem="eC6-bN-b01" firstAttribute="leading" secondItem="YAC-3K-AnH" secondAttribute="leading" constant="120" id="AIY-rK-Erg"/>
-                                        <constraint firstItem="Hzm-jt-80o" firstAttribute="top" secondItem="YAC-3K-AnH" secondAttribute="top" constant="10" id="CDt-o4-ArB"/>
-                                        <constraint firstAttribute="trailing" secondItem="eC6-bN-b01" secondAttribute="trailing" constant="10" id="GF3-Gk-04W"/>
-                                        <constraint firstItem="eC6-bN-b01" firstAttribute="top" secondItem="YAC-3K-AnH" secondAttribute="top" constant="10" id="Ok3-u6-5gr"/>
-                                        <constraint firstItem="eC6-bN-b01" firstAttribute="leading" secondItem="Hzm-jt-80o" secondAttribute="trailing" constant="10" id="bhG-dg-SPy"/>
-                                        <constraint firstAttribute="bottom" secondItem="eC6-bN-b01" secondAttribute="bottom" constant="10" id="bs6-zP-NKJ"/>
-                                        <constraint firstItem="Hzm-jt-80o" firstAttribute="leading" secondItem="YAC-3K-AnH" secondAttribute="leading" constant="10" id="j7B-iu-7BV"/>
+                                        <constraint firstItem="g6x-3J-I7j" firstAttribute="top" secondItem="YAC-3K-AnH" secondAttribute="top" constant="10" id="78D-WQ-xgs"/>
+                                        <constraint firstAttribute="bottom" secondItem="g6x-3J-I7j" secondAttribute="bottom" constant="10" id="ARJ-Lu-9hi"/>
+                                        <constraint firstAttribute="trailing" secondItem="g6x-3J-I7j" secondAttribute="trailing" constant="10" id="dwK-ZS-CqW"/>
+                                        <constraint firstItem="g6x-3J-I7j" firstAttribute="leading" secondItem="YAC-3K-AnH" secondAttribute="leading" constant="20" id="lGu-Bs-Ptf"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>

--- a/Expo1900/Expo1900/CustomTableViewCell.swift
+++ b/Expo1900/Expo1900/CustomTableViewCell.swift
@@ -11,23 +11,4 @@ final class CustomTableViewCell: UITableViewCell {
     @IBOutlet weak var itemNameLabel: UILabel!
     @IBOutlet weak var shortDescriptionLabel: UILabel!
     @IBOutlet weak var itemImageView: UIImageView!
-    
-    func setAccessibilityProperties(itemName: String, shortDescription: String) {
-        self.itemNameLabel.accessibilityLabel = itemName
-        
-        self.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
-        self.shortDescriptionLabel.accessibilityValue = shortDescription
-        
-        self.itemImageView.isAccessibilityElement = true
-        self.itemImageView.accessibilityLabel = itemName
-        self.itemImageView.accessibilityTraits = .image
-        self.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
-        
-        self.isAccessibilityElement = false
-        self.accessibilityElements = [
-            self.itemNameLabel!,
-            self.shortDescriptionLabel!,
-            self.itemImageView!
-        ]
-    }
 }

--- a/Expo1900/Expo1900/CustomTableViewCell.swift
+++ b/Expo1900/Expo1900/CustomTableViewCell.swift
@@ -2,7 +2,7 @@
 //  CustomTableViewCell.swift
 //  Expo1900
 //
-//  Created by jiye Yi on 2023/02/27.
+//  Created by 리지, Rowan on 2023/02/27.
 //
 
 import UIKit

--- a/Expo1900/Expo1900/CustomTableViewCell.swift
+++ b/Expo1900/Expo1900/CustomTableViewCell.swift
@@ -11,4 +11,23 @@ final class CustomTableViewCell: UITableViewCell {
     @IBOutlet weak var itemNameLabel: UILabel!
     @IBOutlet weak var shortDescriptionLabel: UILabel!
     @IBOutlet weak var itemImageView: UIImageView!
+    
+    func setAccessibilityProperties(itemName: String, shortDescription: String) {
+        self.itemNameLabel.accessibilityLabel = itemName
+        
+        self.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
+        self.shortDescriptionLabel.accessibilityValue = shortDescription
+        
+        self.itemImageView.isAccessibilityElement = true
+        self.itemImageView.accessibilityLabel = itemName
+        self.itemImageView.accessibilityTraits = .image
+        self.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
+        
+        self.isAccessibilityElement = false
+        self.accessibilityElements = [
+            self.itemNameLabel!,
+            self.shortDescriptionLabel!,
+            self.itemImageView!
+        ]
+    }
 }

--- a/Expo1900/Expo1900/CustomTableViewCell.swift
+++ b/Expo1900/Expo1900/CustomTableViewCell.swift
@@ -11,11 +11,48 @@ final class CustomTableViewCell: UITableViewCell {
     @IBOutlet weak var itemNameLabel: UILabel!
     @IBOutlet weak var shortDescriptionLabel: UILabel!
     @IBOutlet weak var itemImageView: UIImageView!
+    @IBOutlet var contents: [Any]!
     
-    func setContents(_ itemName: String, _ shortDescription: String, _ itemImage: UIImage?) {
+    var item: Item?
+    
+    func setContents() {
+        guard let item = self.item else { return }
+        let itemName = item.name
+        let shortDescription = item.shortDescription
+        let itemImage = UIImage(named: item.imageName)
+        
         self.itemNameLabel.text = itemName
         self.shortDescriptionLabel.text = shortDescription
         self.itemImageView.image = itemImage
         self.accessoryType = .disclosureIndicator
+    }
+    
+    func allocate(data: Item) {
+        self.item = data
+    }
+
+}
+
+extension CustomTableViewCell {
+    func setAccessibilityProperties() {
+        self.isAccessibilityElement = false
+        self.accessibilityElements = []
+        self.contents.forEach { self.accessibilityElements?.append($0) }
+        
+        setLabelAccessibility()
+        setImageViewAccessibility()
+    }
+    
+    private func setLabelAccessibility() {
+        self.itemNameLabel.accessibilityLabel = item?.name
+        self.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
+        self.shortDescriptionLabel.accessibilityValue = item?.shortDescription
+    }
+    
+    private func setImageViewAccessibility() {
+        self.itemImageView.isAccessibilityElement = true
+        self.itemImageView.accessibilityLabel = item?.name
+        self.itemImageView.accessibilityTraits = .image
+        self.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
     }
 }

--- a/Expo1900/Expo1900/CustomTableViewCell.swift
+++ b/Expo1900/Expo1900/CustomTableViewCell.swift
@@ -13,7 +13,7 @@ final class CustomTableViewCell: UITableViewCell {
     @IBOutlet weak var itemImageView: UIImageView!
     @IBOutlet var contents: [Any]!
     
-    var item: Item?
+    private var item: Item?
     
     func setContents() {
         guard let item = self.item else { return }

--- a/Expo1900/Expo1900/CustomTableViewCell.swift
+++ b/Expo1900/Expo1900/CustomTableViewCell.swift
@@ -11,4 +11,11 @@ final class CustomTableViewCell: UITableViewCell {
     @IBOutlet weak var itemNameLabel: UILabel!
     @IBOutlet weak var shortDescriptionLabel: UILabel!
     @IBOutlet weak var itemImageView: UIImageView!
+    
+    func setContents(_ itemName: String, _ shortDescription: String, _ itemImage: UIImage?) {
+        self.itemNameLabel.text = itemName
+        self.shortDescriptionLabel.text = shortDescription
+        self.itemImageView.image = itemImage
+        self.accessoryType = .disclosureIndicator
+    }
 }

--- a/Expo1900/Expo1900/ViewController/DecodeManager.swift
+++ b/Expo1900/Expo1900/ViewController/DecodeManager.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 enum DecodeManager {
-    static func decodeData<T: Decodable>(of name: String, type: T.Type) -> T? {
+    static func decodeData<T: Decodable>(of name: String) -> T? {
         let jsonDecoder = JSONDecoder()
         guard let dataAsset = NSDataAsset(name: name) else { return nil }
 
         do {
-            let result = try jsonDecoder.decode(type, from: dataAsset.data)
+            let result = try jsonDecoder.decode(T.self, from: dataAsset.data)
 
             return result
         } catch {

--- a/Expo1900/Expo1900/ViewController/DecodeManager.swift
+++ b/Expo1900/Expo1900/ViewController/DecodeManager.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 enum DecodeManager {
-    static func decodeData<T: Decodable>(of name: String, type: T.Type) -> T? {
+    static func decodeData<T: Decodable>(of name: String, returnType: T.Type) -> T? {
         let jsonDecoder = JSONDecoder()
         guard let dataAsset = NSDataAsset(name: name) else { return nil }
 
         do {
-            let result = try jsonDecoder.decode(type, from: dataAsset.data)
+            let result = try jsonDecoder.decode(returnType, from: dataAsset.data)
 
             return result
         } catch {

--- a/Expo1900/Expo1900/ViewController/DescriptionViewController.swift
+++ b/Expo1900/Expo1900/ViewController/DescriptionViewController.swift
@@ -12,7 +12,7 @@ final class DescriptionViewController: UIViewController {
     
     @IBOutlet private weak var DescriptionScrollView: UIScrollView!
     @IBOutlet private weak var descriptionLabel: UILabel!
-    @IBOutlet private weak var itemImage: UIImageView!
+    @IBOutlet private weak var itemImageView: UIImageView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,7 +27,7 @@ final class DescriptionViewController: UIViewController {
     
     private func setImageView() {
         guard let itemImage = UIImage(named: item.imageName) else { return }
-        self.itemImage.image = itemImage
+        self.itemImageView.image = itemImage
     }
     
     private func setLabel() {

--- a/Expo1900/Expo1900/ViewController/DescriptionViewController.swift
+++ b/Expo1900/Expo1900/ViewController/DescriptionViewController.swift
@@ -35,15 +35,6 @@ final class DescriptionViewController: UIViewController {
         self.descriptionLabel.text = item.description
     }
     
-    private func setAccessibilityProperties() {
-        self.itemImageView.isAccessibilityElement = true
-        self.itemImageView.accessibilityLabel = item.name
-        self.itemImageView.accessibilityTraits = .image
-        
-        self.descriptionLabel.accessibilityLabel = item.name + " 상세 설명"
-        self.descriptionLabel.accessibilityValue = item.description
-    }
-    
     init?(item: Item, coder: NSCoder) {
         self.item = item
         super.init(coder: coder)
@@ -51,5 +42,23 @@ final class DescriptionViewController: UIViewController {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension DescriptionViewController {
+    private func setAccessibilityProperties() {
+        setLabelAccessibility()
+        setImageViewAccessibility()
+    }
+    
+    private func setLabelAccessibility() {
+        self.descriptionLabel.accessibilityLabel = item.name + " 상세 설명"
+        self.descriptionLabel.accessibilityValue = item.description
+    }
+    
+    private func setImageViewAccessibility() {
+        self.itemImageView.isAccessibilityElement = true
+        self.itemImageView.accessibilityLabel = item.name
+        self.itemImageView.accessibilityTraits = .image
     }
 }

--- a/Expo1900/Expo1900/ViewController/DescriptionViewController.swift
+++ b/Expo1900/Expo1900/ViewController/DescriptionViewController.swift
@@ -16,9 +16,10 @@ final class DescriptionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setNavigationBar()
         setImageView()
         setLabel()
-        setNavigationBar()
+        setAccessibilityProperties()
     }
     
     private func setNavigationBar() {
@@ -32,6 +33,15 @@ final class DescriptionViewController: UIViewController {
     
     private func setLabel() {
         self.descriptionLabel.text = item.description
+    }
+    
+    private func setAccessibilityProperties() {
+        self.itemImageView.isAccessibilityElement = true
+        self.itemImageView.accessibilityLabel = item.name
+        self.itemImageView.accessibilityTraits = .image
+        
+        self.descriptionLabel.accessibilityLabel = item.name + " 상세 설명"
+        self.descriptionLabel.accessibilityValue = item.description
     }
     
     init?(item: Item, coder: NSCoder) {

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -71,11 +71,11 @@ final class ExpoViewController: UIViewController {
             from: expoData.numberOfVisitors
         ) else { return }
         
-        self.visitorSubtitleLabel.text = "방문객"
+        self.visitorSubtitleLabel.text = Subtitle.visitor
         self.numberOfVisitorsLabel.text = " : \(decimalVisitors) 명"
-        self.locationSubtitleLabel.text = "개최지"
+        self.locationSubtitleLabel.text = Subtitle.location
         self.locationLabel.text = " : \(expoData.location)"
-        self.durationSubtitileLabel.text = "개최 기간"
+        self.durationSubtitileLabel.text = Subtitle.duration
         self.durationLabel.text = " : \(expoData.duration)"
 
         self.titleLabel.text = expoData.title
@@ -103,6 +103,12 @@ final class ExpoViewController: UIViewController {
         static let expo = "exposition_universelle_1900"
         static let poster = "poster"
         static let flag = "flag"
+    }
+    
+    private enum Subtitle {
+        static let visitor = "방문객"
+        static let location = "개최지"
+        static let duration = "개최 기간"
     }
 }
 

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -115,13 +115,22 @@ final class ExpoViewController: UIViewController {
 
 extension ExpoViewController {
     private func setAccessibilityProperties() {
+        setLabelAccessibility()
+        setImageViewAccessibility()
+    }
+    
+    private func setLabelAccessibility() {
         self.titleLabel.accessibilityLabel = "파리 만국박람회 1900"
-        self.posterImageView.isAccessibilityElement = true
-        self.posterImageView.accessibilityLabel = "박람회 포스터"
-        self.posterImageView.accessibilityTraits = .image
         self.durationLabel.accessibilityLabel = "1900년 4월 14일부터 1900년 11월 12일까지"
         self.descriptionLabel.accessibilityLabel = "1900년 파리 만국박람회 설명"
         self.goButton.accessibilityHint = "한국의 출품작 화면으로 이동합니다."
+    }
+    
+    private func setImageViewAccessibility() {
+        self.posterImageView.isAccessibilityElement = true
+        self.posterImageView.accessibilityLabel = "박람회 포스터"
+        self.posterImageView.accessibilityTraits = .image
+        
         self.flagImageViews.forEach {
             $0.isAccessibilityElement = true
             $0.accessibilityTraits = .image

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -8,11 +8,8 @@ import UIKit
 
 final class ExpoViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var visitorSubtitleLabel: UILabel!
     @IBOutlet private weak var numberOfVisitorsLabel: UILabel!
-    @IBOutlet private weak var locationSubtitleLabel: UILabel!
     @IBOutlet private weak var locationLabel: UILabel!
-    @IBOutlet private weak var durationSubtitileLabel: UILabel!
     @IBOutlet private weak var durationLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private weak var posterImageView: UIImageView!
@@ -70,15 +67,36 @@ final class ExpoViewController: UIViewController {
             from: expoData.numberOfVisitors
         ) else { return }
         
-        self.visitorSubtitleLabel.text = Subtitle.visitor
-        self.numberOfVisitorsLabel.text = " : \(decimalVisitors) 명"
-        self.locationSubtitleLabel.text = Subtitle.location
-        self.locationLabel.text = " : \(expoData.location)"
-        self.durationSubtitileLabel.text = Subtitle.duration
-        self.durationLabel.text = " : \(expoData.duration)"
-        
         self.titleLabel.text = expoData.title
+        self.numberOfVisitorsLabel.text = String(format: LabelText.visitor, decimalVisitors)
+        self.locationLabel.text = String(format: LabelText.location, expoData.location)
+        self.durationLabel.text = String(format: LabelText.duration, expoData.duration)
+        
+        convertTextSize(of: numberOfVisitorsLabel)
+        convertTextSize(of: locationLabel)
+        convertTextSize(of: durationLabel)
+        
         self.descriptionLabel.text = expoData.description
+    }
+    
+    private func convertTextSize(of label: UILabel) {
+        guard let target = label.text,
+              let colonIndex = target.firstIndex(of: ":")else { return }
+        
+        let leftFont = UIFont.preferredFont(forTextStyle: .title3)
+        let rightFont = UIFont.preferredFont(forTextStyle: .body)
+        
+        let leftDistance = target.distance(from: target.startIndex, to: colonIndex)
+        let rightDistance = target.distance(from: colonIndex, to: target.endIndex)
+        
+        let leftRange = NSMakeRange(0, leftDistance)
+        let rightRange = NSMakeRange(leftDistance, rightDistance)
+        
+        let attributedString = NSMutableAttributedString(string: target)
+        attributedString.addAttribute(.font, value: leftFont, range: leftRange)
+        attributedString.addAttribute(.font, value: rightFont, range: rightRange)
+        
+        label.attributedText = attributedString
     }
     
     private func convertToDecimal(from visitors: Int) -> String? {
@@ -104,10 +122,10 @@ final class ExpoViewController: UIViewController {
         static let flag = "flag"
     }
     
-    private enum Subtitle {
-        static let visitor = "방문객"
-        static let location = "개최지"
-        static let duration = "개최 기간"
+    private enum LabelText {
+        static let visitor = "방문객 : %@ 명"
+        static let location = "개최지 : %@"
+        static let duration = "개최 기간 : %@"
     }
 }
 
@@ -127,8 +145,9 @@ extension ExpoViewController {
     
     private func setLabelAccessibility() {
         self.titleLabel.accessibilityLabel = "파리 만국박람회 1900"
-        self.durationLabel.accessibilityLabel = "1900년 4월 14일부터 1900년 11월 12일까지"
-        self.descriptionLabel.accessibilityLabel = "1900년 파리 만국박람회 설명"
+        self.durationLabel.accessibilityLabel = "개최 기간"
+        self.durationLabel.accessibilityValue = "1900년 4월 14일부터 1900년 11월 12일까지"
+        self.descriptionLabel.accessibilityLabel = "1900년 파리 만국박람회 설명" 
         self.goButton.accessibilityHint = "한국의 출품작 화면으로 이동합니다."
     }
     

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -48,7 +48,7 @@ final class ExpoViewController: UIViewController {
     
     private func decodeExpoData() {
         self.expoUniverselle = DecodeManager.decodeData(
-            of: AssetName.expo, type: ExpoUniverselle.self
+            of: AssetName.expo, returnType: ExpoUniverselle.self
         ) ?? nil
     }
     

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -47,9 +47,7 @@ final class ExpoViewController: UIViewController {
     }
     
     private func decodeExpoData() {
-        self.expoUniverselle = DecodeManager.decodeData(
-            of: AssetName.expo, type: ExpoUniverselle.self
-        ) ?? nil
+        self.expoUniverselle = DecodeManager.decodeData(of: AssetName.expo) ?? nil
     }
     
     private func setMainScene() {

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -8,13 +8,18 @@ import UIKit
 
 final class ExpoViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var numberOfVisitorLabel: UILabel!
+   
+    @IBOutlet private weak var visitorSubtitleLabel: UILabel!
+    @IBOutlet private weak var numberOfVisitorsLabel: UILabel!
+    @IBOutlet private weak var locationSubtitleLabel: UILabel!
     @IBOutlet private weak var locationLabel: UILabel!
+    @IBOutlet private weak var durationSubtitileLabel: UILabel!
     @IBOutlet private weak var durationLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private weak var posterImageView: UIImageView!
     @IBOutlet private var flagImageViews: [UIImageView]!
     @IBOutlet private weak var goButton: UIButton!
+   
     private var expoUniverselle: ExpoUniverselle?
     
     override func viewDidLoad() {
@@ -60,14 +65,13 @@ final class ExpoViewController: UIViewController {
             from: expoData.numberOfVisitors
         ) else { return }
         
-        self.numberOfVisitorLabel.text = "방문객 : \(decimalVisitors) 명"
-        self.locationLabel.text = "개최지 : \(expoData.location)"
-        self.durationLabel.text = "개최 기간 : \(expoData.duration)"
-        
-        convertTextSize(of: self.numberOfVisitorLabel, range: NSMakeRange(0, 3))
-        convertTextSize(of: self.locationLabel, range: NSMakeRange(0, 3))
-        convertTextSize(of: self.durationLabel, range: NSMakeRange(0, 5))
-        
+        self.visitorSubtitleLabel.text = "방문객"
+        self.numberOfVisitorsLabel.text = " : \(decimalVisitors) 명"
+        self.locationSubtitleLabel.text = "개최지"
+        self.locationLabel.text = " : \(expoData.location)"
+        self.durationSubtitileLabel.text = "개최 기간"
+        self.durationLabel.text = " : \(expoData.duration)"
+
         self.titleLabel.text = expoData.title
         self.descriptionLabel.text = expoData.description
     }

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -20,7 +20,7 @@ final class ExpoViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setNavigationControllerDelegate()
+        self.navigationController?.delegate = self
         setNavigationBar()
         decodeExpoData()
         setMainScene()
@@ -30,10 +30,6 @@ final class ExpoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
-    }
-    
-    private func setNavigationControllerDelegate() {
-        self.navigationController?.delegate = self
     }
     
     private func setNavigationBar() {

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -18,12 +18,12 @@ final class ExpoViewController: UIViewController {
     @IBOutlet private weak var posterImageView: UIImageView!
     @IBOutlet private var flagImageViews: [UIImageView]!
     @IBOutlet private weak var goButton: UIButton!
-   
-    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
+    
     private var expoUniverselle: ExpoUniverselle?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setNavigationControllerDelegate()
         setNavigationBar()
         decodeExpoData()
         setMainScene()
@@ -33,12 +33,10 @@ final class ExpoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
-        appDelegate?.shouldSupportAllOrientation = false
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        appDelegate?.shouldSupportAllOrientation = true
+    private func setNavigationControllerDelegate() {
+        self.navigationController?.delegate = self
     }
     
     private func setNavigationBar() {
@@ -78,7 +76,7 @@ final class ExpoViewController: UIViewController {
         self.locationLabel.text = " : \(expoData.location)"
         self.durationSubtitileLabel.text = Subtitle.duration
         self.durationLabel.text = " : \(expoData.duration)"
-
+        
         self.titleLabel.text = expoData.title
         self.descriptionLabel.text = expoData.description
     }
@@ -110,6 +108,14 @@ final class ExpoViewController: UIViewController {
         static let visitor = "방문객"
         static let location = "개최지"
         static let duration = "개최 기간"
+    }
+}
+
+extension ExpoViewController: UINavigationControllerDelegate {
+    func navigationControllerSupportedInterfaceOrientations(
+        _ navigationController: UINavigationController
+    ) -> UIInterfaceOrientationMask {
+        return .portrait
     }
 }
 

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -115,18 +115,18 @@ final class ExpoViewController: UIViewController {
 
 extension ExpoViewController {
     private func setAccessibilityProperties() {
-        titleLabel.accessibilityLabel = "파리 만국박람회 1900"
-        posterImageView.isAccessibilityElement = true
-        posterImageView.accessibilityLabel = "박람회 포스터"
-        posterImageView.accessibilityTraits = .image
-        durationLabel.accessibilityLabel = "1900년 4월 14일부터 1900년 11월 12일까지"
-        descriptionLabel.accessibilityLabel = "1900년 파리 만국박람회 설명"
-        goButton.accessibilityHint = "한국의 출품작 화면으로 이동합니다."
-        flagImageViews.forEach {
+        self.titleLabel.accessibilityLabel = "파리 만국박람회 1900"
+        self.posterImageView.isAccessibilityElement = true
+        self.posterImageView.accessibilityLabel = "박람회 포스터"
+        self.posterImageView.accessibilityTraits = .image
+        self.durationLabel.accessibilityLabel = "1900년 4월 14일부터 1900년 11월 12일까지"
+        self.descriptionLabel.accessibilityLabel = "1900년 파리 만국박람회 설명"
+        self.goButton.accessibilityHint = "한국의 출품작 화면으로 이동합니다."
+        self.flagImageViews.forEach {
             $0.isAccessibilityElement = true
             $0.accessibilityTraits = .image
         }
-        flagImageViews[0].accessibilityLabel = "버튼 오른쪽 태극기"
-        flagImageViews[1].accessibilityLabel = "버튼 왼쪽 태극기"
+        self.flagImageViews[0].accessibilityLabel = "버튼 오른쪽 태극기"
+        self.flagImageViews[1].accessibilityLabel = "버튼 왼쪽 태극기"
     }
 }

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -27,6 +27,7 @@ final class ExpoViewController: UIViewController {
         setNavigationBar()
         decodeExpoData()
         setMainScene()
+        setAccessibilityProperties()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -112,3 +113,20 @@ final class ExpoViewController: UIViewController {
     }
 }
 
+extension ExpoViewController {
+    private func setAccessibilityProperties() {
+        titleLabel.accessibilityLabel = "파리 만국박람회 1900"
+        posterImageView.isAccessibilityElement = true
+        posterImageView.accessibilityLabel = "박람회 포스터"
+        posterImageView.accessibilityTraits = .image
+        durationLabel.accessibilityLabel = "1900년 4월 14일부터 1900년 11월 12일까지"
+        descriptionLabel.accessibilityLabel = "1900년 파리 만국박람회 설명"
+        goButton.accessibilityHint = "한국의 출품작 화면으로 이동합니다."
+        flagImageViews.forEach {
+            $0.isAccessibilityElement = true
+            $0.accessibilityTraits = .image
+        }
+        flagImageViews[0].accessibilityLabel = "버튼 오른쪽 태극기"
+        flagImageViews[1].accessibilityLabel = "버튼 왼쪽 태극기"
+    }
+}

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -8,7 +8,6 @@ import UIKit
 
 final class ExpoViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
-   
     @IBOutlet private weak var visitorSubtitleLabel: UILabel!
     @IBOutlet private weak var numberOfVisitorsLabel: UILabel!
     @IBOutlet private weak var locationSubtitleLabel: UILabel!
@@ -20,6 +19,7 @@ final class ExpoViewController: UIViewController {
     @IBOutlet private var flagImageViews: [UIImageView]!
     @IBOutlet private weak var goButton: UIButton!
    
+    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
     private var expoUniverselle: ExpoUniverselle?
     
     override func viewDidLoad() {
@@ -32,6 +32,12 @@ final class ExpoViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = true
+        appDelegate?.shouldSupportAllOrientation = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        appDelegate?.shouldSupportAllOrientation = true
     }
     
     private func setNavigationBar() {

--- a/Expo1900/Expo1900/ViewController/ExpoViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ExpoViewController.swift
@@ -91,16 +91,6 @@ final class ExpoViewController: UIViewController {
         return decimalVisitors
     }
     
-    private func convertTextSize(of label: UILabel, range: NSRange) {
-        guard let target = label.text else { return }
-        
-        let fontSize = UIFont.systemFont(ofSize: 20)
-        let attributedString = NSMutableAttributedString(string: target)
-        
-        attributedString.addAttribute(.font, value: fontSize, range: range)
-        label.attributedText = attributedString
-    }
-    
     @IBAction private func touchUpGoButton(_ sender: UIButton) {
         let identifier = "ItemEntryViewController"
         guard let nextViewController = self.storyboard?.instantiateViewController(

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -28,7 +28,7 @@ final class ItemEntryViewController: UIViewController {
     private func decodeItemsData() {
         let assetName = "items"
         
-        self.items = DecodeManager.decodeData(of: assetName, type: [Item].self) ?? []
+        self.items = DecodeManager.decodeData(of: assetName) ?? []
     }
     
     private enum Identifier {

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -48,12 +48,9 @@ extension ItemEntryViewController: UITableViewDataSource {
             withIdentifier: Identifier.cell, for: indexPath
         ) as? CustomTableViewCell else { return UITableViewCell() }
         
-        let itemName = items[indexPath.row].name
-        let shortDescription = items[indexPath.row].shortDescription
-        let itemImage = UIImage(named: items[indexPath.row].imageName) ?? nil
-        
-        cell.setContents(itemName, shortDescription, itemImage)
-        setAccessibilityProperties(of: cell, itemName: itemName, shortDescription: shortDescription)
+        cell.allocate(data: items[indexPath.row])
+        cell.setContents()
+        cell.setAccessibilityProperties()
         
         return cell
     }
@@ -77,37 +74,3 @@ extension ItemEntryViewController: UITableViewDelegate {
     }
 }
 
-extension ItemEntryViewController {
-    private func setAccessibilityProperties(
-        of cell: CustomTableViewCell,
-        itemName: String,
-        shortDescription: String
-    ) {
-        cell.isAccessibilityElement = false
-        cell.accessibilityElements = [
-            cell.itemNameLabel!,
-            cell.shortDescriptionLabel!,
-            cell.itemImageView!
-        ]
-        
-        setLabelAccessibility(in: cell, itemName: itemName, shortDescription: shortDescription)
-        setImageViewAccessibility(in: cell, itemName: itemName)
-    }
-    
-    private func setLabelAccessibility(
-        in cell: CustomTableViewCell,
-        itemName: String,
-        shortDescription: String
-    ) {
-        cell.itemNameLabel.accessibilityLabel = itemName
-        cell.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
-        cell.shortDescriptionLabel.accessibilityValue = shortDescription
-    }
-    
-    private func setImageViewAccessibility(in cell: CustomTableViewCell, itemName: String) {
-        cell.itemImageView.isAccessibilityElement = true
-        cell.itemImageView.accessibilityLabel = itemName
-        cell.itemImageView.accessibilityTraits = .image
-        cell.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
-    }
-}

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -28,7 +28,7 @@ final class ItemEntryViewController: UIViewController {
     private func decodeItemsData() {
         let assetName = "items"
         
-        self.items = DecodeManager.decodeData(of: assetName, type: [Item].self) ?? []
+        self.items = DecodeManager.decodeData(of: assetName, returnType: [Item].self) ?? []
     }
     
     private enum Identifier {

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -48,22 +48,14 @@ extension ItemEntryViewController: UITableViewDataSource {
             withIdentifier: Identifier.cell, for: indexPath
         ) as? CustomTableViewCell else { return UITableViewCell() }
         
-        setContents(of: cell, at: indexPath)
-        
-        return cell
-    }
-    
-    private func setContents(of cell: CustomTableViewCell, at indexPath: IndexPath) {
-        guard let itemImage = UIImage(named: items[indexPath.row].imageName) else { return }
         let itemName = items[indexPath.row].name
         let shortDescription = items[indexPath.row].shortDescription
+        let itemImage = UIImage(named: items[indexPath.row].imageName) ?? nil
         
-        cell.itemNameLabel.text = itemName
-        cell.shortDescriptionLabel.text = shortDescription
-        cell.itemImageView.image = itemImage
-        
+        cell.setContents(itemName, shortDescription, itemImage)
         setAccessibilityProperties(of: cell, itemName: itemName, shortDescription: shortDescription)
-        cell.accessoryType = .disclosureIndicator
+        
+        return cell
     }
 }
 

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -57,15 +57,8 @@ extension ItemEntryViewController: UITableViewDataSource {
         guard let itemImage = UIImage(named: items[indexPath.row].imageName) else { return }
         
         cell.itemNameLabel.text = items[indexPath.row].name
-        cell.itemNameLabel.font = UIFont.systemFont(ofSize: 25)
-        
         cell.shortDescriptionLabel.text = items[indexPath.row].shortDescription
-        cell.shortDescriptionLabel.font = UIFont.systemFont(ofSize: 18)
-        cell.shortDescriptionLabel.numberOfLines = 0
-        cell.shortDescriptionLabel.lineBreakMode = .byWordWrapping
-        
         cell.itemImageView.image = itemImage
-        
         cell.accessoryType = .disclosureIndicator
     }
 }

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -13,6 +13,7 @@ final class ItemEntryViewController: UIViewController {
     @IBOutlet private weak var tableView: UITableView!
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         self.tableView.dataSource = self
         self.tableView.delegate = self
         setNavigationBar()
@@ -27,7 +28,6 @@ final class ItemEntryViewController: UIViewController {
     
     private func decodeItemsData() {
         let assetName = "items"
-        
         self.items = DecodeManager.decodeData(of: assetName, returnType: [Item].self) ?? []
     }
     
@@ -73,4 +73,3 @@ extension ItemEntryViewController: UITableViewDelegate {
         self.tableView.deselectRow(at: indexPath, animated: true)
     }
 }
-

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -55,14 +55,14 @@ extension ItemEntryViewController: UITableViewDataSource {
     
     private func setContents(of cell: CustomTableViewCell, at indexPath: IndexPath) {
         guard let itemImage = UIImage(named: items[indexPath.row].imageName) else { return }
+        let itemName = items[indexPath.row].name
+        let shortDescription = items[indexPath.row].shortDescription
         
-        cell.itemNameLabel.text = items[indexPath.row].name
-        cell.shortDescriptionLabel.text = items[indexPath.row].shortDescription
+        cell.itemNameLabel.text = itemName
+        cell.shortDescriptionLabel.text = shortDescription
         cell.itemImageView.image = itemImage
-        cell.setAccessibilityProperties(
-            itemName: items[indexPath.row].name,
-            shortDescription: items[indexPath.row].shortDescription
-        )
+        
+        setAccessibilityProperties(of: cell, itemName: itemName, shortDescription: shortDescription)
         cell.accessoryType = .disclosureIndicator
     }
 }
@@ -82,5 +82,40 @@ extension ItemEntryViewController: UITableViewDelegate {
         
         self.navigationController?.pushViewController(nextViewController, animated: true)
         self.tableView.deselectRow(at: indexPath, animated: true)
+    }
+}
+
+extension ItemEntryViewController {
+    private func setAccessibilityProperties(
+        of cell: CustomTableViewCell,
+        itemName: String,
+        shortDescription: String
+    ) {
+        cell.isAccessibilityElement = false
+        cell.accessibilityElements = [
+            cell.itemNameLabel!,
+            cell.shortDescriptionLabel!,
+            cell.itemImageView!
+        ]
+        
+        setLabelAccessibility(in: cell, itemName: itemName, shortDescription: shortDescription)
+        setImageViewAccessibility(in: cell, itemName: itemName)
+    }
+    
+    private func setLabelAccessibility(
+        in cell: CustomTableViewCell,
+        itemName: String,
+        shortDescription: String
+    ) {
+        cell.itemNameLabel.accessibilityLabel = itemName
+        cell.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
+        cell.shortDescriptionLabel.accessibilityValue = shortDescription
+    }
+    
+    private func setImageViewAccessibility(in cell: CustomTableViewCell, itemName: String) {
+        cell.itemImageView.isAccessibilityElement = true
+        cell.itemImageView.accessibilityLabel = itemName
+        cell.itemImageView.accessibilityTraits = .image
+        cell.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
     }
 }

--- a/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
+++ b/Expo1900/Expo1900/ViewController/ItemEntryViewController.swift
@@ -59,6 +59,10 @@ extension ItemEntryViewController: UITableViewDataSource {
         cell.itemNameLabel.text = items[indexPath.row].name
         cell.shortDescriptionLabel.text = items[indexPath.row].shortDescription
         cell.itemImageView.image = itemImage
+        cell.setAccessibilityProperties(
+            itemName: items[indexPath.row].name,
+            shortDescription: items[indexPath.row].shortDescription
+        )
         cell.accessoryType = .disclosureIndicator
     }
 }

--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@
 #### 📱 iPhone 12 mini 
 | 앱 실행| Dynamic Type 적용| 화면 회전|
 |:---:|:---:|:---:|
-| <img src="https://i.imgur.com/H1apPpv.gif" width="300"> | <img src = "https://i.imgur.com/mEEj8mF.gif" width="300"> | <img src="https://i.imgur.com/JSEb3yd.gif" width ="600"> |
+| <img src="https://user-images.githubusercontent.com/114971172/222661318-13dd3618-64b8-4a3d-946e-0bbc5d5f8713.gif" width="150"> | <img src = "https://user-images.githubusercontent.com/114971172/222661661-01246808-a48b-49a8-824b-aad5520f7e9b.gif" width="150"> | <img src="https://i.imgur.com/JSEb3yd.gif" width ="300"> |
 
 
 #### 📱 iPhone SE
 
 |앱 실행|Dynamic Type 적용|화면 회전|
 |:---:|:---:|:---:|
-|<img src="https://i.imgur.com/DrAIXe7.gif" width="300">|<img src = "https://i.imgur.com/av3yqfF.gif" width="300">|<img src="https://i.imgur.com/QQ1tCfr.gif" width="600">|
+|<img src="https://user-images.githubusercontent.com/114971172/222661672-789ff840-390b-48f9-9234-2a6f8b49f81e.gif" width="150">|<img src = "https://i.imgur.com/av3yqfF.gif" width="150">|<img src="https://i.imgur.com/QQ1tCfr.gif" width="300">|
 
 
 <br/>

--- a/README.md
+++ b/README.md
@@ -27,15 +27,20 @@
 - 2023.02.22 : ItemsEntryViewController, DescriptionViewController 구현
 - 2023.02.23 : ViewController refactoring
 - 2023.02.24 : refactoring, README.md 작성
-<br>
+- 2023.02.27 : refactoring(컨벤션, Custom TableViewCell 적용, JSONDecoder 기능 분리)
+- 2023.02.28 : Storyboard를 통한 오토레이아웃 수정, 첫 번째 화면 portrait orientation으로 고정
+- 2023.03.01 : refactoring(NameSpace 전역 -> Nested type으로 변경)
+- 2023.03.02 : Accessibility 추가 구현 및 오토레이아웃 refactoring
+- 2023.03.03 : README.md 수정, refactoring
+<br/>
 
 
 # 프로젝트 구조
 
 <details>
     <summary><big>UML</big></big></summary>
-    
-![ExopUML](https://i.imgur.com/wccGcUV.jpg)
+
+![ExopUML](https://i.imgur.com/QF8D1Db.jpg)
 
 </details>
 
@@ -45,19 +50,20 @@
 
 ```
 └── Expo1900
-    ├── App
-    │   ├── AppDelegate
-    │   └── SceneDelegate
-    ├── Common
-    │   └── NameSpace
     ├── Model
     │   └── JSON
     │       ├── ExpoUniverselle
     │       └── Item
+    ├── View
+    │   └── CustomTableViewCell
     └── ViewController
+    │   ├── ExpoViewController 
+    │   ├── ItemEntryViewController
     │   ├── DescriptionViewController
-    │   ├── ExpoViewController
-    │   └── ItemEntryViewController
+    │   └── DecodeManager
+    ├── App
+    │   ├── AppDelegate
+    │   └── SceneDelegate
     ├── Assets
     │   ├── AccentColor
     │   ├── AppIcon
@@ -74,14 +80,24 @@
 
    
 # 실행화면
+#### 📱 iPhone 12 mini 
+| 앱 실행| Dynamic Type 적용| 화면 회전|
+|:---:|:---:|:---:|
+| <img src="https://i.imgur.com/H1apPpv.gif" width="300"> | <img src = "https://i.imgur.com/mEEj8mF.gif" width="300"> | <img src="https://i.imgur.com/JSEb3yd.gif" width ="600"> |
 
-- step3 완성 후 업데이트 예정입니다!
+
+#### 📱 iPhone SE
+
+|앱 실행|Dynamic Type 적용|화면 회전|
+|:---:|:---:|:---:|
+|<img src="https://i.imgur.com/DrAIXe7.gif" width="300">|<img src = "https://i.imgur.com/av3yqfF.gif" width="300">|<img src="https://i.imgur.com/QQ1tCfr.gif" width="600">|
+
 
 <br/>
 
 # 트러블 슈팅
-## Image Size
-### 문제점
+## 1️⃣ Image Size
+### 🔍 문제점
 - `ItemEntryViewController`에서 이미지와 설명이 들어가는데, 이미지 사이즈가 다 제각각이여서 그걸 맞춰주는 것이 필요했습니다.
 프로젝트 초기, 커스텀 셀을 구현한 것이 아니라 subtitle style의 셀을 사용하여 오토레이아웃을 사용할 수 없어 `UIGraphicsBeginImageContext(_:)`메서드로 이미지 자체의 크기를 다시 조정하여 만들어주도록 구현했습니다. 
 
@@ -102,19 +118,160 @@
 ```
 - 이러한 image 자체의 사이즈를 조정하는 방법은 auto layout이 적용되지 않아 어플리케이션을 사용하는 기기가 바뀌었을 때 고정된 image size 때문에 화면의 크기와 맞지 않는 이미지가 출력될 것으로 예상됩니다.
 
-<br/>
+### ⚒️ 해결방안
+- TableViewCell의 style을 custom 이외의 다른 것을 사용하는 경우 오토레이아웃을 적용할 수 없어 CustomTableViewCell을 정의하여 오토레이아웃을 통해 image size를 조정하였습니다. 
 
-### 해결방안
-- 추가예정
+```swift
+import UIKit
+
+final class CustomTableViewCell: UITableViewCell {
+    @IBOutlet weak var itemNameLabel: UILabel!
+    @IBOutlet weak var shortDescriptionLabel: UILabel!
+    @IBOutlet weak var itemImageView: UIImageView!
+}
+```
+
+**오토레이아웃**
+- `imageView width`와 `stackView width`의 비율을 multiplier 0.2로 주고 `imageView`의 ratio를 1:1로 지정하여 크기를 조정하였습니다.
+
+<img src="https://i.imgur.com/CRKNMHB.png" width="400">
 
 <br/>
 
 
 ----
 
-## NavigationBar 관련 이슈
+<br/>
 
-### 1️⃣ 화면전환시 첫 번째 화면에 navigationBar가 다시 나타나는 문제
+## 2️⃣ DescriptionViewController에 데이터 전달 방법
+### 🔍 문제점
+처음 데이터 전달은 Delegation 패턴을 사용하기 위해 `ContentsDataSource` 프로토콜을 추가로 정의하고 `DescriptionViewController`가 `delegate` 프로퍼티를 갖도록 구현했습니다.
+
+이때, 아래 코드에서 확인할 수 있듯 외부에서 DescriptionViewController의 프로퍼티에 값을 직접 주입하고 있습니다.
+
+```swift
+func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    guard let nextViewController = self.storyboard?.instantiateViewController(
+        withIdentifier: Identifier.descriptionViewController
+    ) else { return }
+
+    nextViewController.delegate = self
+    self.navigationController?.pushViewController(nextViewController, animated: true)
+    self.tableView.deselectRow(at: indexPath, animated: true)
+}
+```
+
+외부에서 주입하는 것이 가능한데도 protocol에 의해 코드에 추가적인 depth가 생기는 문제가 있었습니다.
+
+### ⚒️ 해결방안
+ViewController에 지정이니셜라이저를 정의하여 화면 전환 시 생성할 인스턴스에 이니셜라이저를 통한 주입으로 해결하였습니다.
+이니셜라이저를 통한 주입을 구현함으로써 `DescriptionViewController`에 `Item`이 반드시 필요하다는 점도 명확하게 나타난다고 생각합니다.
+
+```swift
+init?(item: Item, coder: NSCoder) {
+    self.item = item
+    super.init(coder: coder)
+}
+    
+required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+}
+```
+해당 지정이니셜라이저를 호출하기 위해서는 `instantiateViewController(identifier:creator:)` 메서드가 필요했습니다.
+creator의 타입은 `((NSCoder) -> ViewController?)?` 로 클로저입니다. creator 클로저 내부 코드블록에서 지정 이니셜라이저를 호출하여 프로퍼티에 원하는 값을 주입할 수 있었습니다.
+
+   - `required`는 `UIViewController`가 `NSCoding` 프로토콜을 채택하고 있기 때문에 해당 프로토콜에 정의된 이니셜라이저를 구현하면 붙는 키워드입니다.
+새로운 지정 이니셜라이저를 정의하기 위해서는 required init을 반드시 정의할 필요가 있었습니다. 
+
+----
+
+<br/>
+
+## 3️⃣ Generic 메서드 구현
+### 🔍 문제점
+
+JSON 데이터를 디코딩하는 기능을 ViewController에서 분리하기 위해 `DecodeManager` 객체를 따로 정의하였습니다. 
+데이터를 디코딩하는 메서드를 정의할 때, 리턴 값의 타입이 두 가지 였습니다. 저희는 Decoding할 값의 타입이 달라도 하나의 메서드만 사용해서 decode 할 수 있도록 Generic을 활용하였습니다.
+그런데 Generic 함수를 구현하는 과정에서 몇 가지 오류가 발생하였습니다.
+
+◾️ **Error #1 Generic parameter 'T' could not be inferred.** 
+
+<img src="https://i.imgur.com/A7pcpiQ.png" width="400">
+<br/>
+<br/>
+
+- JSONDecoder의 decode 메서드를 확인해보면 `_ type: T.Type` 파라미터가 필요한 것을 알 수 있습니다. 해당 파라미터는 제공된 JSON 객체에서 디코딩할 값의 타입을 뜻합니다. 즉, 디코딩한 반환값의 Type을 의미하며 구체적인 타입 명시가 필요합니다.
+
+<br/>
+
+<img src="https://i.imgur.com/vJq3W9K.png" width="600">
+<br/>
+
+<br/>
+
+- 함수를 호출할 때 디코딩할 객체의 타입을 명시하지 않아도 되지만 이 경우, 컴파일러가 디코딩할 객체의 타입을 알 수 없기 때문에 디코딩할 객체의 타입이 일치하지 않는 경우 런타임 오류(Runtime Error)가 발생할 가능성이 있습니다. swift 는 type-safety 언어이기 때문에 구체적인 타입을 명시한다면 디코딩할 객체의 타입이 일치하지 않는 경우 컴파일 단계에서 오류를 발생시켜 예방할 수 있습니다.
+
+**따라서 Generic 함수의 반환 값의 타입이 Generic이라면, 정확한 타입을 매개변수로 받아야 합니다.**
+
+<br/>
+
+◾️ **Error #2 Cannot explicitly specialize a generic function.** 
+
+- generic 메서드를 호출할 때, "<>"를 통해 타입을 써줘야한다고 착각하여(`decodeData<ExpoUniverselle>(of: AssetName.expo)`), 호출할 때 꺽쇠를 사용해 오류가 발생하였습니다. -> **generic 메서드 호출 시 "<>" 사용하지 않기**
+  
+
+#### 기존 코드 
+
+```swift
+static func decodeData<T: Decodable>(of name: String) -> T? {
+        let jsonDecoder = JSONDecoder()
+        guard let dataAsset = NSDataAsset(name: name) else { return nil }
+
+        do {
+            let result = try jsonDecoder.decode(T.self, from: dataAsset.data)
+
+            return result
+        } catch {
+            print(error.localizedDescription)
+
+            return nil
+        }
+    }
+```
+
+
+
+### ⚒️ 해결방안
+#### 수정 코드
+
+```swift
+enum DecodeManager {
+    static func decode<T: Decodable>(of name: String, returnType: T.Type) -> T? {
+        let jsonDecoder = JSONDecoder()
+        guard let dataAsset = NSDataAsset(name: name) else { return nil }
+
+        do {
+            let result = try jsonDecoder.decode(returnType, from: dataAsset.data)
+
+            return result
+        } catch {
+            print(error.localizedDescription)
+
+            return nil
+        }
+    }
+}
+```
+
+- decode 메서드의 파라미터타입으로 returnType을 받아 구체적인 타입을 명시하도록 수정하였습니다.
+
+
+----
+<br/>
+
+## 4️⃣ NavigationBar 관련 이슈
+
+### 🔍 화면전환시 첫 번째 화면에 navigationBar가 다시 나타나는 문제
 NavigationBar를 숨기기 위해 `isNaviagtionBarHidden` 프로퍼티를 구현하여 사라지도록 `viewDidLoad()` 에서 설정하였습니다.
 두 번째 화면에서 다시 첫 번째 화면으로 돌아올 때, navigationBar가 사라지지 않는 문제가 있었습니다. 
 
@@ -128,15 +285,17 @@ var isNavigationBarHidden: Bool { get set }
 - `setNavigationBarHidden(_: animated: )`를 사용하여 animated를 추가할 수도 있습니다.
 
 
-### 해결방안
+### ⚒️ 해결방안
 
 - view의 생명주기를 생각해보았습니다. 첫 번째 화면에서 `isNavigationBarHidden`의 설정을 `viewDidLoad` 메서드에서 했습니다. 이후 화면전환이 일어나면 `viewDidLoad`는 다시 실행되지 않기 때문에 NavigationBar가 사라지지 않았습니다. 따라서, `isNavigationBarHidden`의 설정을 첫 번째 화면이 screen에 표시되기 직전 호출되는 `viewWillAppear`에 구현하여 문제를 해결하였습니다.
 
-### 2️⃣ backButton title 수정 문제
+<br/>
+
+### 🔍 backButton title 수정 문제
 두 번째 혹은 세 번째 화면에서 이전 화면으로 돌아가려면 `navigationBar`의 `backButton`을 누르면 되는데, 이 버튼의 이름을 기본 `back`이 아닌 다른 이름으로 수정하고자 했습니다.
 처음에 `backButton`이 보여지는 화면에서 `navigationItem.title`에 접근하여 수정하였는데, title이 수정되지 않는 문제가 있었습니다.
 
-### 해결방안
+### ⚒️ 해결방안
 - `back button`은 이전 화면의 navigationBar title로 설정되기 때문에 이전 화면의 `navigationItem.title`에 접근하여 수정하여 해결했습니다.
 
 
@@ -146,7 +305,7 @@ var isNavigationBarHidden: Bool { get set }
 # 핵심경험 
 
 <details>
-    <summary><big>1️⃣ JSON</big></summary>
+    <summary><big>✅ JSON</big></summary>
 
 JSON을 처음 활용하며 추가적으로 학습했던 내용입니다.
 
@@ -196,8 +355,142 @@ typealias Codable = Decodable + Encodable
     
 </details>
 
+    
 <details>
-    <summary><big>2️⃣ 화면 간 데이터 공유</big></summary>
+    <summary><big>✅  Label 일부 크기 조정</big></summary> 
+
+- 첫번째 화면에서 방문객, 개최지, 개최기간등 일부 Label의 크기가 달라 이를 조정할 필요가 있었습니다. Label의 일부를 변경하는 메서드가 있어 아래의 내용을 적용해보았습니다.
+
+### NSMutableAttributedString
+> 텍스트의 일부에 대한 관련 속성(예: 시각적 스타일, 하이퍼링크 또는 접근성 데이터)이 있는 변경 가능한 문자열.
+
+```swift
+private func convertTextSize(of label: UILabel, range: NSRange) {
+        guard let target = label.text else { return }
+        
+        let fontSize = UIFont.systemFont(ofSize: 20)
+        let attributedString = NSMutableAttributedString(string: target)
+        
+        attributedString.addAttribute(.font, value: fontSize, range: range)
+        label.attributedText = attributedString
+    }
+```
+- 텍스트의 일부 속성을 변경하기위해 `NSMutableAttributedString(String:)`을 attributedString 상수로 선언합니다.
+- `addAttribute(_:value:range:)` 인스턴스 메서드를 사용하여 지정된 범위의 문자에 주어진 이름과 값을 가진 속성을 추가합니다.
+
+<img src="https://i.imgur.com/vq2Cn9N.png" width="400">
+
+- 띄워줄 label에 `attributedText` 메서드를 사용하여 변경된 속성을 부여해줍니다.
+- range의 경우 index로 접근할수도 있고 특정 문자열을 입력하여 접근할 수도 있습니다.
+   - NSMakeRange(Int,Int) : Int 부터 Int까지의 문자열, 지정된 값에서 새 NSRange를 만드는 메서드
+   - range: (text as NSString).range(of: "특정문자열")
+</details>
+    
+
+<details>
+    <summary><big>✅  UITableView - Modern Cell Configuration 적용</big></summary>
+
+처음에`TableViewCell`에 올려져 있는 Label, detailTextLabel, imageView의 속성을 변경하기 위해 직접 접근하였습니다. 그러나 iOS 14 부터 `UIContentConfiguration`을 이용하도록 변경되어 기존 접근 방식을 권장하지 않는다는 것을 알게되어 `modern cell configuration`을 적용하였습니다.
+
+
+### 적용방법
+
+- cell에 defaultContentConfiguration()을 호출합니다.
+- text, secondaryText, image를 설정하여 원하는 조건을 줍니다.
+- cell의 contentConfiguration에 첫 번째 변수로 생성한 content를 넣어줍니다.
+
+```swift
+ private func setContents(of cell: UITableViewCell, at indexPath: IndexPath) {
+    var customConfiguration = cell.defaultContentConfiguration()
+        
+    customConfiguration.secondaryText = items[indexPath.row].shortDescription
+    customConfiguration.secondaryTextProperties.font = UIFont.systemFont(ofSize: 18)
+    customConfiguration.secondaryTextProperties.numberOfLines = 0
+    customConfiguration.secondaryTextProperties.lineBreakMode = .byWordWrapping
+        
+    cell.contentConfiguration = customConfiguration
+    cell.accessoryType = .disclosureIndicator
+}
+```
+</details>
+
+<details>
+    <summary><big>✅ 첫 번째 화면 세로 고정</big></summary>
+특정 화면만 portrait orientation으로 고정하기 위해 여러가지 방법을 찾아보았습니다. 저희는 그 중에서 화면의 orientation에 대한 상태에 응답하는 것이 중요한 부분이라고 생각하여 AppDelegate를 활용한 방법을 선택하여 구현해 보았습니다.
+
+```swift
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var shouldSupportAllOrientation = true
+
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        shouldSupportAllOrientation == true ? .all : .portrait
+    }
+}
+```
+
+```swift
+final class ExpoViewController: UIViewController {
+   
+    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
+}
+```
+</details>
+
+
+<details>
+    <summary><big>✅ TableViewCell Contents Accessibility </big></summary>
+
+테이블 뷰에 VoiceOver를 실행해보니 Cell을 통째로 인식해서 내부의 Label Title이 모두 합쳐져 cell.accessibilityLabel에 설정되어 있는 것을 확인했습니다.
+
+cell 내부의 정보를 사용자에게 VoiceOver를 통해 들려주는 것이 바람직하다고 생각하여 해결 방법을 찾아보았습니다.
+
+비공식 프로토콜 `UIAccessibilityContainer`를 채택하고 있는 클래스는 해당 클래스의 subview를 선택적으로 accessibiliyElement로 만들어줄 수 있는 메서드 / 프로퍼티를 제공하고 있습니다. 그 중에서 `var accessibilityElements: [Any]?`을 이용하였습니다.
+
+1. cell 자체에 VoiceOver가 접근하지 못하도록 해준다.
+2. cell.accessibilityElements에 label, imageView를 추가한다.
+3. 각각의 subview들의 accessibilityProperty를 설정한다.
+
+```swift
+func setAccessibilityProperties(itemName: String, shortDescription: String) {
+    self.itemNameLabel.accessibilityLabel = itemName
+        
+    self.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
+    self.shortDescriptionLabel.accessibilityValue = shortDescription
+        
+    self.itemImageView.isAccessibilityElement = true
+    self.itemImageView.accessibilityLabel = itemName
+    self.itemImageView.accessibilityTraits = .image
+    self.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
+        
+    self.isAccessibilityElement = false
+    self.accessibilityElements = [
+        self.itemNameLabel!,
+        self.shortDescriptionLabel!,
+        self.itemImageView!
+    ]
+}
+```
+</details>
+
+<details>
+    <summary><big>추가 학습</big></summary>
+
+## View의 생명주기 override, super는 필수적인가?
+- UIViewController의 메서드를 상속해서 사용하고 거기에 있는 viewWillAppear를 override(재정의) 하였습니다. 그리고 바로 아래와 같이 정의하였는데 오류가 나지 않았습니다.
+
+```swift
+override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.isNavigationBarHidden = true
+    }
+```
+- 생각해보니 `override`를 하면 `super.`을 하여 부모클래스의 메서드를 마무리 지어야 했는데 왜 오류가 나지 않았지? 의문이 들었습니다.
+- 공식문서를 찾아보니, `If you override this method, you must call super at some point in your implementation.` 반드시 `super`를 호출해야한다고 나와있어 정의해주는 것으로 수정하였습니다. 
+- 반면 선택적으로 호출할 수 있는 메서드도 있고 이는 공식문서에서 확인할 수 있었습니다.
+
+<br/>
+    
+## 화면 간 데이터 공유(Refactoring 전)
 
 `DescriptionViewController`에서 선택된 셀의 `imageItem`, `description` 데이터가 필요했는데 JSON decode를 `DescriptionViewController`에서 다시 해주게 되면 선택된 셀의 데이터를 사용할 수 없었습니다. 그래서 다시 decoding을 하는것이 아니라 화면간 데이터 공유방법 중 하나인 `delegation` 패턴을 활용하여 `ItemEntryViewController`에서 데이터를 전달받았습니다.  `delegation` 패턴을 사용하면서 그 역할에 대해 다시 한 번 학습하였습니다.
 
@@ -240,89 +533,29 @@ func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 2. 현재 선택된 셀의 `Item`을 `selectedItem` 프로퍼티에 할당.
 3. `ItemEntryViewController`를 nextViewController의 `dataSource`로 할당. 
 
----
-</details>
-    
-<details>
-    <summary><big>3️⃣ Label 일부 크기 조정</big></summary> 
-
-- 첫번째 화면에서 방문객, 개최지, 개최기간등 일부 Label의 크기가 달라 이를 조정할 필요가 있었습니다. Label의 일부를 변경하는 메서드가 있어 아래의 내용을 적용해보았습니다.
-
-### NSMutableAttributedString
-> 텍스트의 일부에 대한 관련 속성(예: 시각적 스타일, 하이퍼링크 또는 접근성 데이터)이 있는 변경 가능한 문자열.
-
-```swift
-private func convertTextSize(of label: UILabel, range: NSRange) {
-        guard let target = label.text else { return }
-        
-        let fontSize = UIFont.systemFont(ofSize: 20)
-        let attributedString = NSMutableAttributedString(string: target)
-        
-        attributedString.addAttribute(.font, value: fontSize, range: range)
-        label.attributedText = attributedString
-    }
-```
-- 텍스트의 일부 속성을 변경하기위해 `NSMutableAttributedString(String:)`을 attributedString 상수로 선언합니다.
-- `addAttribute(_:value:range:)` 인스턴스 메서드를 사용하여 지정된 범위의 문자에 주어진 이름과 값을 가진 속성을 추가합니다.
-
-<img src="https://i.imgur.com/vq2Cn9N.png" width="400">
-
-- 띄워줄 label에 `attributedText` 메서드를 사용하여 변경된 속성을 부여해줍니다.
-- range의 경우 index로 접근할수도 있고 특정 문자열을 입력하여 접근할 수도 있습니다.
-   - NSMakeRange(Int,Int) : Int 부터 Int까지의 문자열, 지정된 값에서 새 NSRange를 만드는 메서드
-   - range: (text as NSString).range(of: "특정문자열")
-</details>
-    
-
-<details>
-    <summary><big>4️⃣ UITableView - Modern Cell Configuration 적용</big></summary>
-
-처음에`TableViewCell`에 올려져 있는 Label, detailTextLabel, imageView의 속성을 변경하기 위해 직접 접근하였습니다. 그러나 iOS 14 부터 `UIContentConfiguration`을 이용하도록 변경되어 기존 접근 방식을 권장하지 않는다는 것을 알게되어 `modern cell configuration`을 적용하였습니다.
-
-
-### 적용방법
-
-- cell에 defaultContentConfiguration()을 호출합니다.
-- text, secondaryText, image를 설정하여 원하는 조건을 줍니다.
-- cell의 contentConfiguration에 첫 번째 변수로 생성한 content를 넣어줍니다.
-
-```swift
- private func setContents(of cell: UITableViewCell, at indexPath: IndexPath) {
-    var customConfiguration = cell.defaultContentConfiguration()
-        
-    customConfiguration.secondaryText = items[indexPath.row].shortDescription
-    customConfiguration.secondaryTextProperties.font = UIFont.systemFont(ofSize: 18)
-    customConfiguration.secondaryTextProperties.numberOfLines = 0
-    customConfiguration.secondaryTextProperties.lineBreakMode = .byWordWrapping
-        
-    cell.contentConfiguration = customConfiguration
-    cell.accessoryType = .disclosureIndicator
-}
-```
-</details>
-
-<details>
-    <summary><big>추가 학습</big></summary>
-
-## View의 생명주기 override, super는 필수적인가?
-- UIViewController의 메서드를 상속해서 사용하고 거기에 있는 viewWillAppear를 override(재정의) 하였습니다. 그리고 바로 아래와 같이 정의하였는데 오류가 나지 않았습니다.
-
-```swift
-override func viewWillAppear(_ animated: Bool) {
-        self.navigationController?.isNavigationBarHidden = true
-    }
-```
-- 생각해보니 `override`를 하면 `super.`을 하여 부모클래스의 메서드를 마무리 지어야 했는데 왜 오류가 나지 않았지? 의문이 들었습니다.
-- 공식문서를 찾아보니, `If you override this method, you must call super at some point in your implementation.` 반드시 `super`를 호출해야한다고 나와있어 정의해주는 것으로 수정하였습니다. 
-- 반면 선택적으로 호출할 수 있는 메서드도 있고 이는 공식문서에서 확인할 수 있었습니다.
-
 </details>
 
 ----
+    
 # 팀 회고
 
-- step3 완성 후 업데이트 예정입니다!
+### 잘한 점
+  - 문제를 해결할 때 단순히 해결만 하는 것이 아니라 적용한 개념에 대해 서로 이해할 수 있도록 많은 토론이 이루어졌다.
+  - 프로젝트의 요구사항을 정확히 이해하고 적용하려고 노력했다.
+### 개선할 점
+  - 앞으로는 그라운드룰 설정을 하면 좋겠다.
+  - 코드 작성할 때 코드 컨벤션에 대해 더 명확한 기준을 가지면 좋겠다.
+  - 로완 토론할 때 조금 더 차분한 목소리로 친절하게 대답합시다 🙏
 
+### 서로 칭찬하기 
+  - 리지가 Rowan에게
+     - 프로젝트 진행시 Rowan이 생각하는 부분을 명확하게 설명해주고, 저의 의견도 참고하여 같이 프로젝트를 진행하려고 노력하는 모습이 좋았습니다!
+     - 코드를 해석하는데 어려움이 있을 때, 공식문서를 하나씩 같이 살펴보며 설명해주어 덕분에 많은 공부를 할 수 있었습니다 👍
+     - 응원의 말로 자존감을 높여주었습니다 😁
+  - Rowan이 리지에게
+     - 문법적 / 구조적 개념에 대해 이해하려고 노력하는 모습이 멋있습니다 🔥
+     - 문제가 발생했을 때 해결 방안을 고안하는 속도가 빠릅니다 💫
+     - 토론식 대화가 잘 이루어질 수 있도록 답변해주셔서 좋았습니다 👍
 ----
 
 # 참고 링크
@@ -341,3 +574,10 @@ override func viewWillAppear(_ animated: Bool) {
 * [Swift Language Guide - Protocols](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/)
 * [Apple Developer Documentation - UIContentConfiguration](https://developer.apple.com/documentation/uikit/uicontentconfiguration)
 * [WWDC2020 - Modern Cell Configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)
+* [Accessibility-WWDC2019](https://developer.apple.com/videos/play/wwdc2019/257/) 
+* [Accessibility-WWDC2019](https://developer.apple.com/videos/play/wwdc2019/254/)
+* [Apple Developer Documentation - instantViewController(identifier:creator:)](https://developer.apple.com/documentation/uikit/uistoryboard/3213989-instantiateviewcontroller) 
+* [Swift Language Guide - Protocols; Initializer Requirements](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/protocols/#Initializer-Requirements)
+* [Swift Language Guide - Initialization](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/initialization)
+* [Swift Language Guide - Generic; Generic Functions](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/generics/#Generic-Functions)
+    


### PR DESCRIPTION
@yim2627 
안녕하세요 지성!! step3 완성하여 PR보냅니다 😀 
잘 부탁드립니다!

# 만국박람회 STEP 3 PR
# 고민했던 점 
## 첫 번째 화면 세로로 고정하기
특정 화면만 portrait orientation으로 고정하기 위해 여러가지 방법을 찾아보았습니다. 저희는 그 중에서 화면의 orientation에 대한 상태에 응답하는 것이 중요한 부분이라고 생각하여 AppDelegate를 활용한 방법을 선택하여 구현해 보았습니다.

```swift
class AppDelegate: UIResponder, UIApplicationDelegate {

    var shouldSupportAllOrientation = true

    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
        shouldSupportAllOrientation == true ? .all : .portrait
    }
}
```

```swift
final class ExpoViewController: UIViewController {
   
    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
}
```

<br/>

## TableViewCell Contents Accessibility 설정하기
테이블 뷰에 VoiceOver를 실행해보니 Cell을 통째로 인식해서 내부의 Label Title이 모두 합쳐져 cell.accessibilityLabel에 설정되어 있는 것을 확인했습니다.

cell 내부의 정보를 사용자에게 VoiceOver를 통해 들려주는 것이 바람직하다고 생각하여 해결 방법을 찾아보았습니다.

비공식 프로토콜 `UIAccessibilityContainer`를 채택하고 있는 클래스는 해당 클래스의 subview를 선택적으로 accessibiliyElement로 만들어줄 수 있는 메서드 / 프로퍼티를 제공하고 있습니다. 그 중에서 `var accessibilityElements: [Any]?`을 이용하였습니다.

1. cell 자체에 VoiceOver가 접근하지 못하도록 해준다.
2. cell.accessibilityElements에 label, imageView를 추가한다.
3. 각각의 subview들의 accessibilityProperty를 설정한다.

```swift
func setAccessibilityProperties(itemName: String, shortDescription: String) {
    self.itemNameLabel.accessibilityLabel = itemName
        
    self.shortDescriptionLabel.accessibilityLabel = "짧은 설명"
    self.shortDescriptionLabel.accessibilityValue = shortDescription
        
    self.itemImageView.isAccessibilityElement = true
    self.itemImageView.accessibilityLabel = itemName
    self.itemImageView.accessibilityTraits = .image
    self.itemImageView.accessibilityHint = "현재 셀을 선택하면 상세 화면으로 이동합니다."
        
    self.isAccessibilityElement = false
    self.accessibilityElements = [
        self.itemNameLabel!,
        self.shortDescriptionLabel!,
        self.itemImageView!
    ]
}
```

<br/>

# 조언이 필요한 점

## Description 화면 가로회전 시 height가 더 긴 이미지의 오토레이아웃 

- Description 화면에서 `imageView`와 `label`을 `stackView`에 넣어 오토레이아웃을 적용하였습니다. 이때 imageView에 들어오는 image의 크기에 따라 intrinsic size가 결정되어 어느곳을 기준으로 오토레이아웃을 잡을지 고민하였습니다. 
처음 선택한 방법은 아래 사진처럼 `label`의 `Top`을 `Contents view` 기준으로 150 수치만큼 떨어트려 그 공간만큼 `image`가 맞춰지도록 하였습니다. 그러나 화면을 가로로 회전할 때 `image` 크기가 화면에 맞게 늘어나지 않는 문제가 있었습니다.

<img src="https://i.imgur.com/pb8NkIk.png" width="400">

<br/>

- 그래서 그 문제를 해결하고자 두번째 방법(현재 적용방법)으로 `imageView`의 오토레이아웃을 `Frame Layout Guide`와 `width` 비율을 주고 `imageView`의 ratio를 1:1로 지정하였습니다. 이렇게 할 경우, 화면을 가로로 회전할 때 화면 크기에 맞춰 이미지 크기도 같이 증가하게 되었습니다. 그러나 이미지 크기별로 label간의 간격이 다 달라 이부분을 어떻게 해결할 수 있을지 지성의 조언이 필요합니다! 

<img src="https://i.imgur.com/gPcn92c.png" width="400">

<br/>

## Expo화면에서 numberOfLines에 따른 Dynamic type 오류

Dynamic type을 적용하고자 방문객, 개최지, 개최 기간과 그 설명을 다른 두개의 `label`로 나누어 글씨체를 다르게 적용하였습니다. 그리고 글씨크기가 커지면 자동줄바꿈 기능을 주고자 line 수를 0으로 지정하였는데 두개의 `label` 둘다 0으로 주었더니 오토레이아웃을 잡았어도 `label`간 간격이 벌어지는 문제가 발생하였습니다.
따라서 앞의 `label (방문객, 개최지, 개최기간)`은 글자 수가 많지 않아 글씨크기가 커져도 줄바꿈이 필요없어 line을 1로 하고 뒤에 길어지는 `label`의 line만 0으로 지정하였습니다.
오류는 해결하였지만, 왜 첫 번째 label의 line을 0으로 주었을 때, 여백이 생기는 이유는 잘 모르겠습니다. 어떤 부분을 고민해보면 좋을까요? 🤔

<img src="https://i.imgur.com/yOs4vmQ.png" width="300">

- 방문객 label (line: 0) / 방문객수 label (line: 0) 인 경우 공백 문제 발생.
- 개최지 label (line: 1) / 프랑스 파리 label (line: 0) 인 경우 문제 없음.

<br/>

# 해결하지 못한 점
## localization base 파일 오류
Accessibility 속성들을 정의하여 Accessibility Inspector를 통해 VoiceOver 기능의 시뮬레이션을 진행했습니다. 이때 활동학습 시간에 localization을 korean으로 설정하면 "button" 등의 기본 속성이 "버튼"으로 바뀌는 것을 시도해보고자 localization을 설정해주었는데요... 해당 변경사항을 원래대로 되돌리고 싶어 localization 속성을 삭제했더니 첫 번째 화면의 "한국의 출품작 보러가기" 버튼의 타이틀이 "Button"으로 고정되는 현상이 발생했습니다. 

저희는 의문이 들었습니다.. Xcode에서 String file을 삭제한 것 같은데도 계속해서 버튼의 타이틀이 Button 으로 고정되는 이유가 뭘까.. 추측하기로는 String file을 Xcode 내부적으로 갖고 있어서 따로 변경하지 않으면 해당 사항이 계속 저장된 상태로 남아있는 것 같습니다.

[Localization Tutorial](https://medium.com/lean-localization/ios-localization-tutorial-938231f9f881)이라는 글을 발견해서 알아보니 `Localizable.strings` 이라는 file을 통해 localization을 구현해 주는 것이라고 이해하게 되었습니다. 해당 파일은 기본적으로 생성되지 않으며 수정하고 싶을 때 개발자가 따로 Resource tab의 Strings File을 선택해 생성해야 한다고 합니다.

저희가 생각하고 있는게 맞을까요? 그리고 String file의 설정 기록을 남기지 않고 삭제하는 방법은 없을까요? 😢

일단 이번 문제는 git에서 reset, merge를 이용해 문제가 발생하기 이전 커밋 상태로 돌아가 해결했습니다.

<br/> 

## NavigationBar backbutton Accessibility 적용하는 방법

두 번째 화면에서 첫 번째 화면으로 돌아갈 때, navigationBar `<메인` 버튼을 눌러서 이동하게 되는데 이 버튼을 눌렀을 때 AccessibilityHint를 적용하려고 했습니다.
그래서 시도한 방법으로
- 두번째 화면의 setNavigationBar 메서드에 추가

- 메인이 곧 첫번째 화면의 navigationBarTitle 이므로 첫번째 화면의 setNavigationBar() 메서드에 추가

```swift
self.navigationItem.backBarButtonItem?.accessibilityHint
``` 

위의 두가지 방법을 시도하였으나 제대로 작동하지 않았습니다. 방법을 찾아보니 저희와 같은 고민을 한 사람은 많았지만 제대로 된 해결법을 찾지 못하여 지성에게 조언을 구하고 싶습니다..!