### PR TITLE
만국박람회 [STEP2] Hisop, Charles

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		B9F036032AF233AB00911F37 /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F036022AF233AB00911F37 /* DecodingTests.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
-		C79FF4B92589F401005FB0FD /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* FirstViewController.swift */; };
+		C79FF4B92589F401005FB0FD /* ExpositionIntroductionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ExpositionIntroductionViewController.swift */; };
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
@@ -39,7 +39,7 @@
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C79FF4B82589F401005FB0FD /* FirstViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstViewController.swift; sourceTree = "<group>"; };
+		C79FF4B82589F401005FB0FD /* ExpositionIntroductionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionIntroductionViewController.swift; sourceTree = "<group>"; };
 		C79FF4BB2589F401005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -86,7 +86,7 @@
 		B96A747F2AF0C49400B13E18 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C79FF4B82589F401005FB0FD /* FirstViewController.swift */,
+				C79FF4B82589F401005FB0FD /* ExpositionIntroductionViewController.swift */,
 				DC27946A2AF397260026AAA3 /* CulturalAssetListViewController.swift */,
 				B92B82692AF3CE4F007C000F /* DetailViewController.swift */,
 			);
@@ -260,7 +260,7 @@
 				B96A747C2AEFDF7A00B13E18 /* CulturalAsset.swift in Sources */,
 				DC27946B2AF397260026AAA3 /* CulturalAssetListViewController.swift in Sources */,
 				B96A74812AF0C51300B13E18 /* Exposition.swift in Sources */,
-				C79FF4B92589F401005FB0FD /* FirstViewController.swift in Sources */,
+				C79FF4B92589F401005FB0FD /* ExpositionIntroductionViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				B92B826A2AF3CE4F007C000F /* DetailViewController.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B92B826A2AF3CE4F007C000F /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92B82692AF3CE4F007C000F /* DetailViewController.swift */; };
 		B96A747C2AEFDF7A00B13E18 /* CulturalAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96A747B2AEFDF7A00B13E18 /* CulturalAsset.swift */; };
 		B96A74812AF0C51300B13E18 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96A74802AF0C51300B13E18 /* Exposition.swift */; };
 		B9F036032AF233AB00911F37 /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F036022AF233AB00911F37 /* DecodingTests.swift */; };
@@ -30,6 +31,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B92B82692AF3CE4F007C000F /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
 		B96A747B2AEFDF7A00B13E18 /* CulturalAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CulturalAsset.swift; sourceTree = "<group>"; };
 		B96A74802AF0C51300B13E18 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		B9F036002AF233AB00911F37 /* DecodingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DecodingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -86,6 +88,7 @@
 			children = (
 				C79FF4B82589F401005FB0FD /* FirstViewController.swift */,
 				DC27946A2AF397260026AAA3 /* CulturalAssetListViewController.swift */,
+				B92B82692AF3CE4F007C000F /* DetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 				C79FF4B92589F401005FB0FD /* FirstViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
+				B92B826A2AF3CE4F007C000F /* DetailViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B92B826A2AF3CE4F007C000F /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92B82692AF3CE4F007C000F /* DetailViewController.swift */; };
+		B934121D2AF8DCF700690545 /* AssetParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B934121C2AF8DCF700690545 /* AssetParser.swift */; };
 		B96A747C2AEFDF7A00B13E18 /* CulturalAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96A747B2AEFDF7A00B13E18 /* CulturalAsset.swift */; };
 		B96A74812AF0C51300B13E18 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96A74802AF0C51300B13E18 /* Exposition.swift */; };
 		B9F036032AF233AB00911F37 /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F036022AF233AB00911F37 /* DecodingTests.swift */; };
@@ -32,6 +33,7 @@
 
 /* Begin PBXFileReference section */
 		B92B82692AF3CE4F007C000F /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		B934121C2AF8DCF700690545 /* AssetParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetParser.swift; sourceTree = "<group>"; };
 		B96A747B2AEFDF7A00B13E18 /* CulturalAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CulturalAsset.swift; sourceTree = "<group>"; };
 		B96A74802AF0C51300B13E18 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		B9F036002AF233AB00911F37 /* DecodingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DecodingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -70,6 +72,7 @@
 			children = (
 				B96A747B2AEFDF7A00B13E18 /* CulturalAsset.swift */,
 				B96A74802AF0C51300B13E18 /* Exposition.swift */,
+				B934121C2AF8DCF700690545 /* AssetParser.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B96A747C2AEFDF7A00B13E18 /* CulturalAsset.swift in Sources */,
+				B934121D2AF8DCF700690545 /* AssetParser.swift in Sources */,
 				DC27946B2AF397260026AAA3 /* CulturalAssetListViewController.swift in Sources */,
 				B96A74812AF0C51300B13E18 /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* ExpositionIntroductionViewController.swift in Sources */,

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 		B9F036032AF233AB00911F37 /* DecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F036022AF233AB00911F37 /* DecodingTests.swift */; };
 		C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B42589F401005FB0FD /* AppDelegate.swift */; };
 		C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B62589F401005FB0FD /* SceneDelegate.swift */; };
-		C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* ViewController.swift */; };
+		C79FF4B92589F401005FB0FD /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79FF4B82589F401005FB0FD /* FirstViewController.swift */; };
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
@@ -36,7 +36,7 @@
 		C79FF4B12589F401005FB0FD /* Expo1900.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expo1900.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C79FF4B42589F401005FB0FD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C79FF4B62589F401005FB0FD /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		C79FF4B82589F401005FB0FD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		C79FF4B82589F401005FB0FD /* FirstViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstViewController.swift; sourceTree = "<group>"; };
 		C79FF4BB2589F401005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -82,7 +82,7 @@
 		B96A747F2AF0C49400B13E18 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				C79FF4B82589F401005FB0FD /* ViewController.swift */,
+				C79FF4B82589F401005FB0FD /* FirstViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -253,7 +253,7 @@
 			files = (
 				B96A747C2AEFDF7A00B13E18 /* CulturalAsset.swift in Sources */,
 				B96A74812AF0C51300B13E18 /* Exposition.swift in Sources */,
-				C79FF4B92589F401005FB0FD /* ViewController.swift in Sources */,
+				C79FF4B92589F401005FB0FD /* FirstViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 			);

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		C79FF4BC2589F401005FB0FD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BA2589F401005FB0FD /* Main.storyboard */; };
 		C79FF4BE2589F404005FB0FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BD2589F404005FB0FD /* Assets.xcassets */; };
 		C79FF4C12589F404005FB0FD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C79FF4BF2589F404005FB0FD /* LaunchScreen.storyboard */; };
+		DC27946B2AF397260026AAA3 /* CulturalAssetListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC27946A2AF397260026AAA3 /* CulturalAssetListViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,6 +42,7 @@
 		C79FF4BD2589F404005FB0FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C79FF4C02589F404005FB0FD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		C79FF4C22589F404005FB0FD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DC27946A2AF397260026AAA3 /* CulturalAssetListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CulturalAssetListViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -83,6 +85,7 @@
 			isa = PBXGroup;
 			children = (
 				C79FF4B82589F401005FB0FD /* FirstViewController.swift */,
