### PR TITLE
만국박람회 [STEP 3] Dasan, EtialMoon

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		286CCF332A4BF6D9008F6BB7 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286CCF322A4BF6D9008F6BB7 /* Decoder.swift */; };
 		286CCF362A4BFDAB008F6BB7 /* DecoderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286CCF352A4BFDAB008F6BB7 /* DecoderError.swift */; };
 		286CCF382A4C19A8008F6BB7 /* EntryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 286CCF372A4C19A8008F6BB7 /* EntryDetailViewController.swift */; };
+		28C922602A53A864002DF0CD /* Expo1900NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C9225F2A53A864002DF0CD /* Expo1900NavigationController.swift */; };
 		AC0931142A49BF4700ECA2BC /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0931132A49BF4700ECA2BC /* Entry.swift */; };
 		AC09311C2A49C30500ECA2BC /* EntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC09311B2A49C30500ECA2BC /* EntryTests.swift */; };
 		ACB8240E2A4B198800E2128B /* EntryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB8240D2A4B198800E2128B /* EntryTableViewCell.swift */; };
@@ -42,6 +43,7 @@
 		286CCF322A4BF6D9008F6BB7 /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
 		286CCF352A4BFDAB008F6BB7 /* DecoderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderError.swift; sourceTree = "<group>"; };
 		286CCF372A4C19A8008F6BB7 /* EntryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryDetailViewController.swift; sourceTree = "<group>"; };
+		28C9225F2A53A864002DF0CD /* Expo1900NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expo1900NavigationController.swift; sourceTree = "<group>"; };
 		AC0931132A49BF4700ECA2BC /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		AC0931192A49C30500ECA2BC /* EntryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EntryTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC09311B2A49C30500ECA2BC /* EntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryTests.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				C79FF4B82589F401005FB0FD /* MainViewController.swift */,
 				ACD80C692A4AF21E009B364C /* EntryListViewController.swift */,
 				286CCF372A4C19A8008F6BB7 /* EntryDetailViewController.swift */,
+				28C9225F2A53A864002DF0CD /* Expo1900NavigationController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -305,6 +308,7 @@
 				ACCF262B2A52DA0900A6147A /* UIViewController+.swift in Sources */,
 				AC0931142A49BF4700ECA2BC /* Entry.swift in Sources */,
 				286201692A49C96500ACCDD7 /* Introduction.swift in Sources */,