+				DC27946A2AF397260026AAA3 /* CulturalAssetListViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B96A747C2AEFDF7A00B13E18 /* CulturalAsset.swift in Sources */,
+				DC27946B2AF397260026AAA3 /* CulturalAssetListViewController.swift in Sources */,
 				B96A74812AF0C51300B13E18 /* Exposition.swift in Sources */,
 				C79FF4B92589F401005FB0FD /* FirstViewController.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -16,7 +16,17 @@ final class CulturalAssetListViewController: UITableViewController {
         navigationController?.navigationBar.topItem?.title = "메인"
         navigationController?.isNavigationBarHidden = false
         
-        decodeDataAsset()
+        do {
+            try culturalAssets = AssetParser<[CulturalAsset]>().decodeDataAsset(assetName: "items")
+        } catch {
+            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다.", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default) { action in
+                self.navigationController?.popViewController(animated: true)
+            }
+            
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -48,25 +58,5 @@ final class CulturalAssetListViewController: UITableViewController {
         navigationController?.pushViewController(detailViewController, animated: true)
     
         detailViewController.setUp(culturalAsset: culturalAssets[indexPath.row])
-    }
-
-    func decodeDataAsset() {
-        guard let dataAsset = NSDataAsset(name: "items") else {
-            return
-        }
-
-        let decoder = JSONDecoder()
-
-        do {
-            culturalAssets = try decoder.decode([CulturalAsset].self, from: dataAsset.data)
-        } catch {
-            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다.", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "예", style: .default) { action in
-                self.navigationController?.popViewController(animated: true)
-            }
-            
-            alert.addAction(okAction)
-            present(alert, animated: true)
-        }
     }
 }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -51,12 +51,12 @@ final class CulturalAssetListViewController: UITableViewController {
     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let detailViewController = storyboard?.instantiateViewController(identifier: String(describing: DetailViewController.self)) as? DetailViewController else {
+        guard let detailViewController = storyboard?.instantiateViewController(identifier: String(describing: DetailViewController.self), creator: { coder in
+            DetailViewController(coder: coder, culturalAsset: self.culturalAssets[indexPath.row])
+        }) else {
             return
         }
         
         navigationController?.pushViewController(detailViewController, animated: true)
-    
-        detailViewController.setUp(culturalAsset: culturalAssets[indexPath.row])
     }
 }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -41,8 +41,11 @@ class CulturalAssetListViewController: UITableViewController {
         guard let detailViewController = storyboard?.instantiateViewController(identifier: String(describing: DetailViewController.self)) as? DetailViewController else {
             return
         }
-        
+    
         navigationController?.pushViewController(detailViewController, animated: true)
+        detailViewController.name = culturalAssets[indexPath.row].name
+        detailViewController.imageName = culturalAssets[indexPath.row].imageName
+        detailViewController.detailDescription = culturalAssets[indexPath.row].detailDescription
     }
 
     func decodeDataAsset() {

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -51,11 +51,11 @@ final class CulturalAssetListViewController: UITableViewController {
     }
 
     func decodeDataAsset() {
-        let decoder = JSONDecoder()
-
         guard let dataAsset = NSDataAsset(name: "items") else {
             return
         }
+
+        let decoder = JSONDecoder()
 
         do {
             culturalAssets = try decoder.decode([CulturalAsset].self, from: dataAsset.data)

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -16,9 +16,10 @@ final class CulturalAssetListViewController: UITableViewController {
         navigationController?.navigationBar.topItem?.title = "메인"
         navigationController?.isNavigationBarHidden = false
         
-        do {
-            try culturalAssets = AssetParser<[CulturalAsset]>().decodeDataAsset(assetName: "items")
-        } catch {
+        switch AssetParser<[CulturalAsset]>().decodeDataAsset(assetName: "items") {
+        case .success(let data):
+            culturalAssets = data
+        case .failure(let error):
             let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다.", preferredStyle: .alert)
             let okAction = UIAlertAction(title: "예", style: .default) { action in
                 self.navigationController?.popViewController(animated: true)

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -47,9 +47,7 @@ final class CulturalAssetListViewController: UITableViewController {
         
         navigationController?.pushViewController(detailViewController, animated: true)
     
-        detailViewController.name = culturalAssets[indexPath.row].name
-        detailViewController.imageName = culturalAssets[indexPath.row].imageName
-        detailViewController.detailDescription = culturalAssets[indexPath.row].detailDescription
+        detailViewController.setUp(culturalAsset: culturalAssets[indexPath.row])
     }
 
     func decodeDataAsset() {

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -36,6 +36,14 @@ class CulturalAssetListViewController: UITableViewController {
 
         return cell
     }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let detailViewController = storyboard?.instantiateViewController(identifier: String(describing: DetailViewController.self)) as? DetailViewController else {
+            return
+        }
+        
+        navigationController?.pushViewController(detailViewController, animated: true)
+    }
 
     func decodeDataAsset() {
         let decoder = JSONDecoder()

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -8,82 +8,31 @@
 import UIKit
 
 class CulturalAssetListViewController: UITableViewController {
-
+    var culturalAssets:[CulturalAsset] = []
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
-    }
-
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 0
+        
+        decodeDataAsset()
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
         return 0
     }
 
-    /*
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+    func decodeDataAsset() {
+        let decoder = JSONDecoder()
 
-        // Configure the cell...
+        guard let dataAsset = NSDataAsset(name: "items") else {
+            return
+        }
 
-        return cell
+        do {
+            culturalAssets = try decoder.decode([CulturalAsset].self, from: dataAsset.data)
+        } catch {
+            print(error.localizedDescription)
+        }
     }
-    */
 
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -16,18 +16,7 @@ final class CulturalAssetListViewController: UITableViewController {
         navigationController?.navigationBar.topItem?.title = "메인"
         navigationController?.isNavigationBarHidden = false
         
-        switch AssetParser<[CulturalAsset]>.decodeDataAsset(assetName: "items") {
-        case .success(let data):
-            culturalAssets = data
-        case .failure(let error):
-            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "예", style: .default) { action in
-                self.navigationController?.popViewController(animated: true)
-            }
-            
-            alert.addAction(okAction)
-            present(alert, animated: true)
-        }
+        processDataAsset()
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -59,5 +48,20 @@ final class CulturalAssetListViewController: UITableViewController {
         }
         
         navigationController?.pushViewController(detailViewController, animated: true)
+    }
+    
+    private func processDataAsset() {
+        switch AssetParser<[CulturalAsset]>.decodeDataAsset(assetName: "items") {
+        case .success(let data):
+            culturalAssets = data
+        case .failure(let error):
+            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default) { action in
+                self.navigationController?.popViewController(animated: true)
+            }
+            
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
     }
 }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -20,7 +20,7 @@ final class CulturalAssetListViewController: UITableViewController {
         case .success(let data):
             culturalAssets = data
         case .failure(let error):
-            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다.", preferredStyle: .alert)
+            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다", preferredStyle: .alert)
             let okAction = UIAlertAction(title: "예", style: .default) { action in
                 self.navigationController?.popViewController(animated: true)
             }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class CulturalAssetListViewController: UITableViewController {
+final class CulturalAssetListViewController: UITableViewController {
     var culturalAssets:[CulturalAsset] = []
     
     override func viewDidLoad() {

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -42,8 +42,9 @@ class CulturalAssetListViewController: UITableViewController {
         guard let detailViewController = storyboard?.instantiateViewController(identifier: String(describing: DetailViewController.self)) as? DetailViewController else {
             return
         }
-    
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "한국의 출품작", style: .plain, target: self, action: nil)
         navigationController?.pushViewController(detailViewController, animated: true)
+        
         detailViewController.name = culturalAssets[indexPath.row].name
         detailViewController.imageName = culturalAssets[indexPath.row].imageName
         detailViewController.detailDescription = culturalAssets[indexPath.row].detailDescription

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -17,7 +17,24 @@ class CulturalAssetListViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 0
+        return culturalAssets.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        var content = cell.defaultContentConfiguration()
+        
+        content.image = UIImage(named: culturalAssets[indexPath.row].imageName)
+        content.imageProperties.maximumSize = CGSize(width: 60, height: 60)
+        content.imageProperties.reservedLayoutSize = CGSize(width: 65, height: 0)
+        
+        content.text = culturalAssets[indexPath.row].name
+        content.secondaryText = culturalAssets[indexPath.row].shortDescription
+        
+        cell.contentConfiguration = content
+        cell.accessoryType = .disclosureIndicator
+
+        return cell
     }
 
     func decodeDataAsset() {
@@ -33,6 +50,4 @@ class CulturalAssetListViewController: UITableViewController {
             print(error.localizedDescription)
         }
     }
-
-
 }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -13,6 +13,7 @@ class CulturalAssetListViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationController?.isNavigationBarHidden = false
         decodeDataAsset()
     }
 

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -13,7 +13,9 @@ final class CulturalAssetListViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationController?.navigationBar.topItem?.title = "메인"
         navigationController?.isNavigationBarHidden = false
+        
         decodeDataAsset()
     }
 
@@ -42,9 +44,9 @@ final class CulturalAssetListViewController: UITableViewController {
         guard let detailViewController = storyboard?.instantiateViewController(identifier: String(describing: DetailViewController.self)) as? DetailViewController else {
             return
         }
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: "한국의 출품작", style: .plain, target: self, action: nil)
-        navigationController?.pushViewController(detailViewController, animated: true)
         