+				28C922602A53A864002DF0CD /* Expo1900NavigationController.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* MainViewController.swift in Sources */,
 				ACB8240E2A4B198800E2128B /* EntryTableViewCell.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,

--- a/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
+++ b/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
@@ -8,14 +8,6 @@
 import UIKit
 
 final class Expo1900NavigationController: UINavigationController {
-    override var shouldAutorotate: Bool {
-        guard let shouldAutorotate = self.topViewController?.shouldAutorotate else {
-            return self.shouldAutorotate
-        }
-        
-        return shouldAutorotate
-    }
-    
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         guard let supportedInterfaceOrientations = self.topViewController?.supportedInterfaceOrientations else {
             return self.supportedInterfaceOrientations

--- a/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
+++ b/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
@@ -9,10 +9,18 @@ import UIKit
 
 final class Expo1900NavigationController: UINavigationController {
     override var shouldAutorotate: Bool {
-        return (self.topViewController?.shouldAutorotate)!
+        guard let shouldAutorotate = self.topViewController?.shouldAutorotate else {
+            return self.shouldAutorotate
+        }
+        
+        return shouldAutorotate
     }
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return (self.topViewController?.supportedInterfaceOrientations)!
+        guard let supportedInterfaceOrientations = self.topViewController?.supportedInterfaceOrientations else {
+            return self.supportedInterfaceOrientations
+        }
+        
+        return supportedInterfaceOrientations
     }
 }

--- a/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
+++ b/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
@@ -1,0 +1,18 @@
+//
+//  Expo1900NavigationController.swift
+//  Expo1900
+//
+//  Created by 조호준 on 2023/07/04.
+//
+
+import UIKit
+
+class Expo1900NavigationController: UINavigationController {
+    override var shouldAutorotate: Bool {
+        return (self.topViewController?.shouldAutorotate)!
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return (self.topViewController?.supportedInterfaceOrientations)!
+    }
+}

--- a/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
+++ b/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
@@ -2,12 +2,12 @@
 //  Expo1900NavigationController.swift
 //  Expo1900
 //
-//  Created by 조호준 on 2023/07/04.
+//  Created by Dasan & Moo on 2023/07/04.
 //
 
 import UIKit
 
-class Expo1900NavigationController: UINavigationController {
+final class Expo1900NavigationController: UINavigationController {
     override var shouldAutorotate: Bool {
         return (self.topViewController?.shouldAutorotate)!
     }

--- a/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
+++ b/Expo1900/Expo1900/Controller/Expo1900NavigationController.swift
@@ -2,7 +2,7 @@
 //  Expo1900NavigationController.swift
 //  Expo1900
 //
-//  Created by Dasan & Moo on 2023/07/04.
+//  Created by Dasan & Moon on 2023/07/04.
 //
 
 import UIKit

--- a/Expo1900/Expo1900/Controller/Extension/UIViewController+.swift
+++ b/Expo1900/Expo1900/Controller/Extension/UIViewController+.swift
@@ -10,16 +10,9 @@ import UIKit
 extension UIViewController {
     func showDecoderErrorAlert(_ error: Error) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
         
-        switch error {
-        case DecoderError.notFoundAsset:
-            alert.message = DecoderError.notFoundAsset.description
-        case DecoderError.decodeFailed:
-            alert.message = DecoderError.decodeFailed.description
-        default:
-            alert.message = DecoderError.unexpectedError.description
-        }
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        alert.message = error.localizedDescription
         
         present(alert, animated: true)
     }

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -28,12 +28,8 @@ final class MainViewController: UIViewController {
         configureNavigation()
     }
     
-    override var shouldAutorotate: Bool {
-        return true
-    }
-    
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return [.portrait]
+        return .portrait
     }
 
     @IBAction func touchUpGoToEntryListButton(_ sender: UIButton) {

--- a/Expo1900/Expo1900/Controller/MainViewController.swift
+++ b/Expo1900/Expo1900/Controller/MainViewController.swift
@@ -27,6 +27,14 @@ final class MainViewController: UIViewController {
         
         configureNavigation()
     }
+    
+    override var shouldAutorotate: Bool {
+        return true
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return [.portrait]
+    }
 
     @IBAction func touchUpGoToEntryListButton(_ sender: UIButton) {
         let storyboard = UIStoryboard(name: StoryboardNamespace.Name.main, bundle: Bundle.main)

--- a/Expo1900/Expo1900/Error/DecoderError.swift
+++ b/Expo1900/Expo1900/Error/DecoderError.swift
@@ -5,12 +5,14 @@
 //  Created by Dasan & Moon on 2023/06/28.
 //
 
-enum DecoderError: Error {
+import Foundation
+
+enum DecoderError: LocalizedError {
     case notFoundAsset
     case decodeFailed
     case unexpectedError
     
-    var description: String {
+    var errorDescription: String? {
         switch self {
         case .notFoundAsset:
             return "에셋을 찾을 수 없습니다."

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -211,22 +211,21 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="LFn-C0-zBc">
-                                        <rect key="frame" x="20" y="0.0" width="353" height="182"/>
+                                        <rect key="frame" x="20" y="0.0" width="353" height="177.33333333333334"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bHg-T3-Rsa">
-                                                <rect key="frame" x="0.0" y="79" width="353" height="54.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="79" width="353" height="50"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" priority="1" constant="1" id="cer-nX-zmk"/>
+                                                </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vnH-rL-ibm">
-                                                <rect key="frame" x="0.0" y="141.66666666666666" width="353" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="137" width="353" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" secondItem="LFn-C0-zBc" secondAttribute="height" multiplier="0.1" priority="1" id="bOn-gM-fcB"/>
-                                            <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" relation="lessThanOrEqual" secondItem="LFn-C0-zBc" secondAttribute="height" multiplier="0.3" priority="800" id="dbY-U5-9D4"/>
-                                        </constraints>
                                         <edgeInsets key="layoutMargins" top="20" left="0.0" bottom="20" right="0.0"/>
                                     </stackView>
                                 </subviews>
@@ -234,6 +233,7 @@
                                     <constraint firstItem="LFn-C0-zBc" firstAttribute="trailing" secondItem="EZD-49-Vci" secondAttribute="trailing" constant="20" id="7pV-PA-K1y"/>
                                     <constraint firstItem="LFn-C0-zBc" firstAttribute="bottom" secondItem="EZD-49-Vci" secondAttribute="bottom" id="Djx-tR-vrV"/>
                                     <constraint firstItem="LFn-C0-zBc" firstAttribute="centerX" secondItem="nw4-w2-dN9" secondAttribute="centerX" id="T9t-qJ-NWU"/>
+                                    <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" relation="lessThanOrEqual" secondItem="00A-U0-5qi" secondAttribute="height" multiplier="0.5" id="gOT-JB-4Ax"/>
                                     <constraint firstItem="LFn-C0-zBc" firstAttribute="top" secondItem="EZD-49-Vci" secondAttribute="top" id="yKC-uv-5Ep"/>
                                     <constraint firstItem="LFn-C0-zBc" firstAttribute="leading" secondItem="EZD-49-Vci" secondAttribute="leading" constant="20" id="ySC-lX-era"/>
                                 </constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -265,10 +265,10 @@
             </objects>
             <point key="canvasLocation" x="2449.6183206106871" y="-46.478873239436624"/>
         </scene>
-        <!--Navigation Controller-->
+        <!--Expo1900 Navigation Controller-->
         <scene sceneID="c6f-CT-m9n">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pxi-iO-3ZG" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="pxi-iO-3ZG" customClass="Expo1900NavigationController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="N3e-iR-Y5u">
                         <rect key="frame" x="0.0" y="59" width="393" height="44"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -210,23 +210,23 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nw4-w2-dN9">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="LFn-C0-zBc">
-                                        <rect key="frame" x="20" y="0.0" width="353" height="228.33333333333334"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="LFn-C0-zBc">
+                                        <rect key="frame" x="20" y="0.0" width="353" height="327.33333333333331"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bHg-T3-Rsa">
-                                                <rect key="frame" x="76.666666666666686" y="0.0" width="200" height="200"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="200" id="9Im-Za-BLy"/>
-                                                    <constraint firstAttribute="width" constant="200" id="BSx-Fr-Szh"/>
-                                                </constraints>
+                                                <rect key="frame" x="0.0" y="79" width="353" height="200"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vnH-rL-ibm">
-                                                <rect key="frame" x="156" y="208" width="41.333333333333343" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vnH-rL-ibm">
+                                                <rect key="frame" x="0.0" y="287" width="353" height="20.333333333333314"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" secondItem="LFn-C0-zBc" secondAttribute="height" multiplier="0.3" priority="1" id="RsK-Bb-IyH"/>
+                                        </constraints>
+                                        <edgeInsets key="layoutMargins" top="20" left="0.0" bottom="20" right="0.0"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -23,30 +23,26 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="an6-nR-6hk">
                                         <rect key="frame" x="20" y="0.0" width="353" height="438"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fvg-D6-Ogp">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.050000000000000003" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fvg-D6-Ogp">
                                                 <rect key="frame" x="0.0" y="0.0" width="353" height="40.666666666666664"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="dyr-94-fGc">
-                                                <rect key="frame" x="106.66666666666669" y="48.666666666666657" width="140" height="200"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="140" id="GXB-EZ-AJB"/>
-                                                    <constraint firstAttribute="height" constant="200" id="xxi-vD-Qmg"/>
-                                                </constraints>
+                                                <rect key="frame" x="98" y="48.666666666666657" width="157" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="sms-Vf-MbK">
-                                                <rect key="frame" x="116.66666666666666" y="256.66666666666669" width="120" height="26.333333333333314"/>
+                                                <rect key="frame" x="115.33333333333334" y="256.66666666666669" width="122.66666666666666" height="26.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l51-nV-pQ7">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l51-nV-pQ7">
                                                         <rect key="frame" x="0.0" y="0.0" width="57.333333333333336" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tzy-kk-EVB">
-                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="54.666666666666657" height="26.333333333333332"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tzy-kk-EVB">
+                                                        <rect key="frame" x="65.333333333333314" y="0.0" width="57.333333333333343" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -54,16 +50,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Ows-uz-jfo">
-                                                <rect key="frame" x="113.66666666666666" y="291" width="125.66666666666666" height="26.333333333333314"/>
+                                                <rect key="frame" x="112.33333333333336" y="291" width="128.66666666666663" height="26.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2C-cg-KIo">
-                                                        <rect key="frame" x="0.0" y="0.0" width="57.333333333333336" height="26.333333333333332"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2C-cg-KIo">
+                                                        <rect key="frame" x="0.0" y="0.0" width="60.333333333333336" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fSy-YK-vrS">
-                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="60.333333333333343" height="26.333333333333332"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fSy-YK-vrS">
+                                                        <rect key="frame" x="68.333333333333314" y="0.0" width="60.333333333333343" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -71,23 +67,23 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="OHj-3M-lAb">
-                                                <rect key="frame" x="100.33333333333333" y="325.33333333333331" width="152.66666666666669" height="26.333333333333314"/>
+                                                <rect key="frame" x="91.333333333333329" y="325.33333333333331" width="170.66666666666669" height="26.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PcU-d4-qWk">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PcU-d4-qWk">
                                                         <rect key="frame" x="0.0" y="0.0" width="81.333333333333329" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x9l-cD-mat">
-                                                        <rect key="frame" x="89.333333333333329" y="0.0" width="63.333333333333329" height="26.333333333333332"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x9l-cD-mat">
+                                                        <rect key="frame" x="89.333333333333343" y="0.0" width="81.333333333333343" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XIl-BG-S4C">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XIl-BG-S4C">
                                                 <rect key="frame" x="134" y="359.66666666666669" width="85.333333333333314" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
@@ -134,6 +130,7 @@
                                     <constraint firstItem="aWY-lM-XP8" firstAttribute="top" secondItem="an6-nR-6hk" secondAttribute="top" id="8u6-60-1hh"/>
                                     <constraint firstItem="an6-nR-6hk" firstAttribute="centerX" secondItem="8zm-n4-pEr" secondAttribute="centerX" id="SLD-LK-02H"/>
                                     <constraint firstItem="an6-nR-6hk" firstAttribute="trailing" secondItem="aWY-lM-XP8" secondAttribute="trailing" constant="20" id="crW-nO-eIr"/>
+                                    <constraint firstItem="dyr-94-fGc" firstAttribute="width" secondItem="5x6-hh-MUY" secondAttribute="width" multiplier="0.4" id="g9S-Bx-Dru"/>
                                     <constraint firstItem="an6-nR-6hk" firstAttribute="bottom" secondItem="aWY-lM-XP8" secondAttribute="bottom" id="yD4-i9-I2a"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="aWY-lM-XP8"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -211,20 +211,21 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="LFn-C0-zBc">
-                                        <rect key="frame" x="20" y="0.0" width="353" height="327.33333333333331"/>
+                                        <rect key="frame" x="20" y="0.0" width="353" height="182"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bHg-T3-Rsa">
-                                                <rect key="frame" x="0.0" y="79" width="353" height="200"/>
+                                                <rect key="frame" x="0.0" y="79" width="353" height="54.666666666666657"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vnH-rL-ibm">
-                                                <rect key="frame" x="0.0" y="287" width="353" height="20.333333333333314"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vnH-rL-ibm">
+                                                <rect key="frame" x="0.0" y="141.66666666666666" width="353" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" secondItem="LFn-C0-zBc" secondAttribute="height" multiplier="0.3" priority="1" id="RsK-Bb-IyH"/>
+                                            <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" secondItem="LFn-C0-zBc" secondAttribute="height" multiplier="0.1" priority="1" id="bOn-gM-fcB"/>
+                                            <constraint firstItem="bHg-T3-Rsa" firstAttribute="height" relation="lessThanOrEqual" secondItem="LFn-C0-zBc" secondAttribute="height" multiplier="0.3" priority="800" id="dbY-U5-9D4"/>
                                         </constraints>
                                         <edgeInsets key="layoutMargins" top="20" left="0.0" bottom="20" right="0.0"/>
                                     </stackView>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -21,28 +21,28 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="an6-nR-6hk">
-                                        <rect key="frame" x="20" y="0.0" width="353" height="438"/>
+                                        <rect key="frame" x="20" y="0.0" width="353" height="462.33333333333331"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.050000000000000003" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fvg-D6-Ogp">
-                                                <rect key="frame" x="0.0" y="0.0" width="353" height="40.666666666666664"/>
+                                                <rect key="frame" x="0.0" y="19.999999999999996" width="353" height="40.666666666666657"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="dyr-94-fGc">
-                                                <rect key="frame" x="98" y="48.666666666666657" width="157" height="200"/>
+                                                <rect key="frame" x="98" y="68.666666666666686" width="157" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="sms-Vf-MbK">
-                                                <rect key="frame" x="115.33333333333334" y="256.66666666666669" width="122.66666666666666" height="26.333333333333314"/>
+                                                <rect key="frame" x="116.66666666666666" y="276.66666666666669" width="120" height="26.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l51-nV-pQ7">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l51-nV-pQ7">
                                                         <rect key="frame" x="0.0" y="0.0" width="57.333333333333336" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="visitors" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tzy-kk-EVB">
-                                                        <rect key="frame" x="65.333333333333314" y="0.0" width="57.333333333333343" height="26.333333333333332"/>
+                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="54.666666666666657" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -50,16 +50,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Ows-uz-jfo">
-                                                <rect key="frame" x="112.33333333333336" y="291" width="128.66666666666663" height="26.333333333333314"/>
+                                                <rect key="frame" x="113.66666666666666" y="311" width="125.66666666666666" height="26.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2C-cg-KIo">
-                                                        <rect key="frame" x="0.0" y="0.0" width="60.333333333333336" height="26.333333333333332"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2C-cg-KIo">
+                                                        <rect key="frame" x="0.0" y="0.0" width="57.333333333333336" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="location" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fSy-YK-vrS">
-                                                        <rect key="frame" x="68.333333333333314" y="0.0" width="60.333333333333343" height="26.333333333333332"/>
+                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="60.333333333333343" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -67,16 +67,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="OHj-3M-lAb">
-                                                <rect key="frame" x="91.333333333333329" y="325.33333333333331" width="170.66666666666669" height="26.333333333333314"/>
+                                                <rect key="frame" x="100.33333333333333" y="345.33333333333331" width="152.66666666666669" height="26.333333333333314"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PcU-d4-qWk">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PcU-d4-qWk">
                                                         <rect key="frame" x="0.0" y="0.0" width="81.333333333333329" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="duration" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x9l-cD-mat">
-                                                        <rect key="frame" x="89.333333333333343" y="0.0" width="81.333333333333343" height="26.333333333333332"/>
+                                                        <rect key="frame" x="89.333333333333329" y="0.0" width="63.333333333333329" height="26.333333333333332"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -84,23 +84,19 @@
                                                 </subviews>
                                             </stackView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XIl-BG-S4C">
-                                                <rect key="frame" x="134" y="359.66666666666669" width="85.333333333333314" height="20.333333333333314"/>
+                                                <rect key="frame" x="134" y="379.66666666666669" width="85.333333333333314" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="42" translatesAutoresizingMaskIntoConstraints="NO" id="HWj-Z2-UNe">
-                                                <rect key="frame" x="24" y="388" width="305" height="50"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HWj-Z2-UNe">
+                                                <rect key="frame" x="0.0" y="408" width="353" height="34.333333333333314"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="AkX-At-pe0">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="50" id="eP8-A3-weg"/>
-                                                            <constraint firstAttribute="height" constant="50" id="tTN-C3-AyG"/>
-                                                        </constraints>
+                                                        <rect key="frame" x="0.0" y="0.0" width="70.666666666666671" height="34.333333333333336"/>
                                                     </imageView>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Rk-b0-IVA">
-                                                        <rect key="frame" x="92" y="0.0" width="121" height="50"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="800" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Rk-b0-IVA">
+                                                        <rect key="frame" x="78.666666666666671" y="0.0" width="195.66666666666663" height="34.333333333333336"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기">
                                                             <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -110,19 +106,20 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="zF8-CL-YKL">
-                                                        <rect key="frame" x="255" y="0.0" width="50" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="1hg-RA-avV"/>
-                                                            <constraint firstAttribute="width" constant="50" id="eTo-Lf-AIZ"/>
-                                                        </constraints>
+                                                        <rect key="frame" x="282.33333333333331" y="0.0" width="70.666666666666686" height="34.333333333333336"/>
                                                     </imageView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="zF8-CL-YKL" firstAttribute="width" secondItem="HWj-Z2-UNe" secondAttribute="width" multiplier="0.2" id="m6M-SL-jYd"/>
+                                                    <constraint firstItem="AkX-At-pe0" firstAttribute="width" secondItem="HWj-Z2-UNe" secondAttribute="width" multiplier="0.2" id="xrb-x1-936"/>
+                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="Fvg-D6-Ogp" firstAttribute="leading" secondItem="an6-nR-6hk" secondAttribute="leading" id="N1C-vV-ogQ"/>
                                             <constraint firstAttribute="trailing" secondItem="Fvg-D6-Ogp" secondAttribute="trailing" id="NRU-2Y-8ou"/>
                                         </constraints>
+                                        <edgeInsets key="layoutMargins" top="20" left="0.0" bottom="20" right="0.0"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -15,7 +15,9 @@ final class EntryTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        setUpTitleAndShortDescriptionLabel()
+        setUpEntryImageView()
+        setUpEntryNameLabel()
+        setUpShortDescriptionLabel()
         
         let entryTextStackView = configureEntryTextStackView(arrangedSubviews: [entryNameLabel, shortDescriptionLabel])
         
@@ -29,16 +31,22 @@ final class EntryTableViewCell: UITableViewCell {
     }
     
     func configureCell(with entry: Entry) {
+        entryImageView.image = UIImage(named: entry.imageName)
         entryNameLabel.text = entry.name
         shortDescriptionLabel.text = entry.shortDescription
-        entryImageView.image = UIImage(named: entry.imageName)
     }
 
-    private func setUpTitleAndShortDescriptionLabel() {
+    private func setUpEntryImageView() {
+        entryImageView.contentMode = .scaleAspectFit
+    }
+    
+    private func setUpEntryNameLabel() {
         entryNameLabel.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         entryNameLabel.adjustsFontForContentSizeCategory = true
         entryNameLabel.numberOfLines = 0
-        
+    }
+    
+    private func setUpShortDescriptionLabel() {
         shortDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .body)
         shortDescriptionLabel.adjustsFontForContentSizeCategory = true
         shortDescriptionLabel.numberOfLines = 0
@@ -58,7 +66,6 @@ final class EntryTableViewCell: UITableViewCell {
 extension EntryTableViewCell {
     private func setUpEntryImageViewConstraints() {
         entryImageView.translatesAutoresizingMaskIntoConstraints = false
-        entryImageView.contentMode = .scaleAspectFit
         NSLayoutConstraint.activate([
             entryImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             entryImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -37,6 +37,7 @@ final class EntryTableViewCell: UITableViewCell {
     private func setUpTitleAndShortDescriptionLabel() {
         entryNameLabel.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         entryNameLabel.adjustsFontForContentSizeCategory = true
+        entryNameLabel.numberOfLines = 0
         
         shortDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .body)
         shortDescriptionLabel.adjustsFontForContentSizeCategory = true

--- a/Expo1900/Expo1900/View/EntryTableViewCell.swift
+++ b/Expo1900/Expo1900/View/EntryTableViewCell.swift
@@ -36,8 +36,10 @@ final class EntryTableViewCell: UITableViewCell {
 
     private func setUpTitleAndShortDescriptionLabel() {
         entryNameLabel.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        entryNameLabel.adjustsFontForContentSizeCategory = true
         
         shortDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        shortDescriptionLabel.adjustsFontForContentSizeCategory = true
         shortDescriptionLabel.numberOfLines = 0
     }
     
@@ -55,22 +57,22 @@ final class EntryTableViewCell: UITableViewCell {
 extension EntryTableViewCell {
     private func setUpEntryImageViewConstraints() {
         entryImageView.translatesAutoresizingMaskIntoConstraints = false
+        entryImageView.contentMode = .scaleAspectFit
         NSLayoutConstraint.activate([
-            entryImageView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            entryImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            entryImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            entryImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 15),
             entryImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
-            entryImageView.widthAnchor.constraint(equalTo: entryImageView.heightAnchor),
-            entryImageView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor)
+            entryImageView.heightAnchor.constraint(lessThanOrEqualToConstant: 80),
         ])
     }
     
     private func setUpEntryTextStackViewConstraints(for stackView: UIStackView) {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: entryImageView.trailingAnchor, constant: 8),
-            stackView.topAnchor.constraint(equalTo: entryImageView.topAnchor),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            stackView.leadingAnchor.constraint(equalTo: entryImageView.trailingAnchor, constant: 10),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -15),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15)
         ])
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🇫🇷🇰🇷 만국박람회
 
 ## 🍀 소개
-`Dasan`과 `EtialMoon`이 만든 만국박람회 앱입니다. 이 앱은 1990 만국박람회에 출품된 한국의 출품작들을 볼 수 있습니다.
+`Dasan`과 `EtialMoon`이 만든 만국박람회입니다. `파리 만국박람회 1900`에 대한 소개와 한국 출품작들을 볼 수 있습니다.
 
 <br>
 
@@ -9,8 +9,10 @@
 1. [팀원](#-팀원)
 2. [타임라인](#-타임라인)
 3. [시각화된 프로젝트 구조](#-시각화된-프로젝트-구조)
-4. [트러블 슈팅](#-트러블-슈팅)
-5. [참고 링크](#-참고-링크)
+4. [실행 화면](#-실행-화면)
+5. [트러블 슈팅](#-트러블-슈팅)
+6. [참고 링크](#-참고-링크)
+7. [팀 회고](#-팀-회고)
 
 <br>
 
@@ -30,6 +32,11 @@
 |2023.06.28.(수)| - 레이블 내 문자열 수정 및 하위 항목 레이블 추가<br> -`EntryTableViewCell`에 `accessory` 추가 <br> - 스토리보드에 출품작 상세화면 추가 <br> - `EntryDetailViewController` 추가 및 `화면전환` 구현 | 
 |2023.06.29.(목)| - 전체적인 리펙토링 진행 |
 |2023.06.30.(금)| - README 작성 <br> - 피드백 요청사항 반영 및 전체적인 리펙토링 진행 |
+|2023.07.03.(월)| - 각 뷰에서 중복되는 에러 처리를 `extension`으로 분리|
+|2023.07.04.(화)| - 각 뷰에 `Dynamic Type` 및 `오토레이아웃` 적용|
+|2023.07.05.(수)| - `불필요한 코드` 제거 및 전체적인 `오토레이아웃` 점검| 
+|2023.07.06.(목)| - `에러`와 관련된 리펙토링 진행|
+|2023.07.07.(금)| - README 작성 <br> - 피드백 요청사항 반영 및 전체적인 리펙토링 진행 |
 
 <br>
 
@@ -37,8 +44,20 @@
 
 ### Class Diagram
 <p>
-<img width="800" src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/e17c106a-a026-496a-9494-1340c9bb96e0">
+<img width="800" src="https://github-production-user-asset-6210df.s3.amazonaws.com/106504779/251443920-d64269b9-81fc-4e29-8e3d-1e68762b6bd8.png">
 </p>
+
+<br>
+
+## 💻 실행 화면 
+
+|메인 화면|한국의 출품작 화면|
+|:--:|:--:|
+|<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/106504779/251444354-ce5d98bc-15c2-4fd3-b94c-36ec559c16cb.gif" width="400">|<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/106504779/251444591-1c7af31c-fbf9-4471-8928-c64f480b9e09.gif" width="400">|
+|출품작 상세 화면|Dynamic Type|
+|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/107505eb-23b6-44ef-a376-427f7d995aff.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/cd5daba0-bb45-4e7d-af62-a54099c8826e.gif" width="400">|
+|실행 화면(iPhone SE)|Dynamic Type(iPhone SE)|
+|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/c6306406-e495-4dfb-96a1-1460300ac2de.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/22e370ea-bcd5-4714-97b3-3a6703068d2c.gif" width="400">|
 
 </br>
 
@@ -196,16 +215,75 @@
         }
     }
     ```
+
+
 <br>
+
+### 6️⃣ 화면 전환 고정
+
+⚠️ **문제점** <br>
+- 처음엔 `AppDelegate` 내의 `application(_ :supportedInterfaceOrientationsFor:)`에 아래와 같이 코드를 작성하였더니 `모든 화면`이 `portrait`로 고정되었습니다.
+- `application(_ :supportedInterfaceOrientationsFor:)` 메서드 내에 로직을 추가하여 `첫번째 화면`만 고정되도록 할 수 있었지만, 화면 방향과 관련된 로직을 추가하는 것은 **코드가 복잡**해지고 **유지 보수가 어려워질 수 있다**고 판단하여 다른 방법을 모색하였습니다.
+- Before
+    ```swift
+    // AppDelegate.swift
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
+    ```
+
+✅ **해결방법** <br>
+- `UIViewController`가 지원하는 인터페이스 방향 프로퍼티인 [supportedInterfaceOrientations](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations)을 사용하였습니다. 이 프로퍼티를 `재정의`하면 **View Controller가 지원하는 방향을 선언**할 수 있는데, 기기 방향이 변경되면 `the root view controller` 또는 `the topmost modal view controller`에서 이 메서드를 호출합니다.
+- 이에 `root view`인 `Expo1900NavigationController`에서 `supportedInterfaceOrientations`을 `topViewController`의 방향으로 선언하도록 재정의를 한 뒤,
+- 방향을 고정하고자 하였던 `MainViewController`에서 `supportedInterfaceOrientations`가 `세로 방향(portrait)`만 반환하도록 재정의해주었습니다.
+
+- After
+    ```swift
+    // Expo1900NavigationController.swift
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard let supportedInterfaceOrientations = self.topViewController?.supportedInterfaceOrientations else {
+            return self.supportedInterfaceOrientations
+        }
+
+        return supportedInterfaceOrientations
+    }
+    
+    ```
+    ```swift
+    // MainViewController.swift
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+    ```
+
+<br>
+
 
 ## 📚 참고 링크
 
-- [🍎Apple Docs: JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
-- [🍎Apple Docs: Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
-- [🍎Apple Docs: scrollEdgeAppearance](https://developer.apple.com/documentation/uikit/uinavigationbar/3198027-scrolledgeappearance)
-- [🍎Apple Docs: backBarButtonItem](https://developer.apple.com/documentation/uikit/uinavigationitem/1624958-backbarbuttonitem)
-- [🍎Apple Docs: init(coder:)](https://developer.apple.com/documentation/foundation/nscoding/1416145-init)
-- [🌐Blog: init(coder:)](https://babbab2.tistory.com/171)
-- [🌐boostcourse: JSON 다루기](https://www.boostcourse.org/mo326/lecture/20146)
+- [🍎 Apple Docs: JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)
+- [🍎 Apple Docs: Using JSON with Custom Types](https://developer.apple.com/documentation/foundation/archives_and_serialization/using_json_with_custom_types)
+- [🍎 Apple Docs: scrollEdgeAppearance](https://developer.apple.com/documentation/uikit/uinavigationbar/3198027-scrolledgeappearance)
+- [🍎 Apple Docs: backBarButtonItem](https://developer.apple.com/documentation/uikit/uinavigationitem/1624958-backbarbuttonitem)
+- [🍎 Apple Docs: init(coder:)](https://developer.apple.com/documentation/foundation/nscoding/1416145-init)
+- [🍎 Apple Docs: supportedInterfaceOrientations](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations)
+- [🍎 Apple Docs: shouldAutorotate](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621419-shouldautorotate)
+- [🌐 Blog: iOS 디바이스 회전 처리에 대한 정리](https://jongwonwoo.medium.com/ios-%EB%94%94%EB%B0%94%EC%9D%B4%EC%8A%A4-%ED%9A%8C%EC%A0%84-%EC%B2%98%EB%A6%AC%EC%97%90-%EB%8C%80%ED%95%9C-%EC%A0%95%EB%A6%AC-340f37204a27)
+- [🌐 Blog: iOS Device 방향 처리](https://velog.io/@wonhee010/%ED%8A%B9%EC%A0%95-ViewController%EC%97%90%EC%84%9C-%ED%99%94%EB%A9%B4-%ED%9A%8C%EC%A0%84-%EC%B2%98%EB%A6%AC)
+- [🌐 Blog: init(coder:)](https://babbab2.tistory.com/171)
+- [🌐 boostcourse: JSON 다루기](https://www.boostcourse.org/mo326/lecture/20146)
+
 
 <br>
+
+## 👥 팀 회고
+### 칭찬할 부분
+
+
+### 개선해야할 부분
+
+
+### 서로에게 하고 싶은 말
+- To. Dasan
+
+- To. EtialMoon

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@
 
 |메인 화면|한국의 출품작 화면|
 |:--:|:--:|
-|<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/106504779/251444354-ce5d98bc-15c2-4fd3-b94c-36ec559c16cb.gif" width="400">|<img src="https://github-production-user-asset-6210df.s3.amazonaws.com/106504779/251444591-1c7af31c-fbf9-4471-8928-c64f480b9e09.gif" width="400">|
-|출품작 상세 화면|Dynamic Type|
-|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/107505eb-23b6-44ef-a376-427f7d995aff.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/cd5daba0-bb45-4e7d-af62-a54099c8826e.gif" width="400">|
-|실행 화면(iPhone SE)|Dynamic Type(iPhone SE)|
-|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/c6306406-e495-4dfb-96a1-1460300ac2de.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/22e370ea-bcd5-4714-97b3-3a6703068d2c.gif" width="400">|
+|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/05e345a6-ec8d-431a-baa9-c9230523ab64.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/60206299-1327-467c-b051-6998dc96e8ea.gif" width="400">|
+|**출품작 상세 화면**|**Dynamic Type**|
+|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/9bd7c395-d728-443b-a9f3-0e87e52b7b85.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/cd5daba0-bb45-4e7d-af62-a54099c8826e.gif" width="400">|
+|**실행 화면(iPhone SE)**|**Dynamic Type(iPhone SE)**|
+|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/cfe44371-c776-4c02-83d7-b2c8cde0fe4c.gif" width="400">|<img src="https://github.com/DasanKim/ios-exposition-universelle/assets/106504779/679c83fc-94c0-47fc-96f8-15f840884494.gif" width="400">|
 
 </br>
 
@@ -278,12 +278,17 @@
 
 ## 👥 팀 회고
 ### 칭찬할 부분
-
-
-### 개선해야할 부분
-
+- 서로 시간 약속을 잘 지킨 점
+- 생활 패턴이 비슷한 것을 활용하여 효율적으로 프로젝트를 진행한 점
+- PR를 보내기 전, 다시 한번 요구사항 점검 및 코드 점검을 진행하여 실수를 줄인 점
+- 프로젝트를 진행하면서도 학습활동 예습 시간을 따로 마련해 놓은 점 
 
 ### 서로에게 하고 싶은 말
 - To. Dasan
+    - 제 성격이 좀 느린 편인데 잘 기다려 주시고 놓칠 수 있는 부분까지 꼼꼼히 봐주셔서 감사합니다.🙏
+    - 2주 동안 수고 많으셨습니다!👍
 
 - To. EtialMoon
+    - 문교수님...🥹 프로젝트를 진행하면서 쾌적(?)하다고 느끼게 된 것은 문의 멋진 코딩실력을 포함하여 탁월한 방향 제시가 있었기 때문인 것 같습니다!
+    - 또한 함께 성장하기 위하여 저의 걸음을 맞춰주시고, 제가 질문을 하기 전에 먼저 설명을 해주셨던 부분에서 문의 따뜻한 마음을 느낄 수 있었습니다👍
+    - 2주라는 시간이 정말 아쉽네요... 진심으로 2주동안 감사했습니다 문! 앞으로 자주 찾아뵐게요 교수님🥹


### PR DESCRIPTION
안녕하세요 그린!🍏 (@GREENOVER)

STEP3 PR을 보내드립니다. 
어느덧 STEP3이여서 그린과 함께 할 수 있는 시간이 얼마 남지 않았다는 것이 아쉽습니다...😭
남은 시간 동안 그린이 해주시는 말씀 더 새겨듣겠습니다!

감사합니다☺️

-----

# STEP 3

## 🔍 고민되었던 점

### 1.  autoshrink vs lines
모든 화면에 `Dynamic Type`을 적용하기 위하여 `출품작 목록 화면`에도 `Dynamic Type`을 적용하였습니다. 또한 각 Label `attribute`의 [Lines(NumberOfLines)](https://developer.apple.com/documentation/uikit/uilabel/1620539-numberoflines)을 `0`으로 주어 글자 크기가 늘어나더라도, 최대 줄 수 제한 없이 필요한 만큼의 줄을 사용하게 하였습니다.
   - 하지만 `출품작 목록 화면`에서 `autoshrink`가 적용된 `Title`에 `Lines`를 `0`으로 주었을 때, `autoshrink`가 무시되는 것을 알게되었습니다. `Title`의 폰트 크기가 레이블 크기에 맞춰지지 않고 필요한 만큼 줄을 사용하게 되어, 원하는 오토레이아웃을 얻을 수 없었습니다.
   - 반대로 `Title`에 `autoshrink`을 적용하고 `Lines`를 `2`로 설정해주면, `Accessibility`에서 `Title`만 폰트 크기가 적용되지 않았습니다.

`요구사항`과 `Accessibility` 중 모두 가져갈 수 없는 상황에서 둘 중에 `요구사항`을 지키기로 결정하여, `Title`에만 `autoshrink`를 적용하였습니다.

### 2. Priority
세번째 화면의 이미지뷰의 높이가 전체 화면의 3분의1 정도를 차지하는 것 같았습니다. 이미지뷰의 `Equal Heights Constraint`를 스택뷰의 0.3으로 맞추고 이미지가 화면의 3분의 1보다 작을 수도 있기 때문에 `Priority`를 1로 설정했습니다. 이 때, 세로 이미지의 높이가 커지거나 레이블의 높이가 커지는 일이 생겼습니다. 이 문제를 다음과 같은 방법으로 해결했습니다.
- 스크롤뷰의 `y position`에 대한 에러가 안 나오게 하기 위해 이미지뷰의 `Equal Heights Constraint`를 스택뷰의 0.1로 설정하고 `Priority`를 1로 설정했습니다.
- 이미지뷰의 높이를 화면의 3분의 1보다 작게 하기 위해 `Less Then or Equal Heights Constraint`를 스택뷰의 0.3로 설정하고 `Priority`를 800으로 설정했습니다.
- 레이블의 높이가 커지는 것을 막기 위해 `Vertical Hugging Priority`를 900으로 설정했습니다.

<br>

## 🙏 조언을 얻고 싶은 부분
### 1. 화면 전환 고정
`supportedInterfaceOrientations` 공식 문서에는 '시스템은 뷰 컨트롤러의 `shouldAutorotate` 메서드가 `true`를 반환하는 경우에만 이 메서드를 호출 한다'고 나와있습니다. 그런데 `shouldAutorotate` 문서를 보면 `Deprecated`라고 되어 있습니다. 실제로 `shouldAutorotate`를 사용하지 않고 `supportedInterfaceOrientations`만 사용해도 화면 고정이 되는 것같습니다. 이럴 때는 `Deprecated`인 `shouldAutorotate`를 사용하지 않고 `supportedInterfaceOrientations`만 사용하는게 맞는 걸까요?
<br>

## 📚 참고 링크

- [🍎 Apple Docs: supportedInterfaceOrientations](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621435-supportedinterfaceorientations)
- [🍎 Apple Docs: shouldAutorotate](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621419-shouldautorotate)
- [🌐 Blog: iOS 디바이스 회전 처리에 대한 정리](https://jongwonwoo.medium.com/ios-%EB%94%94%EB%B0%94%EC%9D%B4%EC%8A%A4-%ED%9A%8C%EC%A0%84-%EC%B2%98%EB%A6%AC%EC%97%90-%EB%8C%80%ED%95%9C-%EC%A0%95%EB%A6%AC-340f37204a27)
- [🌐 Blog: iOS Device 방향 처리](https://velog.io/@wonhee010/%ED%8A%B9%EC%A0%95-ViewController%EC%97%90%EC%84%9C-%ED%99%94%EB%A9%B4-%ED%9A%8C%EC%A0%84-%EC%B2%98%EB%A6%AC)