+        navigationController?.pushViewController(detailViewController, animated: true)
+    
         detailViewController.name = culturalAssets[indexPath.row].name
         detailViewController.imageName = culturalAssets[indexPath.row].imageName
         detailViewController.detailDescription = culturalAssets[indexPath.row].detailDescription

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class CulturalAssetListViewController: UITableViewController {
-    private var culturalAssets:[CulturalAsset] = []
+    private var culturalAssets: [CulturalAsset] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -1,0 +1,89 @@
+//
+//  CulturalAssetListViewController.swift
+//  Expo1900
+//
+//  Created by Charles on 2023/11/02.
+//
+
+import UIKit
+
+class CulturalAssetListViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -60,7 +60,13 @@ final class CulturalAssetListViewController: UITableViewController {
         do {
             culturalAssets = try decoder.decode([CulturalAsset].self, from: dataAsset.data)
         } catch {
-            print(error.localizedDescription)
+            let alert = UIAlertController(title: error.localizedDescription, message: "이전 화면으로 돌아갑니다.", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default) { action in
+                self.navigationController?.popViewController(animated: true)
+            }
+            
+            alert.addAction(okAction)
+            present(alert, animated: true)
         }
     }
 }

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -16,7 +16,7 @@ final class CulturalAssetListViewController: UITableViewController {
         navigationController?.navigationBar.topItem?.title = "메인"
         navigationController?.isNavigationBarHidden = false
         
-        switch AssetParser<[CulturalAsset]>().decodeDataAsset(assetName: "items") {
+        switch AssetParser<[CulturalAsset]>.decodeDataAsset(assetName: "items") {
         case .success(let data):
             culturalAssets = data
         case .failure(let error):

--- a/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
+++ b/Expo1900/Expo1900/Controller/CulturalAssetListViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class CulturalAssetListViewController: UITableViewController {
-    var culturalAssets:[CulturalAsset] = []
+    private var culturalAssets:[CulturalAsset] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class DetailViewController: UIViewController {
+final class DetailViewController: UIViewController {
     var name: String = ""
     var imageName: String = ""
     var detailDescription: String = ""

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -8,9 +8,9 @@
 import UIKit
 
 final class DetailViewController: UIViewController {
-    var name: String = ""
-    var imageName: String = ""
-    var detailDescription: String = ""
+    private var name: String = ""
+    private var imageName: String = ""
+    private var detailDescription: String = ""
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var explanation: UILabel!
     
@@ -26,5 +26,11 @@ final class DetailViewController: UIViewController {
         imageView.image = UIImage(named: imageName)
         
         explanation.text = detailDescription
+    }
+    
+    func setUp(culturalAsset: CulturalAsset) {
+        name = culturalAsset.name
+        imageName = culturalAsset.imageName
+        detailDescription = culturalAsset.detailDescription
     }
 }

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -11,15 +11,15 @@ final class DetailViewController: UIViewController {
     var name: String = ""
     var imageName: String = ""
     var detailDescription: String = ""
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var explanation: UILabel!
+    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet private weak var explanation: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
     }
 
-    func configureUI() {
+    private func configureUI() {
         navigationItem.title = name
         imageView.image = UIImage(named: imageName)
         

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -11,22 +11,20 @@ class DetailViewController: UIViewController {
     var name: String = ""
     var imageName: String = ""
     var detailDescription: String = ""
+    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var explanation: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        configureUI()
     }
-    
 
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func configureUI() {
+        navigationItem.title = name
+        imageView.image = UIImage(named: imageName)
+        
+        explanation.text = detailDescription
     }
-    */
-
 }
+
+

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -26,5 +26,3 @@ final class DetailViewController: UIViewController {
         explanation.text = detailDescription
     }
 }
-
-

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -8,11 +8,22 @@
 import UIKit
 
 final class DetailViewController: UIViewController {
-    private var name: String = ""
-    private var imageName: String = ""
-    private var detailDescription: String = ""
+    private let name: String
+    private let imageName: String
+    private let detailDescription: String
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var explanation: UILabel!
+    
+    init?(coder: NSCoder, culturalAsset: CulturalAsset) {
+        name = culturalAsset.name
+        imageName = culturalAsset.imageName
+        detailDescription = culturalAsset.detailDescription
+        super.init(coder: coder)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,11 +37,5 @@ final class DetailViewController: UIViewController {
         imageView.image = UIImage(named: imageName)
         
         explanation.text = detailDescription
-    }
-    
-    func setUp(culturalAsset: CulturalAsset) {
-        name = culturalAsset.name
-        imageName = culturalAsset.imageName
-        detailDescription = culturalAsset.detailDescription
     }
 }

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -1,0 +1,29 @@
+//
+//  DetailViewController.swift
+//  Expo1900
+//
+//  Created by Hisop on 2023/11/02.
+//
+
+import UIKit
+
+class DetailViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -16,6 +16,8 @@ final class DetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        navigationController?.navigationBar.topItem?.title = "한국의 출품작"
         configureUI()
     }
 

--- a/Expo1900/Expo1900/Controller/DetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/DetailViewController.swift
@@ -8,7 +8,10 @@
 import UIKit
 
 class DetailViewController: UIViewController {
-
+    var name: String = ""
+    var imageName: String = ""
+    var detailDescription: String = ""
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -62,20 +62,18 @@ final class ExpositionIntroductionViewController: UIViewController {
         durationLabel.text = exposition.formattingDuration
         explanationLabel.text = exposition.explanation
         
-        visitorsLabel.changeFontSize(targetString: "방문객")
-        locationLabel.changeFontSize(targetString: "개최지")
-        durationLabel.changeFontSize(targetString: "개최 기간")
+        changeFontSize(targetString: "방문객", targetLabel: visitorsLabel)
+        changeFontSize(targetString: "개최지", targetLabel: locationLabel)
+        changeFontSize(targetString: "개최 기간", targetLabel: durationLabel)
 
         buttonImages[0].image = UIImage(named: "flag")
         buttonImages[1].image = UIImage(named: "flag")
     }
-}
-
-extension UILabel {
-    func changeFontSize(targetString: String) {
-        let attributedString = NSMutableAttributedString(string: self.text ?? "")
-        attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 20), range: ((self.text ?? "") as NSString).range(of: targetString))
+    
+    private func changeFontSize(targetString: String, targetLabel: UILabel) {
+        let attributedString = NSMutableAttributedString(string: targetLabel.text ?? "")
+        attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 20), range: ((targetLabel.text ?? "") as NSString).range(of: targetString))
         
-        self.attributedText = attributedString
+        targetLabel.attributedText = attributedString
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -15,9 +15,22 @@ final class ExpositionIntroductionViewController: UIViewController {
     @IBOutlet private weak var explanationLabel: UILabel!
     @IBOutlet private var buttonImages: [UIImageView]!
     @IBOutlet private weak var scrollView: UIScrollView!
+    private var exposition: Exposition?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        do {
+            try exposition = AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900")
+        } catch {
+            let alert = UIAlertController(title: error.localizedDescription, message: "앱이 종료됩니다.", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default) { action in
+                exit(0)
+            }
+            
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
         
         configureUI()
     }
@@ -38,7 +51,7 @@ final class ExpositionIntroductionViewController: UIViewController {
     }
     
     private func configureUI() {
-        guard let exposition = decodeDataAsset() else {
+        guard let exposition = self.exposition else {
             return
         }
         
@@ -55,16 +68,6 @@ final class ExpositionIntroductionViewController: UIViewController {
 
         buttonImages[0].image = UIImage(named: "flag")
         buttonImages[1].image = UIImage(named: "flag")
-    }
-    
-    func decodeDataAsset() -> Exposition? {
-        let decoder = JSONDecoder()
-
-        guard let dataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
-            return nil
-        }
-
-        return try? decoder.decode(Exposition.self, from: dataAsset.data)
     }
 }
 

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -24,7 +24,7 @@ final class ExpositionIntroductionViewController: UIViewController {
         case .success(let data):
             exposition = data
         case .failure(let error):
-            let alert = UIAlertController(title: error.localizedDescription, message: "데이터를 받아오지 못했습니다.", preferredStyle: .alert)
+            let alert = UIAlertController(title: error.localizedDescription, message: "", preferredStyle: .alert)
             let okAction = UIAlertAction(title: "예", style: .default)
             
             alert.addAction(okAction)

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class FirstViewController: UIViewController {
+final class ExpositionIntroductionViewController: UIViewController {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var imageView: UIImageView!
     @IBOutlet private weak var visitorsLabel: UILabel!
@@ -30,11 +30,11 @@ final class FirstViewController: UIViewController {
     }
     
     @IBAction private func buttonTapped(_ sender: UIButton) {
-        guard let CulturalAssetListViewController = storyboard?.instantiateViewController(identifier: String(describing: CulturalAssetListViewController.self)) as? CulturalAssetListViewController else {
+        guard let culturalAssetListViewController = storyboard?.instantiateViewController(identifier: String(describing: CulturalAssetListViewController.self)) as? CulturalAssetListViewController else {
             return
         }
         
-        navigationController?.pushViewController(CulturalAssetListViewController, animated: true)
+        navigationController?.pushViewController(culturalAssetListViewController, animated: true)
     }
     
     private func configureUI() {
@@ -46,7 +46,7 @@ final class FirstViewController: UIViewController {
         imageView.image = UIImage(named: "poster")
         visitorsLabel.text = exposition.formattingVisitors
         locationLabel.text = exposition.formattingLocation
-        durationLabel.text = exposition.formattingduration
+        durationLabel.text = exposition.formattingDuration
         explanationLabel.text = exposition.explanation
         
         visitorsLabel.changeFontSize(targetString: "방문객")

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -19,16 +19,15 @@ final class ExpositionIntroductionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        do {
-            try exposition = AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900")
-        } catch {
-            let alert = UIAlertController(title: error.localizedDescription, message: "데이터를 받아오지 못했습니다.", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "예", style: .default)
-            
-            alert.addAction(okAction)
-            present(alert, animated: true)
-        }
+//        do {
+//            try exposition = AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900")
+//        } catch {
+//            let alert = UIAlertController(title: error.localizedDescription, message: "데이터를 받아오지 못했습니다.", preferredStyle: .alert)
+//            let okAction = UIAlertAction(title: "예", style: .default)
+//            
+//            alert.addAction(okAction)
+//            present(alert, animated: true)
+//        }
         
         configureUI()
     }

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -20,7 +20,7 @@ final class ExpositionIntroductionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        switch AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900") {
+        switch AssetParser<Exposition>.decodeDataAsset(assetName: "exposition_universelle_1900") {
         case .success(let data):
             exposition = data
         case .failure(let error):

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -23,10 +23,8 @@ final class ExpositionIntroductionViewController: UIViewController {
         do {
             try exposition = AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900")
         } catch {
-            let alert = UIAlertController(title: error.localizedDescription, message: "앱이 종료됩니다.", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "예", style: .default) { action in
-                exit(0)
-            }
+            let alert = UIAlertController(title: error.localizedDescription, message: "데이터를 받아오지 못했습니다.", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default)
             
             alert.addAction(okAction)
             present(alert, animated: true)

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -19,15 +19,17 @@ final class ExpositionIntroductionViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-//        do {
-//            try exposition = AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900")
-//        } catch {
-//            let alert = UIAlertController(title: error.localizedDescription, message: "데이터를 받아오지 못했습니다.", preferredStyle: .alert)
-//            let okAction = UIAlertAction(title: "예", style: .default)
-//            
-//            alert.addAction(okAction)
-//            present(alert, animated: true)
-//        }
+        
+        switch AssetParser<Exposition>().decodeDataAsset(assetName: "exposition_universelle_1900") {
+        case .success(let data):
+            exposition = data
+        case .failure(let error):
+            let alert = UIAlertController(title: error.localizedDescription, message: "데이터를 받아오지 못했습니다.", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default)
+            
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
         
         configureUI()
     }

--- a/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionIntroductionViewController.swift
@@ -20,17 +20,7 @@ final class ExpositionIntroductionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        switch AssetParser<Exposition>.decodeDataAsset(assetName: "exposition_universelle_1900") {
-        case .success(let data):
-            exposition = data
-        case .failure(let error):
-            let alert = UIAlertController(title: error.localizedDescription, message: "", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "예", style: .default)
-            
-            alert.addAction(okAction)
-            present(alert, animated: true)
-        }
-        
+        processDataAsset()
         configureUI()
     }
     
@@ -74,5 +64,18 @@ final class ExpositionIntroductionViewController: UIViewController {
         attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 20), range: ((targetLabel.text ?? "") as NSString).range(of: targetString))
         
         targetLabel.attributedText = attributedString
+    }
+    
+    private func processDataAsset() {
+        switch AssetParser<Exposition>.decodeDataAsset(assetName: "exposition_universelle_1900") {
+        case .success(let data):
+            exposition = data
+        case .failure(let error):
+            let alert = UIAlertController(title: error.localizedDescription, message: "", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "예", style: .default)
+            
+            alert.addAction(okAction)
+            present(alert, animated: true)
+        }
     }
 }

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -47,6 +47,10 @@ class FirstViewController: UIViewController {
         durationLabel.text = exposition.formattingduration
         explanationLabel.text = exposition.explanation
         
+        visitorsLabel.changeFontSize(targetString: "방문객")
+        locationLabel.changeFontSize(targetString: "개최지")
+        durationLabel.changeFontSize(targetString: "개최 기간")
+
         buttonImages[0].image = UIImage(named: "flag")
         buttonImages[1].image = UIImage(named: "flag")
     }
@@ -62,3 +66,11 @@ class FirstViewController: UIViewController {
     }
 }
 
+extension UILabel {
+    func changeFontSize(targetString: String) {
+        let attributedString = NSMutableAttributedString(string: self.text ?? "")
+        attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 20), range: ((self.text ?? "") as NSString).range(of: targetString))
+        
+        self.attributedText = attributedString
+    }
+}

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -24,6 +24,7 @@ class FirstViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         scrollView.scrollRectToVisible(titleLabel.frame, animated: true)
+        navigationController?.isNavigationBarHidden = true
     }
     
     @IBAction func buttonTapped(_ sender: UIButton) {

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -19,7 +19,8 @@ class FirstViewController: UIViewController {
         super.viewDidLoad()
         
         configureUI()
-        // Do any additional setup after loading the view.
+        
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "메인", style: .plain, target: self, action: nil)
     }
 
     func configureUI() {

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class FirstViewController: UIViewController {
+final class FirstViewController: UIViewController {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var visitorsLabel: UILabel!

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -38,7 +38,7 @@ class FirstViewController: UIViewController {
         
         titleLabel.text = exposition.titleWithNewLine
         imageView.image = UIImage(named: "poster")
-        visitorsLabel.text = "방문객 : \(exposition.visitors)"
+        visitorsLabel.text = exposition.formattingVisitors
         locationLabel.text = exposition.location
         durationLabel.text = exposition.duration
         explanationLabel.text = exposition.explanation

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -14,14 +14,18 @@ class FirstViewController: UIViewController {
     @IBOutlet weak var durationLabel: UILabel!
     @IBOutlet weak var explanationLabel: UILabel!
     @IBOutlet var buttonImages: [UIImageView]!
+    @IBOutlet weak var scrollView: UIScrollView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
-        
-        
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        scrollView.scrollRectToVisible(titleLabel.frame, animated: true)
+    }
+    
     @IBAction func buttonTapped(_ sender: UIButton) {
         guard let CulturalAssetListViewController = storyboard?.instantiateViewController(identifier: String(describing: CulturalAssetListViewController.self)) as? CulturalAssetListViewController else {
             return

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -36,7 +36,7 @@ class FirstViewController: UIViewController {
             return
         }
         
-        titleLabel.text = exposition.titleWithNewLine
+        titleLabel.text = exposition.formattingTitle
         imageView.image = UIImage(named: "poster")
         visitorsLabel.text = exposition.formattingVisitors
         locationLabel.text = exposition.location

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -16,9 +16,24 @@ class FirstViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        configureUI()
         // Do any additional setup after loading the view.
     }
 
+    func configureUI() {
+        guard let exposition = decodeDataAsset() else {
+            return
+        }
+        
+        titleLabel.text = exposition.title
+        imageView.image = UIImage(named: "poster")
+        visitorsLabel.text = "방문객 : \(exposition.visitors)"
+        locationLabel.text = exposition.location
+        durationLabel.text = exposition.duration
+        explanationLabel.text = exposition.explanation
+    }
+    
     func decodeDataAsset() -> Exposition? {
         let decoder = JSONDecoder()
 

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -13,6 +13,7 @@ class FirstViewController: UIViewController {
     @IBOutlet weak var locationLabel: UILabel!
     @IBOutlet weak var durationLabel: UILabel!
     @IBOutlet weak var explanationLabel: UILabel!
+    @IBOutlet var buttonImages: [UIImageView]!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -32,6 +33,9 @@ class FirstViewController: UIViewController {
         locationLabel.text = exposition.location
         durationLabel.text = exposition.duration
         explanationLabel.text = exposition.explanation
+        
+        buttonImages[0].image = UIImage(named: "flag")
+        buttonImages[1].image = UIImage(named: "flag")
     }
     
     func decodeDataAsset() -> Exposition? {

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -23,6 +23,8 @@ final class FirstViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         scrollView.scrollRectToVisible(titleLabel.frame, animated: true)
         navigationController?.isNavigationBarHidden = true
     }

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -39,8 +39,8 @@ class FirstViewController: UIViewController {
         titleLabel.text = exposition.formattingTitle
         imageView.image = UIImage(named: "poster")
         visitorsLabel.text = exposition.formattingVisitors
-        locationLabel.text = exposition.location
-        durationLabel.text = exposition.duration
+        locationLabel.text = exposition.formattingLocation
+        durationLabel.text = exposition.formattingduration
         explanationLabel.text = exposition.explanation
         
         buttonImages[0].image = UIImage(named: "flag")

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -17,9 +17,16 @@ class FirstViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        //self.navigationItem.titleView?.isHidden = true
     }
 
+    func decodeDataAsset() -> Exposition? {
+        let decoder = JSONDecoder()
 
+        guard let dataAsset = NSDataAsset(name: "exposition_universelle_1900") else {
+            return nil
+        }
+
+        return try? decoder.decode(Exposition.self, from: dataAsset.data)
+    }
 }
 

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -20,9 +20,17 @@ class FirstViewController: UIViewController {
         
         configureUI()
         
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: "메인", style: .plain, target: self, action: nil)
+        
     }
-
+    @IBAction func buttonTapped(_ sender: UIButton) {
+        guard let CulturalAssetListViewController = storyboard?.instantiateViewController(identifier: String(describing: CulturalAssetListViewController.self)) as? CulturalAssetListViewController else {
+            return
+        }
+        
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "메인", style: .plain, target: self, action: nil)
+        navigationController?.pushViewController(CulturalAssetListViewController, animated: true)
+    }
+    
     func configureUI() {
         guard let exposition = decodeDataAsset() else {
             return

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -32,7 +32,6 @@ final class FirstViewController: UIViewController {
             return
         }
         
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: "메인", style: .plain, target: self, action: nil)
         navigationController?.pushViewController(CulturalAssetListViewController, animated: true)
     }
     

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -36,7 +36,7 @@ class FirstViewController: UIViewController {
             return
         }
         
-        titleLabel.text = exposition.title
+        titleLabel.text = exposition.titleWithNewLine
         imageView.image = UIImage(named: "poster")
         visitorsLabel.text = "방문객 : \(exposition.visitors)"
         locationLabel.text = exposition.location

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -27,7 +27,7 @@ final class FirstViewController: UIViewController {
         navigationController?.isNavigationBarHidden = true
     }
     
-    @IBAction func buttonTapped(_ sender: UIButton) {
+    @IBAction private func buttonTapped(_ sender: UIButton) {
         guard let CulturalAssetListViewController = storyboard?.instantiateViewController(identifier: String(describing: CulturalAssetListViewController.self)) as? CulturalAssetListViewController else {
             return
         }

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -7,7 +7,13 @@
 import UIKit
 
 class FirstViewController: UIViewController {
-
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var visitorsLabel: UILabel!
+    @IBOutlet weak var locationLabel: UILabel!
+    @IBOutlet weak var durationLabel: UILabel!
+    @IBOutlet weak var explanationLabel: UILabel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -7,14 +7,14 @@
 import UIKit
 
 final class FirstViewController: UIViewController {
-    @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var visitorsLabel: UILabel!
-    @IBOutlet weak var locationLabel: UILabel!
-    @IBOutlet weak var durationLabel: UILabel!
-    @IBOutlet weak var explanationLabel: UILabel!
-    @IBOutlet var buttonImages: [UIImageView]!
-    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var imageView: UIImageView!
+    @IBOutlet private weak var visitorsLabel: UILabel!
+    @IBOutlet private weak var locationLabel: UILabel!
+    @IBOutlet private weak var durationLabel: UILabel!
+    @IBOutlet private weak var explanationLabel: UILabel!
+    @IBOutlet private var buttonImages: [UIImageView]!
+    @IBOutlet private weak var scrollView: UIScrollView!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -36,7 +36,7 @@ final class FirstViewController: UIViewController {
         navigationController?.pushViewController(CulturalAssetListViewController, animated: true)
     }
     
-    func configureUI() {
+    private func configureUI() {
         guard let exposition = decodeDataAsset() else {
             return
         }

--- a/Expo1900/Expo1900/Controller/FirstViewController.swift
+++ b/Expo1900/Expo1900/Controller/FirstViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class FirstViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Expo1900/Expo1900/Controller/ViewController.swift
+++ b/Expo1900/Expo1900/Controller/ViewController.swift
@@ -11,6 +11,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        //self.navigationItem.titleView?.isHidden = true
     }
 
 

--- a/Expo1900/Expo1900/Model/AssetParser.swift
+++ b/Expo1900/Expo1900/Model/AssetParser.swift
@@ -1,0 +1,35 @@
+//
+//  AssetParser.swift
+//  Expo1900
+//
+//  Created by Hisop on 2023/11/06.
+//
+
+import UIKit
+
+enum dataAssetError: LocalizedError {
+    case dataAssetNameError
+    
+    var errorDescription: String? {
+        switch self {
+        case .dataAssetNameError:
+            return "dataAssetNameError"
+        }
+    }
+}
+
+struct AssetParser<T: Decodable> {
+    func decodeDataAsset(assetName: String) throws -> T {
+        guard let dataAsset = NSDataAsset(name: assetName) else {
+            throw dataAssetError.dataAssetNameError
+        }
+        
+        let decoder = JSONDecoder()
+        
+        do {
+            return try decoder.decode(T.self, from: dataAsset.data)
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Expo1900/Expo1900/Model/AssetParser.swift
+++ b/Expo1900/Expo1900/Model/AssetParser.swift
@@ -7,9 +7,18 @@
 
 import UIKit
 
-enum DataAssetError: Error {
+enum DataAssetError: LocalizedError {
     case dataAssetNameError
     case decodingError
+    
+    var errorDescription: String? {
+        switch self {
+        case .dataAssetNameError:
+            return "데이터를 불러오지 못했습니다"
+        case .decodingError:
+            return "데이터를 해석하지 못했습니다"
+        }
+    }
 }
 
 struct AssetParser<T: Decodable> {

--- a/Expo1900/Expo1900/Model/AssetParser.swift
+++ b/Expo1900/Expo1900/Model/AssetParser.swift
@@ -21,8 +21,8 @@ enum DataAssetError: LocalizedError {
     }
 }
 
-struct AssetParser<T: Decodable> {
-    func decodeDataAsset(assetName: String) -> Result<T, DataAssetError> {
+enum AssetParser<T: Decodable> {
+    static func decodeDataAsset(assetName: String) -> Result<T, DataAssetError> {
         guard let dataAsset = NSDataAsset(name: assetName) else {
             return .failure(.dataAssetNameError)
         }

--- a/Expo1900/Expo1900/Model/AssetParser.swift
+++ b/Expo1900/Expo1900/Model/AssetParser.swift
@@ -7,29 +7,23 @@
 
 import UIKit
 
-enum dataAssetError: LocalizedError {
+enum DataAssetError: Error {
     case dataAssetNameError
-    
-    var errorDescription: String? {
-        switch self {
-        case .dataAssetNameError:
-            return "dataAssetNameError"
-        }
-    }
+    case decodingError
 }
 
 struct AssetParser<T: Decodable> {
-    func decodeDataAsset(assetName: String) throws -> T {
+    func decodeDataAsset(assetName: String) -> Result<T, DataAssetError> {
         guard let dataAsset = NSDataAsset(name: assetName) else {
-            throw dataAssetError.dataAssetNameError
+            return .failure(.dataAssetNameError)
         }
         
         let decoder = JSONDecoder()
         
-        do {
-            return try decoder.decode(T.self, from: dataAsset.data)
-        } catch {
-            throw error
+        guard let result = try? decoder.decode(T.self, from: dataAsset.data) else {
+            return .failure(.decodingError)
         }
+        
+        return .success(result)
     }
 }

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -37,7 +37,7 @@ struct Exposition: Decodable {
         return "개최지 : " + location
     }
     
-    var formattingduration: String {
+    var formattingDuration: String {
         return "개최 기간 : " + duration
     }
     

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -12,6 +12,14 @@ struct Exposition: Decodable {
     let duration: String
     let explanation: String
     
+    var titleWithNewLine: String {
+        guard let index = title.firstIndex(of: "(") else {
+            return title
+        }
+        
+        return "\(title.prefix(upTo: index))\n\(title.suffix(from: index))"
+    }
+    
     enum CodingKeys: String, CodingKey {
         case title, visitors, location, duration
         case explanation = "description"

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -14,7 +14,7 @@ struct Exposition: Decodable {
     let duration: String
     let explanation: String
     
-    var titleWithNewLine: String {
+    var formattingTitle: String {
         guard let index = title.firstIndex(of: "(") else {
             return title
         }

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -33,6 +33,10 @@ struct Exposition: Decodable {
         return "방문객 : " + formattingNumber + " 명"
     }
     
+    var formattingLocation: String {
+        return "개최지 : " + location
+    }
+    
     enum CodingKeys: String, CodingKey {
         case title, visitors, location, duration
         case explanation = "description"

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -5,6 +5,8 @@
 //  Created by Hisop on 2023/10/31.
 //
 
+import Foundation
+
 struct Exposition: Decodable {
     let title: String
     let visitors: Int
@@ -18,6 +20,17 @@ struct Exposition: Decodable {
         }
         
         return "\(title.prefix(upTo: index))\n\(title.suffix(from: index))"
+    }
+    
+    var formattingVisitors: String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        guard let formattingNumber = numberFormatter.string(for: visitors) else {
+            return String(visitors)
+        }
+        
+        return "방문객 : " + formattingNumber + " 명"
     }
     
     enum CodingKeys: String, CodingKey {

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -37,6 +37,10 @@ struct Exposition: Decodable {
         return "개최지 : " + location
     }
     
+    var formattingduration: String {
+        return "개최 기간 : " + duration
+    }
+    
     enum CodingKeys: String, CodingKey {
         case title, visitors, location, duration
         case explanation = "description"

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -111,6 +111,34 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-138.1679389312977" y="-99.295774647887328"/>
+        </scene>
+        <!--Cultural Asset List View Controller-->
+        <scene sceneID="Gwo-1T-4iI">
+            <objects>
+                <tableViewController id="FN4-LC-AZT" customClass="CulturalAssetListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="W4r-8q-q9M">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="eIz-Up-ecZ">
+                                <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eIz-Up-ecZ" id="hVy-JU-UTb">
+                                    <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="FN4-LC-AZT" id="jBR-31-NtY"/>
+                            <outlet property="delegate" destination="FN4-LC-AZT" id="XHS-n0-ylj"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="eNz-bG-arM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="847" y="-99"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="AFL-xW-GCR">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="287.66666666666669"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="304"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
                                                 <rect key="frame" x="0.0" y="0.0" width="393" height="20.333333333333332"/>
@@ -57,18 +57,21 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="41" translatesAutoresizingMaskIntoConstraints="NO" id="YLF-Bl-KGq">
-                                                <rect key="frame" x="0.0" y="229.66666666666663" width="393" height="58"/>
+                                                <rect key="frame" x="0.0" y="229.66666666666666" width="393" height="74.333333333333343"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="weQ-Nb-G5l">
-                                                        <rect key="frame" x="0.0" y="0.0" width="103.66666666666667" height="58"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="103.66666666666667" height="74.333333333333329"/>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1LX-6c-E4s">
-                                                        <rect key="frame" x="144.66666666666666" y="0.0" width="103.66666666666666" height="58"/>
+                                                        <rect key="frame" x="144.66666666666666" y="0.0" width="103.66666666666666" height="74.333333333333329"/>
                                                         <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
+                                                        <connections>
+                                                            <segue destination="FN4-LC-AZT" kind="show" id="BnE-9V-K1R"/>
+                                                        </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pKg-q6-79G">
-                                                        <rect key="frame" x="289.33333333333331" y="0.0" width="103.66666666666669" height="58"/>
+                                                        <rect key="frame" x="289.33333333333331" y="0.0" width="103.66666666666669" height="74.333333333333329"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
@@ -135,10 +138,11 @@
                             <outlet property="delegate" destination="FN4-LC-AZT" id="XHS-n0-ylj"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" id="yvG-XF-y4Q"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eNz-bG-arM" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="847" y="-99"/>
+            <point key="canvasLocation" x="647" y="-99"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="AFL-xW-GCR">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -105,6 +105,7 @@
                         <outlet property="explanationLabel" destination="pBE-Qd-bZh" id="Tw3-hY-ZWY"/>
                         <outlet property="imageView" destination="Ofe-ec-FQC" id="03u-01-rBp"/>
                         <outlet property="locationLabel" destination="9Zc-Ro-B66" id="I6h-NR-H7Z"/>
+                        <outlet property="scrollView" destination="W24-gf-OD9" id="6Qe-gg-G4E"/>
                         <outlet property="titleLabel" destination="pxl-Ks-N5N" id="4xM-xV-ZzP"/>
                         <outlet property="visitorsLabel" destination="Zcn-vv-evB" id="Gkl-cJ-G6Z"/>
                         <outletCollection property="buttonImages" destination="weQ-Nb-G5l" collectionClass="NSMutableArray" id="j86-vC-TdB"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -124,7 +124,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="eIz-Up-ecZ">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" id="eIz-Up-ecZ">
                                 <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eIz-Up-ecZ" id="hVy-JU-UTb">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,24 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <navigationItem key="navigationItem" id="wg9-mw-NVs"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-137" y="-99"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="AFL-xW-GCR">
+            <objects>
+                <navigationController id="itS-Jk-FVN" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="t8p-op-6gG">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="Snu-Oo-raj"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jTj-ar-2SD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-848" y="-99"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -163,7 +163,7 @@
         <!--Detail View Controller-->
         <scene sceneID="meh-KU-wb3">
             <objects>
-                <viewController id="96O-ta-Rlc" customClass="DetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="DetailViewController" id="96O-ta-Rlc" customClass="DetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="KLq-42-SIt">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,43 +21,43 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="304"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="312.33333333333331"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
-                                                <rect key="frame" x="0.0" y="0.0" width="393" height="20.333333333333332"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
+                                                <rect key="frame" x="0.0" y="0.0" width="393" height="28.666666666666668"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
-                                                <rect key="frame" x="0.0" y="20.333333333333329" width="393" height="127.99999999999999"/>
+                                                <rect key="frame" x="0.0" y="28.666666666666671" width="393" height="128"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
-                                                <rect key="frame" x="0.0" y="148.33333333333334" width="393" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="156.66666666666666" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
-                                                <rect key="frame" x="0.0" y="168.66666666666666" width="393" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="177" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
-                                                <rect key="frame" x="0.0" y="189" width="393" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="197.33333333333334" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBE-Qd-bZh" userLabel="explanation">
-                                                <rect key="frame" x="0.0" y="209.33333333333334" width="393" height="20.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="217.66666666666666" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="41" translatesAutoresizingMaskIntoConstraints="NO" id="YLF-Bl-KGq">
-                                                <rect key="frame" x="0.0" y="229.66666666666666" width="393" height="74.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="238.00000000000003" width="393" height="74.333333333333343"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="weQ-Nb-G5l">
                                                         <rect key="frame" x="0.0" y="0.0" width="103.66666666666667" height="74.333333333333329"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -159,6 +159,21 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jTj-ar-2SD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-848" y="-99"/>
+        </scene>
+        <!--Detail View Controller-->
+        <scene sceneID="meh-KU-wb3">
+            <objects>
+                <viewController id="96O-ta-Rlc" customClass="DetailViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="KLq-42-SIt">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="YEa-Db-33e"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="u3d-dj-9DW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1450" y="-99"/>
         </scene>
     </scenes>
     <resources>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,7 +21,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="229.66666666666666"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="287.66666666666669"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
                                                 <rect key="frame" x="0.0" y="0.0" width="393" height="20.333333333333332"/>
@@ -56,6 +56,22 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="41" translatesAutoresizingMaskIntoConstraints="NO" id="YLF-Bl-KGq">
+                                                <rect key="frame" x="0.0" y="229.66666666666663" width="393" height="58"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="weQ-Nb-G5l">
+                                                        <rect key="frame" x="0.0" y="0.0" width="103.66666666666667" height="58"/>
+                                                    </imageView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1LX-6c-E4s">
+                                                        <rect key="frame" x="144.66666666666666" y="0.0" width="103.66666666666666" height="58"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                                    </button>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pKg-q6-79G">
+                                                        <rect key="frame" x="289.33333333333331" y="0.0" width="103.66666666666669" height="58"/>
+                                                    </imageView>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -167,8 +167,24 @@
                     <view key="view" contentMode="scaleToFill" id="KLq-42-SIt">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ggD-aE-v5w">
+                                <rect key="frame" x="10" y="59" width="373" height="759"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="YEa-Db-33e"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="YEa-Db-33e" firstAttribute="bottom" secondItem="ggD-aE-v5w" secondAttribute="bottom" id="4lN-uU-D1M"/>
+                            <constraint firstItem="YEa-Db-33e" firstAttribute="trailing" secondItem="ggD-aE-v5w" secondAttribute="trailing" constant="10" id="5D3-hI-puT"/>
+                            <constraint firstItem="ggD-aE-v5w" firstAttribute="leading" secondItem="YEa-Db-33e" secondAttribute="leading" constant="10" id="U0V-Kv-9x5"/>
+                            <constraint firstItem="ggD-aE-v5w" firstAttribute="top" secondItem="YEa-Db-33e" secondAttribute="top" id="jL8-kY-Yrd"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="u3d-dj-9DW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -177,6 +193,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -67,7 +67,7 @@
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
-                                                            <segue destination="FN4-LC-AZT" kind="show" id="BnE-9V-K1R"/>
+                                                            <action selector="buttonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ubh-2j-uih"/>
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pKg-q6-79G">
@@ -118,7 +118,7 @@
         <!--Cultural Asset List View Controller-->
         <scene sceneID="Gwo-1T-4iI">
             <objects>
-                <tableViewController id="FN4-LC-AZT" customClass="CulturalAssetListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="CulturalAssetListViewController" id="FN4-LC-AZT" customClass="CulturalAssetListViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="W4r-8q-q9M">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,6 +22,46 @@
                                 <subviews>
                                     <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mLo-zi-yv6">
                                         <rect key="frame" x="0.0" y="-103" width="393" height="852"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
+                                                <rect key="frame" x="76" y="63" width="240" height="229.66666666666663"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
+                                                        <rect key="frame" x="0.0" y="0.0" width="240" height="20.333333333333332"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
+                                                        <rect key="frame" x="0.0" y="20.333333333333329" width="240" height="127.99999999999999"/>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
+                                                        <rect key="frame" x="0.0" y="148.33333333333334" width="240" height="20.333333333333343"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
+                                                        <rect key="frame" x="0.0" y="168.66666666666666" width="240" height="20.333333333333343"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
+                                                        <rect key="frame" x="0.0" y="189" width="240" height="20.333333333333343"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBE-Qd-bZh" userLabel="explanation">
+                                                        <rect key="frame" x="0.0" y="209.33333333333334" width="240" height="20.333333333333343"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </view>
                                 </subviews>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -168,37 +168,52 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ggD-aE-v5w">
-                                <rect key="frame" x="10" y="59" width="373" height="759"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <color key="textColor" systemColor="labelColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BlJ-cS-ZPT">
-                                <rect key="frame" x="76" y="81" width="240" height="192"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JAm-fA-a1x">
+                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hmE-tu-tzA">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="793.33333333333337"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="BlJ-cS-ZPT">
+                                                <rect key="frame" x="0.0" y="0.0" width="393" height="386.66666666666669"/>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g14-KV-hhu">
+                                                <rect key="frame" x="0.0" y="406.66666666666663" width="393" height="386.66666666666663"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="hmE-tu-tzA" firstAttribute="top" secondItem="JAm-fA-a1x" secondAttribute="top" id="HIR-OL-a1d"/>
+                                    <constraint firstItem="hmE-tu-tzA" firstAttribute="height" secondItem="98b-fL-JoP" secondAttribute="height" multiplier="1.04523" id="Ydp-QO-nhK"/>
+                                    <constraint firstAttribute="trailing" secondItem="hmE-tu-tzA" secondAttribute="trailing" id="elR-lT-nq3"/>
+                                    <constraint firstItem="hmE-tu-tzA" firstAttribute="leading" secondItem="JAm-fA-a1x" secondAttribute="leading" id="k58-4M-iDw"/>
+                                    <constraint firstAttribute="bottom" secondItem="hmE-tu-tzA" secondAttribute="bottom" id="nGP-Jw-hs7"/>
+                                    <constraint firstItem="hmE-tu-tzA" firstAttribute="width" secondItem="JAm-fA-a1x" secondAttribute="width" id="z1d-OA-aVZ"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="UOt-EY-o5q"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="98b-fL-JoP"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="YEa-Db-33e"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="YEa-Db-33e" firstAttribute="bottom" secondItem="ggD-aE-v5w" secondAttribute="bottom" id="4lN-uU-D1M"/>
-                            <constraint firstItem="YEa-Db-33e" firstAttribute="trailing" secondItem="ggD-aE-v5w" secondAttribute="trailing" constant="10" id="5D3-hI-puT"/>
-                            <constraint firstItem="ggD-aE-v5w" firstAttribute="leading" secondItem="YEa-Db-33e" secondAttribute="leading" constant="10" id="U0V-Kv-9x5"/>
-                            <constraint firstItem="ggD-aE-v5w" firstAttribute="top" secondItem="YEa-Db-33e" secondAttribute="top" id="jL8-kY-Yrd"/>
+                            <constraint firstItem="JAm-fA-a1x" firstAttribute="leading" secondItem="YEa-Db-33e" secondAttribute="leading" id="Huk-1q-i0C"/>
+                            <constraint firstItem="YEa-Db-33e" firstAttribute="trailing" secondItem="JAm-fA-a1x" secondAttribute="trailing" id="LJ1-Ug-orV"/>
+                            <constraint firstItem="YEa-Db-33e" firstAttribute="bottom" secondItem="JAm-fA-a1x" secondAttribute="bottom" id="Uyn-G1-Rhi"/>
+                            <constraint firstItem="JAm-fA-a1x" firstAttribute="top" secondItem="YEa-Db-33e" secondAttribute="top" id="uMB-pD-pt5"/>
                         </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="u3d-dj-9DW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1449.6183206106869" y="-99.295774647887328"/>
+            <point key="canvasLocation" x="1448.0916030534352" y="-99.295774647887328"/>
         </scene>
     </scenes>
     <resources>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -32,19 +32,19 @@
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
                                                 <rect key="frame" x="0.0" y="28.666666666666671" width="393" height="128"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
                                                 <rect key="frame" x="0.0" y="156.66666666666666" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
                                                 <rect key="frame" x="0.0" y="177" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
                                                 <rect key="frame" x="0.0" y="197.33333333333334" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,41 +17,41 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W24-gf-OD9">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W24-gf-OD9">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
-                                        <rect key="frame" x="76" y="208" width="240" height="229.66666666666663"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="229.66666666666666"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
-                                                <rect key="frame" x="0.0" y="0.0" width="240" height="20.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="393" height="20.333333333333332"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
-                                                <rect key="frame" x="0.0" y="20.333333333333329" width="240" height="127.99999999999999"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
+                                                <rect key="frame" x="0.0" y="20.333333333333329" width="393" height="127.99999999999999"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
-                                                <rect key="frame" x="0.0" y="148.33333333333334" width="240" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
+                                                <rect key="frame" x="0.0" y="148.33333333333334" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
-                                                <rect key="frame" x="0.0" y="168.66666666666666" width="240" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
+                                                <rect key="frame" x="0.0" y="168.66666666666666" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
-                                                <rect key="frame" x="0.0" y="189" width="240" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
+                                                <rect key="frame" x="0.0" y="189" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBE-Qd-bZh" userLabel="explanation">
-                                                <rect key="frame" x="0.0" y="209.33333333333334" width="240" height="20.333333333333343"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBE-Qd-bZh" userLabel="explanation">
+                                                <rect key="frame" x="0.0" y="209.33333333333334" width="393" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -59,6 +59,14 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="isO-0r-Q1C" firstAttribute="height" secondItem="5YO-cp-vw0" secondAttribute="height" priority="250" id="3Rs-q8-euL"/>
+                                    <constraint firstItem="isO-0r-Q1C" firstAttribute="leading" secondItem="W24-gf-OD9" secondAttribute="leading" id="MOa-l9-GgH"/>
+                                    <constraint firstAttribute="trailing" secondItem="isO-0r-Q1C" secondAttribute="trailing" id="nBB-9a-i8E"/>
+                                    <constraint firstItem="isO-0r-Q1C" firstAttribute="width" secondItem="W24-gf-OD9" secondAttribute="width" id="phH-0c-2t3"/>
+                                    <constraint firstItem="isO-0r-Q1C" firstAttribute="top" secondItem="W24-gf-OD9" secondAttribute="top" id="qFK-Sn-CSF"/>
+                                    <constraint firstAttribute="bottom" secondItem="isO-0r-Q1C" secondAttribute="bottom" id="rqS-cR-rai"/>
+                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="K1N-WE-nRS"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="5YO-cp-vw0"/>
                             </scrollView>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -171,14 +171,14 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JAm-fA-a1x">
                                 <rect key="frame" x="0.0" y="59" width="393" height="759"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hmE-tu-tzA">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="793.33333333333337"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hmE-tu-tzA">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="417"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="BlJ-cS-ZPT">
                                                 <rect key="frame" x="0.0" y="0.0" width="393" height="386.66666666666669"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g14-KV-hhu">
-                                                <rect key="frame" x="0.0" y="406.66666666666663" width="393" height="386.66666666666663"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g14-KV-hhu">
+                                                <rect key="frame" x="0.0" y="396.66666666666669" width="393" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -188,7 +188,7 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="hmE-tu-tzA" firstAttribute="top" secondItem="JAm-fA-a1x" secondAttribute="top" id="HIR-OL-a1d"/>
-                                    <constraint firstItem="hmE-tu-tzA" firstAttribute="height" secondItem="98b-fL-JoP" secondAttribute="height" multiplier="1.04523" id="Ydp-QO-nhK"/>
+                                    <constraint firstItem="hmE-tu-tzA" firstAttribute="height" secondItem="98b-fL-JoP" secondAttribute="height" priority="250" id="Ydp-QO-nhK"/>
                                     <constraint firstAttribute="trailing" secondItem="hmE-tu-tzA" secondAttribute="trailing" id="elR-lT-nq3"/>
                                     <constraint firstItem="hmE-tu-tzA" firstAttribute="leading" secondItem="JAm-fA-a1x" secondAttribute="leading" id="k58-4M-iDw"/>
                                     <constraint firstAttribute="bottom" secondItem="hmE-tu-tzA" secondAttribute="bottom" id="nGP-Jw-hs7"/>
@@ -207,6 +207,10 @@
                             <constraint firstItem="JAm-fA-a1x" firstAttribute="top" secondItem="YEa-Db-33e" secondAttribute="top" id="uMB-pD-pt5"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="explanation" destination="g14-KV-hhu" id="3DM-Eh-pIf"/>
+                        <outlet property="imageView" destination="BlJ-cS-ZPT" id="Xqs-f0-rst"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="u3d-dj-9DW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -104,6 +104,8 @@
                         <outlet property="locationLabel" destination="9Zc-Ro-B66" id="I6h-NR-H7Z"/>
                         <outlet property="titleLabel" destination="pxl-Ks-N5N" id="4xM-xV-ZzP"/>
                         <outlet property="visitorsLabel" destination="Zcn-vv-evB" id="Gkl-cJ-G6Z"/>
+                        <outletCollection property="buttonImages" destination="weQ-Nb-G5l" collectionClass="NSMutableArray" id="j86-vC-TdB"/>
+                        <outletCollection property="buttonImages" destination="pKg-q6-79G" collectionClass="NSMutableArray" id="nyJ-dO-c9o"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -20,58 +20,45 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W24-gf-OD9">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mLo-zi-yv6">
-                                        <rect key="frame" x="0.0" y="-103" width="393" height="852"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
+                                        <rect key="frame" x="76" y="208" width="240" height="229.66666666666663"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="isO-0r-Q1C">
-                                                <rect key="frame" x="76" y="63" width="240" height="229.66666666666663"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
-                                                        <rect key="frame" x="0.0" y="0.0" width="240" height="20.333333333333332"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
-                                                        <rect key="frame" x="0.0" y="20.333333333333329" width="240" height="127.99999999999999"/>
-                                                    </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
-                                                        <rect key="frame" x="0.0" y="148.33333333333334" width="240" height="20.333333333333343"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
-                                                        <rect key="frame" x="0.0" y="168.66666666666666" width="240" height="20.333333333333343"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
-                                                        <rect key="frame" x="0.0" y="189" width="240" height="20.333333333333343"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBE-Qd-bZh" userLabel="explanation">
-                                                        <rect key="frame" x="0.0" y="209.33333333333334" width="240" height="20.333333333333343"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxl-Ks-N5N" userLabel="title">
+                                                <rect key="frame" x="0.0" y="0.0" width="240" height="20.333333333333332"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ofe-ec-FQC">
+                                                <rect key="frame" x="0.0" y="20.333333333333329" width="240" height="127.99999999999999"/>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zcn-vv-evB" userLabel="visitors">
+                                                <rect key="frame" x="0.0" y="148.33333333333334" width="240" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Zc-Ro-B66" userLabel="location">
+                                                <rect key="frame" x="0.0" y="168.66666666666666" width="240" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6eA-dE-19R" userLabel="duration">
+                                                <rect key="frame" x="0.0" y="189" width="240" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pBE-Qd-bZh" userLabel="explanation">
+                                                <rect key="frame" x="0.0" y="209.33333333333334" width="240" height="20.333333333333343"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                    </view>
+                                    </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="mLo-zi-yv6" firstAttribute="leading" secondItem="W24-gf-OD9" secondAttribute="leading" id="DLs-BD-IXm"/>
-                                    <constraint firstItem="mLo-zi-yv6" firstAttribute="width" secondItem="W24-gf-OD9" secondAttribute="width" id="pcZ-2a-3W5"/>
-                                    <constraint firstItem="mLo-zi-yv6" firstAttribute="top" secondItem="W24-gf-OD9" secondAttribute="top" id="s0P-YA-qgr"/>
-                                    <constraint firstAttribute="bottom" secondItem="mLo-zi-yv6" secondAttribute="bottom" id="t5r-hM-DeO"/>
-                                    <constraint firstAttribute="trailing" secondItem="mLo-zi-yv6" secondAttribute="trailing" id="yra-9C-q1e"/>
-                                </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="K1N-WE-nRS"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="5YO-cp-vw0"/>
                             </scrollView>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -86,6 +86,14 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="wg9-mw-NVs"/>
+                    <connections>
+                        <outlet property="durationLabel" destination="6eA-dE-19R" id="zhF-Gm-2xK"/>
+                        <outlet property="explanationLabel" destination="pBE-Qd-bZh" id="Tw3-hY-ZWY"/>
+                        <outlet property="imageView" destination="Ofe-ec-FQC" id="03u-01-rBp"/>
+                        <outlet property="locationLabel" destination="9Zc-Ro-B66" id="I6h-NR-H7Z"/>
+                        <outlet property="titleLabel" destination="pxl-Ks-N5N" id="4xM-xV-ZzP"/>
+                        <outlet property="visitorsLabel" destination="Zcn-vv-evB" id="Gkl-cJ-G6Z"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -171,11 +171,14 @@
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ggD-aE-v5w">
                                 <rect key="frame" x="10" y="59" width="373" height="759"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BlJ-cS-ZPT">
+                                <rect key="frame" x="76" y="81" width="240" height="192"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="YEa-Db-33e"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -189,7 +192,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="u3d-dj-9DW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1450" y="-99"/>
+            <point key="canvasLocation" x="1449.6183206106869" y="-99.295774647887328"/>
         </scene>
     </scenes>
     <resources>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,14 +16,40 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W24-gf-OD9">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mLo-zi-yv6">
+                                        <rect key="frame" x="0.0" y="-103" width="393" height="852"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="mLo-zi-yv6" firstAttribute="leading" secondItem="W24-gf-OD9" secondAttribute="leading" id="DLs-BD-IXm"/>
+                                    <constraint firstItem="mLo-zi-yv6" firstAttribute="width" secondItem="W24-gf-OD9" secondAttribute="width" id="pcZ-2a-3W5"/>
+                                    <constraint firstItem="mLo-zi-yv6" firstAttribute="top" secondItem="W24-gf-OD9" secondAttribute="top" id="s0P-YA-qgr"/>
+                                    <constraint firstAttribute="bottom" secondItem="mLo-zi-yv6" secondAttribute="bottom" id="t5r-hM-DeO"/>
+                                    <constraint firstAttribute="trailing" secondItem="mLo-zi-yv6" secondAttribute="trailing" id="yra-9C-q1e"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="K1N-WE-nRS"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="5YO-cp-vw0"/>
+                            </scrollView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="W24-gf-OD9" secondAttribute="bottom" id="500-pP-3ju"/>
+                            <constraint firstItem="W24-gf-OD9" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="UMR-iL-hZR"/>
+                            <constraint firstItem="W24-gf-OD9" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="Y96-K8-EVM"/>
+                            <constraint firstItem="W24-gf-OD9" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="e6l-jS-XA5"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="wg9-mw-NVs"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-137" y="-99"/>
+            <point key="canvasLocation" x="-138.1679389312977" y="-99.295774647887328"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="AFL-xW-GCR">

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="itS-Jk-FVN">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--First View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="FirstViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--First View Controller-->
+        <!--Exposition Introduction View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="FirstViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ExpositionIntroductionViewController" customModule="Expo1900" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
@1Consumption  
STEP2 PR입니다.

## 고민했던 점

### NSMutableAttributedString 사용
    
첫 화면의 "방문객", "개최지", "개최 기간"의 폰트 크기가 다른것을 확인해 수정해보고자 했습니다.
- Label의 일부 스트링이 다른 속성을 가지고 있도록 설정하고 싶었습니다.
- 3개의 Label에 적용시켜주어야 했으므로 UILabel에 extension 메서드를 추가해 사용하도록 했습니다.
    
    
```swift
extension UILabel {
    func changeFontSize(targetString: String) {
        let attributedString = NSMutableAttributedString(string: self.text ?? "")
        attributedString.addAttribute(.font, value: UIFont.systemFont(ofSize: 20), range: ((self.text ?? "") as NSString).range(of: targetString))
        
        self.attributedText = attributedString
    }
}
```
```swift
visitorsLabel.changeFontSize(targetString: "방문객")
```

### setContentOffset / scrollRectToVisible 스크롤 이동에 쓰이는 메서드 고민
예시 화면에서 backBarButtonItem을 이용하여 첫 화면으로 돌아올 때 스크롤의 위치가 최상단으로 변경되는 것을 확인해 적용시켜주고자 했습니다.
- setContentOffset
    스크롤 뷰를 전달받은 CGPoint, 한 점으로 이동하는 메서드라 이해했습니다.
- scrollRectToVisible
    스크롤 뷰를 전달받은 CGRect, 직사각형이 표시되도록 이동하는 메서드라 이해했습니다.

특정 포인트를 지정해주기보단 titleLabel을 보여줄것이다 라는 표현이 더 적절하다 생각하여 scrollRectToVisible을 선택했습니다.
```swift
scrollView.scrollRectToVisible(titleLabel.frame, animated: true)
```

### defaultContentConfiguration
[모던 셀 구성 - WWDC](https://developer.apple.com/videos/play/wwdc2020/10027/)를 접하게되어 셀 구성에 해당 기술을 써보고자 했습니다.
```swift
var content = cell.defaultContentConfiguration()
        
content.image = UIImage(named: culturalAssets[indexPath.row].imageName) 
content.text = culturalAssets[indexPath.row].name
content.secondaryText = culturalAssets[indexPath.row].shortDescription
        
cell.contentConfiguration = content
```
위 방식으로 셀의 이미지, 텍스트를 설정할 수 있었습니다.

- 셀 내부의 이미지 정렬
처음에는 커스텀 셀을 만들어 세부적인 이미지의 크기와 레이아웃을 정해주는 쪽으로 수정할지 고민했습니다.
```swift
content.imageProperties.maximumSize = CGSize(width: 60, height: 60)
content.imageProperties.reservedLayoutSize = CGSize(width: 65, height: 0)
```
maximumSize로 이미지의 크기를, reservedLayoutSize로 레이아웃을 정해주도록 설정했습니다.

### Label과 TextView 사용을 고민했습니다.
텍스트 뷰에 스크롤 기능이 내장되어 있는 것을 확인하고 채택해보았습니다. 텍스트 뷰 위에 이미지 뷰를 올려보니 텍스트 뷰 하위에 속하지 않아 텍스트만 스크롤 되고 이미지는 고정되어 있어 스크롤 뷰에 Label을 추가하는 방식으로 구현하였습니다.

### 네비게이션 hidden!
- 네비게이션 바를 숨기기 위한 방법은 무엇이 있는 지 알아보았습니다. 우선 `setNavigationBarHidden(_, animated:)` 메서드가 있었고, `isNavigationBarHidden`라는 속성이 있었습니다. 두 가지 방법을 사용해 보았고 두 방법에 대한 차이는 바가 사라지는 것을 애니메이션으로 보여줄 수 있는 지에 대한 여부라 판단되어 애니메이션 기능자체를 사용하지 않을 거라 후자를 선택하였습니다.

## 조언을 얻고 싶었던 점

### attributedString / NSMutableAttributedString의 차이
- 문자열의 특정 부분의 속성만 바꾸기 위해 알아보았던 방법들이 `AttributedString`과 `NSMutableAttributedString`이었습니다. 처음 구현은 `AttributedString`으로 시도하였고, Label 텍스트로 넣어주는 부분에서 실패를 하여 검색을 해보았지만 SwiftUI로 구현된 방법밖에 제시되어 있지 않아 `NSMutableAttributedString`으로 구현하였습니다. 
- AttributedString 구현할 수 있는 방법이 있는 지에 대해 조언을 얻고 싶습니다.

### Decoding 시행하는 시점에 대한 고민
현재 CulturalAsset에 대한 Decoding은 CulturalAssetListViewController의 ViewDidLoad에 포함되어있어 화면이 전환될때마다 Decoding이 시행됩니다.
현재는 변경되지 않는 JSON파일을 관리하게 되는데 이 과정이 불필요해보여 수정을 고민하고 있습니다.

네트워크로 받는다고 가정할 때에는 어떤 식으로 Decoding을 처리하게 되는지 궁금합니다.
JSON이 변경되었을 때만 다시 디코딩을 하게 되나요?

### 스토리보드를 통한 화면전환 / 코드를 통한 화면전환 선택

현재 명확히 선택하는 기준을 찾지 못했습니다. 선택하는 기준이 있을까요?