### PR TITLE
만국박람회 [Step3] 미르, 쥬봉이

### DIFF
--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4E175D4A2AF3822900E79AEE /* ExpositionItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E175D492AF3822900E79AEE /* ExpositionItemDetailViewController.swift */; };
 		4E27CEED2AFB28CE00AA091B /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */; };
 		4E27CEEF2AFB2A0200AA091B /* DecoderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */; };
+		BF1577FC2AFB3823008B107F /* AccessibilityLabelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1577FB2AFB3823008B107F /* AccessibilityLabelList.swift */; };
 		BF6B2D032AF07DF9003727E2 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6B2D022AF07DF9003727E2 /* Exposition.swift */; };
 		BFFB1C8B2AF38B3A00299583 /* AssetDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */; };
 		BFFB1C952AF4C48000299583 /* AssetNameList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB1C942AF4C48000299583 /* AssetNameList.swift */; };
@@ -30,6 +31,7 @@
 		4E175D492AF3822900E79AEE /* ExpositionItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionItemDetailViewController.swift; sourceTree = "<group>"; };
 		4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderError.swift; sourceTree = "<group>"; };
+		BF1577FB2AFB3823008B107F /* AccessibilityLabelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityLabelList.swift; sourceTree = "<group>"; };
 		BF6B2D022AF07DF9003727E2 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDecoder.swift; sourceTree = "<group>"; };
 		BFFB1C942AF4C48000299583 /* AssetNameList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetNameList.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			children = (
 				BFFB1C942AF4C48000299583 /* AssetNameList.swift */,
 				BFFB1C962AF4C4CE00299583 /* Identifier.swift */,
+				BF1577FB2AFB3823008B107F /* AccessibilityLabelList.swift */,
 			);
 			path = NameSpace;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 				BFFB1C972AF4C4CE00299583 /* Identifier.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
 				4E27CEEF2AFB2A0200AA091B /* DecoderError.swift in Sources */,
+				BF1577FC2AFB3823008B107F /* AccessibilityLabelList.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				4E175D482AF373DA00E79AEE /* ExpositionItemListViewController.swift in Sources */,
 			);

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4E27CEED2AFB28CE00AA091B /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */; };
 		4E27CEEF2AFB2A0200AA091B /* DecoderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */; };
 		BF1577FC2AFB3823008B107F /* AccessibilityLabelList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1577FB2AFB3823008B107F /* AccessibilityLabelList.swift */; };
+		BF31CE722AFDD0C000D648D3 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF31CE712AFDD0C000D648D3 /* UIImage+.swift */; };
 		BF6B2D032AF07DF9003727E2 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6B2D022AF07DF9003727E2 /* Exposition.swift */; };
 		BFFB1C8B2AF38B3A00299583 /* AssetDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */; };
 		BFFB1C952AF4C48000299583 /* AssetNameList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB1C942AF4C48000299583 /* AssetNameList.swift */; };
@@ -32,6 +33,7 @@
 		4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderError.swift; sourceTree = "<group>"; };
 		BF1577FB2AFB3823008B107F /* AccessibilityLabelList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityLabelList.swift; sourceTree = "<group>"; };
+		BF31CE712AFDD0C000D648D3 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		BF6B2D022AF07DF9003727E2 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDecoder.swift; sourceTree = "<group>"; };
 		BFFB1C942AF4C48000299583 /* AssetNameList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetNameList.swift; sourceTree = "<group>"; };
@@ -76,6 +78,7 @@
 				4E175D472AF373DA00E79AEE /* ExpositionItemListViewController.swift */,
 				4E175D492AF3822900E79AEE /* ExpositionItemDetailViewController.swift */,
 				4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */,
+				BF31CE712AFDD0C000D648D3 /* UIImage+.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -211,6 +214,7 @@
 				4E27CEEF2AFB2A0200AA091B /* DecoderError.swift in Sources */,
 				BF1577FC2AFB3823008B107F /* AccessibilityLabelList.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
+				BF31CE722AFDD0C000D648D3 /* UIImage+.swift in Sources */,
 				4E175D482AF373DA00E79AEE /* ExpositionItemListViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -359,12 +363,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 68GK5TDX7T;
 				INFOPLIST_FILE = Expo1900/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.Expo1900;
+				PRODUCT_BUNDLE_IDENTIFIER = net.jyubong.Expo1900;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -377,12 +382,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 68GK5TDX7T;
 				INFOPLIST_FILE = Expo1900/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = net.yagom.Expo1900;
+				PRODUCT_BUNDLE_IDENTIFIER = net.jyubong.Expo1900;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/Expo1900/Expo1900.xcodeproj/project.pbxproj
+++ b/Expo1900/Expo1900.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		4E03D2452AF088EE0098C038 /* ExpositionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E03D2442AF088EE0098C038 /* ExpositionItem.swift */; };
 		4E175D482AF373DA00E79AEE /* ExpositionItemListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E175D472AF373DA00E79AEE /* ExpositionItemListViewController.swift */; };
 		4E175D4A2AF3822900E79AEE /* ExpositionItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E175D492AF3822900E79AEE /* ExpositionItemDetailViewController.swift */; };
+		4E27CEED2AFB28CE00AA091B /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */; };
+		4E27CEEF2AFB2A0200AA091B /* DecoderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */; };
 		BF6B2D032AF07DF9003727E2 /* Exposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6B2D022AF07DF9003727E2 /* Exposition.swift */; };
 		BFFB1C8B2AF38B3A00299583 /* AssetDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */; };
 		BFFB1C952AF4C48000299583 /* AssetNameList.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFB1C942AF4C48000299583 /* AssetNameList.swift */; };
@@ -26,6 +28,8 @@
 		4E03D2442AF088EE0098C038 /* ExpositionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionItem.swift; sourceTree = "<group>"; };
 		4E175D472AF373DA00E79AEE /* ExpositionItemListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionItemListViewController.swift; sourceTree = "<group>"; };
 		4E175D492AF3822900E79AEE /* ExpositionItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpositionItemDetailViewController.swift; sourceTree = "<group>"; };
+		4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
+		4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderError.swift; sourceTree = "<group>"; };
 		BF6B2D022AF07DF9003727E2 /* Exposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Exposition.swift; sourceTree = "<group>"; };
 		BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDecoder.swift; sourceTree = "<group>"; };
 		BFFB1C942AF4C48000299583 /* AssetNameList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetNameList.swift; sourceTree = "<group>"; };
@@ -58,6 +62,7 @@
 				BF6B2D022AF07DF9003727E2 /* Exposition.swift */,
 				4E03D2442AF088EE0098C038 /* ExpositionItem.swift */,
 				BFFB1C8A2AF38B3A00299583 /* AssetDecoder.swift */,
+				4E27CEEE2AFB2A0200AA091B /* DecoderError.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -68,6 +73,7 @@
 				C79FF4B82589F401005FB0FD /* ExpositionHomeViewController.swift */,
 				4E175D472AF373DA00E79AEE /* ExpositionItemListViewController.swift */,
 				4E175D492AF3822900E79AEE /* ExpositionItemDetailViewController.swift */,
+				4E27CEEC2AFB28CE00AA091B /* UIViewController+.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -194,10 +200,12 @@
 				C79FF4B92589F401005FB0FD /* ExpositionHomeViewController.swift in Sources */,
 				4E175D4A2AF3822900E79AEE /* ExpositionItemDetailViewController.swift in Sources */,
 				BFFB1C952AF4C48000299583 /* AssetNameList.swift in Sources */,
+				4E27CEED2AFB28CE00AA091B /* UIViewController+.swift in Sources */,
 				BF6B2D032AF07DF9003727E2 /* Exposition.swift in Sources */,
 				BFFB1C8B2AF38B3A00299583 /* AssetDecoder.swift in Sources */,
 				BFFB1C972AF4C4CE00299583 /* Identifier.swift in Sources */,
 				C79FF4B52589F401005FB0FD /* AppDelegate.swift in Sources */,
+				4E27CEEF2AFB2A0200AA091B /* DecoderError.swift in Sources */,
 				C79FF4B72589F401005FB0FD /* SceneDelegate.swift in Sources */,
 				4E175D482AF373DA00E79AEE /* ExpositionItemListViewController.swift in Sources */,
 			);

--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -1,35 +1,42 @@
 //
 //  Expo1900 - AppDelegate.swift
-//  Created by yagom. 
+//  Created by yagom.
 //  Copyright © yagom academy. All rights reserved.
-// 
+//
 
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
-
-
+    
+    var sholdSupportAllOrientation = true
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if sholdSupportAllOrientation {
+            return UIInterfaceOrientationMask.all
+        }
+        return UIInterfaceOrientationMask.portrait
+    }
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
-
+    
     // MARK: UISceneSession Lifecycle
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-
+    
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
+    
+    
 }
 

--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -1,6 +1,6 @@
 //
 //  Expo1900 - AppDelegate.swift
-//  Created by yagom.
+//  Created by jyubong, mireu
 //  Copyright © yagom academy. All rights reserved.
 //
 

--- a/Expo1900/Expo1900/AppDelegate.swift
+++ b/Expo1900/Expo1900/AppDelegate.swift
@@ -12,10 +12,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var sholdSupportAllOrientation = true
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-        if sholdSupportAllOrientation {
-            return UIInterfaceOrientationMask.all
-        }
-        return UIInterfaceOrientationMask.portrait
+        return sholdSupportAllOrientation ? .all : .portrait
     }
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
@@ -20,8 +20,7 @@ final class ExpositionHomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        exposition = AssetDecoder<Exposition>(assetName: AssetNameList.exposition).decodedItem
-        
+        decodeExposition()
         configureUI()
     }
     
@@ -39,6 +38,14 @@ final class ExpositionHomeViewController: UIViewController {
         appDelegate?.sholdSupportAllOrientation = true
     }
     
+    private func decodeExposition() {
+        do {
+            exposition = try AssetDecoder<Exposition>().parse(assetName: AssetNameList.exposition)
+        } catch {
+            self.showAlert(error)
+        }
+    }
+    
     private func configureUI () {
         titleLabel.text = exposition?.titleDescription
         visitorsLabel.text = exposition?.visitorsDescription
@@ -46,5 +53,4 @@ final class ExpositionHomeViewController: UIViewController {
         durationLabel.text = exposition?.durationDescription
         descriptionLabel.text = exposition?.description
     }
-    
 }

--- a/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
@@ -22,6 +22,7 @@ final class ExpositionHomeViewController: UIViewController {
         
         decodeExposition()
         configureUI()
+        self.setUpBackButtonAccessibilityLabel(to: AccessibilityLabelList.home)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -53,4 +54,5 @@ final class ExpositionHomeViewController: UIViewController {
         durationLabel.text = exposition?.durationDescription
         descriptionLabel.text = exposition?.description
     }
+
 }

--- a/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
@@ -41,7 +41,7 @@ final class ExpositionHomeViewController: UIViewController {
     
     private func decodeExposition() {
         do {
-            exposition = try AssetDecoder<Exposition>().parse(assetName: "")
+            exposition = try AssetDecoder<Exposition>().parse(assetName: AssetNameList.exposition)
         } catch {
             self.showErrorAlert(error)
         }

--- a/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
@@ -2,7 +2,7 @@
 //  Expo1900 - ViewController.swift
 //  Created by jyubong, mireu
 //  Copyright © yagom academy. All rights reserved.
-// 
+//
 
 import UIKit
 
@@ -15,6 +15,7 @@ final class ExpositionHomeViewController: UIViewController {
     @IBOutlet weak var descriptionLabel: UILabel!
     
     private var exposition: Exposition?
+    private let appDelegate = UIApplication.shared.delegate as? AppDelegate
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -28,12 +29,14 @@ final class ExpositionHomeViewController: UIViewController {
         super.viewWillAppear(animated)
         
         navigationController?.isNavigationBarHidden = true
+        appDelegate?.sholdSupportAllOrientation = false
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         navigationController?.isNavigationBarHidden = false
+        appDelegate?.sholdSupportAllOrientation = true
     }
     
     private func configureUI () {

--- a/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionHomeViewController.swift
@@ -41,9 +41,9 @@ final class ExpositionHomeViewController: UIViewController {
     
     private func decodeExposition() {
         do {
-            exposition = try AssetDecoder<Exposition>().parse(assetName: AssetNameList.exposition)
+            exposition = try AssetDecoder<Exposition>().parse(assetName: "")
         } catch {
-            self.showAlert(error)
+            self.showErrorAlert(error)
         }
     }
     

--- a/Expo1900/Expo1900/Controller/ExpositionItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemDetailViewController.swift
@@ -25,7 +25,9 @@ final class ExpositionItemDetailViewController: UIViewController {
     }
     
     private func configureUI() {
-        detailImageView.image = UIImage(named: expositionItem?.imageName ?? "")
+        let imageHeight = 150
+        detailImageView.image = UIImage(named: expositionItem?.imageName ?? "")?.resized(height: imageHeight)
+        
         detailDescriptionLabel.text = expositionItem?.description
         navigationItem.title = expositionItem?.name
     }

--- a/Expo1900/Expo1900/Controller/ExpositionItemDetailViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemDetailViewController.swift
@@ -25,7 +25,7 @@ final class ExpositionItemDetailViewController: UIViewController {
     }
     
     private func configureUI() {
-        let imageHeight = 150
+        let imageHeight = CGFloat(150)
         detailImageView.image = UIImage(named: expositionItem?.imageName ?? "")?.resized(height: imageHeight)
         
         detailDescriptionLabel.text = expositionItem?.description

--- a/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
@@ -23,7 +23,7 @@ final class ExpositionItemListViewController: UIViewController {
     
     private func decodeExpositionItems() {
         do {
-            expositionItems = try AssetDecoder<[ExpositionItem]>().parse(assetName: "")
+            expositionItems = try AssetDecoder<[ExpositionItem]>().parse(assetName: AssetNameList.expositionItems)
         } catch {
             self.showAlert(error)
         }

--- a/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
@@ -18,7 +18,15 @@ final class ExpositionItemListViewController: UIViewController {
         
         tableView.dataSource = self
         
-        expositionItems = AssetDecoder<[ExpositionItem]>(assetName: AssetNameList.expositionItems).decodedItem ?? []
+        decodeExpositionItems()
+    }
+    
+    private func decodeExpositionItems() {
+        do {
+            expositionItems = try AssetDecoder<[ExpositionItem]>().parse(assetName: "")
+        } catch {
+            self.showAlert(error)
+        }
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
@@ -26,7 +26,7 @@ final class ExpositionItemListViewController: UIViewController {
         do {
             expositionItems = try AssetDecoder<[ExpositionItem]>().parse(assetName: AssetNameList.expositionItems)
         } catch {
-            self.showAlert(error)
+            self.showErrorAlert(error)
         }
     }
     

--- a/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
@@ -40,21 +40,27 @@ extension ExpositionItemListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: Identifier.itemCell, for: indexPath)
         let item = expositionItems[indexPath.row]
+
+        cell.contentConfiguration = configureContent(of: cell, from: item)
         
+        return cell
+    }
+    
+    private func configureContent(of cell: UITableViewCell, from item: ExpositionItem) -> UIListContentConfiguration {
         var content = cell.defaultContentConfiguration()
         
         content.text = item.name
         content.textProperties.font = UIFont.preferredFont(forTextStyle: .title1)
+        
         content.secondaryText = item.shortDescription
         content.secondaryTextProperties.font = UIFont.preferredFont(forTextStyle: .body)
-        content.image = UIImage(named: item.imageName)
         
-        let imageSize = CGSize(width: 60, height: 60)
+        let imageWidth = 60
+        let imageSize = CGSize(width: imageWidth, height: imageWidth)
+        content.image = UIImage(named: item.imageName)
         content.imageProperties.maximumSize = imageSize
         content.imageProperties.reservedLayoutSize = imageSize
         
-        cell.contentConfiguration = content
-        
-        return cell
+        return content
     }
 }

--- a/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
@@ -2,7 +2,7 @@
 //  ExpositionItemViewController.swift
 //  Expo1900
 //
-//   Created by jyubong, mireu
+//  Created by jyubong, mireu
 //
 
 import UIKit
@@ -19,6 +19,7 @@ final class ExpositionItemListViewController: UIViewController {
         tableView.dataSource = self
         
         decodeExpositionItems()
+        self.setUpBackButtonAccessibilityLabel(to: AccessibilityLabelList.previous)
     }
     
     private func decodeExpositionItems() {

--- a/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
+++ b/Expo1900/Expo1900/Controller/ExpositionItemListViewController.swift
@@ -44,7 +44,9 @@ extension ExpositionItemListViewController: UITableViewDataSource {
         var content = cell.defaultContentConfiguration()
         
         content.text = item.name
+        content.textProperties.font = UIFont.preferredFont(forTextStyle: .title1)
         content.secondaryText = item.shortDescription
+        content.secondaryTextProperties.font = UIFont.preferredFont(forTextStyle: .body)
         content.image = UIImage(named: item.imageName)
         
         let imageSize = CGSize(width: 60, height: 60)

--- a/Expo1900/Expo1900/Controller/UIImage+.swift
+++ b/Expo1900/Expo1900/Controller/UIImage+.swift
@@ -1,0 +1,23 @@
+//
+//  UIImage+.swift
+//  Expo1900
+//
+//  Created by jyubong, mireu
+//
+
+import UIKit
+
+extension UIImage {
+    func resized(height: CGFloat) -> UIImage {
+        let ratio = self.size.width / self.size.height
+        let newWidth = height * ratio
+        let size = CGSize(width: newWidth, height: height)
+        
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { _ in
+            draw(in: CGRect(origin: .zero, size: size))
+        }
+        
+        return image
+    }
+}

--- a/Expo1900/Expo1900/Controller/UIViewController+.swift
+++ b/Expo1900/Expo1900/Controller/UIViewController+.swift
@@ -12,7 +12,7 @@ extension UIViewController {
         let alertTitle: String = "오류"
         var message: String {
             switch error {
-            case DecoderError.esetNameError:
+            case DecoderError.assetNameError:
                 return "애셋네임을 알 수 없습니다."
             case DecoderError.jsonDataError:
                 return "제이슨 데이터를 알 수 없습니다."
@@ -26,10 +26,10 @@ extension UIViewController {
         let alert = UIAlertController(title: alertTitle, message: message, preferredStyle: .alert)
         
         let cancelAction = UIAlertAction(title: cancelTiltle, style: .default)
-        let retreyAction = UIAlertAction(title: retryTitle, style: .default)
+        let retryAction = UIAlertAction(title: retryTitle, style: .default)
         
+        alert.addAction(retryAction)
         alert.addAction(cancelAction)
-        alert.addAction(retreyAction)
         
         present(alert, animated: true)
     }

--- a/Expo1900/Expo1900/Controller/UIViewController+.swift
+++ b/Expo1900/Expo1900/Controller/UIViewController+.swift
@@ -1,0 +1,36 @@
+//
+//  ViewController.swift
+//  Expo1900
+//
+//  Created by jyubong, mireu
+//
+
+import UIKit
+
+extension UIViewController {
+    func showAlert(_ error: Error) {
+        let alertTitle: String = "오류"
+        var message: String {
+            switch error {
+            case DecoderError.esetNameError:
+                return "애셋네임을 알 수 없습니다."
+            case DecoderError.jsonDataError:
+                return "제이슨 데이터를 알 수 없습니다."
+            default:
+                return "시스템오류가 발생했습니다."
+            }
+        }
+        let cancelTiltle: String = "취소"
+        let retryTitle: String = "재시도"
+        
+        let alert = UIAlertController(title: alertTitle, message: message, preferredStyle: .alert)
+        
+        let cancelAction = UIAlertAction(title: cancelTiltle, style: .default)
+        let retreyAction = UIAlertAction(title: retryTitle, style: .default)
+        
+        alert.addAction(cancelAction)
+        alert.addAction(retreyAction)
+        
+        present(alert, animated: true)
+    }
+}

--- a/Expo1900/Expo1900/Controller/UIViewController+.swift
+++ b/Expo1900/Expo1900/Controller/UIViewController+.swift
@@ -33,4 +33,12 @@ extension UIViewController {
         
         present(alert, animated: true)
     }
+    
+    func setUpBackButtonAccessibilityLabel(to label: String) {
+        let title = navigationItem.title
+        let backButton = UIBarButtonItem(title: title, style: .plain, target: self, action: nil)
+        
+        navigationItem.backBarButtonItem = backButton
+        navigationItem.backBarButtonItem?.accessibilityLabel = label
+    }
 }

--- a/Expo1900/Expo1900/Controller/UIViewController+.swift
+++ b/Expo1900/Expo1900/Controller/UIViewController+.swift
@@ -8,14 +8,13 @@
 import UIKit
 
 extension UIViewController {
-    func showAlert(_ error: Error) {
+    func showErrorAlert(_ error: Error) {
         let alertTitle: String = "오류"
         var message: String {
             switch error {
-            case DecoderError.assetNameError:
-                return "애셋네임을 알 수 없습니다."
-            case DecoderError.jsonDataError:
-                return "제이슨 데이터를 알 수 없습니다."
+            case DecoderError.assetName, DecoderError.jsonData:
+                print(error.localizedDescription)
+                return "데이터를 불러올 수 없습니다."
             default:
                 return "시스템오류가 발생했습니다."
             }

--- a/Expo1900/Expo1900/Model/AssetDecoder.swift
+++ b/Expo1900/Expo1900/Model/AssetDecoder.swift
@@ -10,13 +10,13 @@ import UIKit
 struct AssetDecoder<Element: Decodable> {
     func parse(assetName: String) throws -> Element {
         guard let data = NSDataAsset(name: assetName)?.data else {
-            throw DecoderError.assetNameError
+            throw DecoderError.assetName
         }
         
         let decoder = JSONDecoder()
         
         guard let jsonData = try? decoder.decode(Element.self, from: data) else {
-            throw DecoderError.jsonDataError
+            throw DecoderError.jsonData
         }
         
         return jsonData

--- a/Expo1900/Expo1900/Model/AssetDecoder.swift
+++ b/Expo1900/Expo1900/Model/AssetDecoder.swift
@@ -8,23 +8,17 @@
 import UIKit
 
 struct AssetDecoder<Element: Decodable> {
-    let assetName: String
-    
-    var decodedItem: Element? {
-        var item: Element?
+    func parse(assetName: String) throws -> Element {
+        guard let data = NSDataAsset(name: assetName)?.data else {
+            throw DecoderError.assetNameError
+        }
         
         let decoder = JSONDecoder()
         
-        guard let data = NSDataAsset(name: assetName)?.data else {
-            return item
+        guard let jsonData = try? decoder.decode(Element.self, from: data) else {
+            throw DecoderError.jsonDataError
         }
         
-        do {
-            item = try decoder.decode(Element.self, from: data)
-        } catch {
-            print(error.localizedDescription)
-        }
-        
-        return item
+        return jsonData
     }
 }

--- a/Expo1900/Expo1900/Model/DecoderError.swift
+++ b/Expo1900/Expo1900/Model/DecoderError.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 enum DecoderError: Error {
-    case esetNameError
+    case assetNameError
     case jsonDataError
 }

--- a/Expo1900/Expo1900/Model/DecoderError.swift
+++ b/Expo1900/Expo1900/Model/DecoderError.swift
@@ -1,0 +1,13 @@
+//
+//  DecoderError.swift
+//  Expo1900
+//
+//  Created by jyubong, mireu
+//
+
+import Foundation
+
+enum DecoderError: Error {
+    case esetNameError
+    case jsonDataError
+}

--- a/Expo1900/Expo1900/Model/DecoderError.swift
+++ b/Expo1900/Expo1900/Model/DecoderError.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 enum DecoderError: Error {
-    case assetNameError
-    case jsonDataError
+    case assetName
+    case jsonData
 }

--- a/Expo1900/Expo1900/Model/Exposition.swift
+++ b/Expo1900/Expo1900/Model/Exposition.swift
@@ -23,17 +23,17 @@ struct Exposition: Decodable {
             return formatter
         }()
         
-        guard let visitors = formatter.string(for: visitorsCount) else { return "방문객 : \(visitorsCount) 명" }
+        guard let visitors = formatter.string(for: visitorsCount) else { return " : \(visitorsCount) 명" }
         
-        return "방문객 : \(visitors) 명"
+        return " : \(visitors) 명"
     }
     
     var locationDescription: String {
-        return "개최지 : \(location)"
+        return " : \(location)"
     }
     
     var durationDescription: String {
-        return "개최 기간 : \(duration)"
+        return " : \(duration)"
     }
     
     private enum CodingKeys: String, CodingKey {

--- a/Expo1900/Expo1900/Model/NameSpace/AccessibilityLabelList.swift
+++ b/Expo1900/Expo1900/Model/NameSpace/AccessibilityLabelList.swift
@@ -1,0 +1,11 @@
+//
+//  BackButtonAccessibilityLabel.swift
+//  Expo1900
+//
+//  Created by jyubong, mireu
+//
+
+enum AccessibilityLabelList {
+    static let home = "홈"
+    static let previous = "이전 화면"
+}

--- a/Expo1900/Expo1900/Model/NameSpace/AssetNameList.swift
+++ b/Expo1900/Expo1900/Model/NameSpace/AssetNameList.swift
@@ -2,7 +2,7 @@
 //  AssetNameList.swift
 //  Expo1900
 //
-//  Created by jyubong on 11/3/23.
+//  Created by jyubong, mireu
 //
 
 enum AssetNameList {

--- a/Expo1900/Expo1900/Model/NameSpace/Identifier.swift
+++ b/Expo1900/Expo1900/Model/NameSpace/Identifier.swift
@@ -2,7 +2,7 @@
 //  Identifier.swift
 //  Expo1900
 //
-//  Created by jyubong on 11/3/23.
+//  Created by jyubong, mireu
 //
 
 enum Identifier {

--- a/Expo1900/Expo1900/SceneDelegate.swift
+++ b/Expo1900/Expo1900/SceneDelegate.swift
@@ -1,6 +1,6 @@
 //
 //  Expo1900 - SceneDelegate.swift
-//  Created by yagom. 
+//  Created by jyubong, mireu
 //  Copyright © yagom academy. All rights reserved.
 // 
 

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -176,18 +176,23 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="erR-tk-yGc">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="234.33333333333334"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="230.33333333333334"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vXt-LS-7yP">
-                                                <rect key="frame" x="50" y="0.0" width="293" height="194"/>
+                                                <rect key="frame" x="96.666666666666686" y="20" width="200" height="150"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="150" id="8Hm-nO-C1M"/>
+                                                    <constraint firstAttribute="width" constant="200" id="aCE-tG-97u"/>
+                                                </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c2u-Zm-dcC">
-                                                <rect key="frame" x="176" y="214" width="41.333333333333343" height="20.333333333333343"/>
+                                                <rect key="frame" x="176" y="190" width="41.333333333333343" height="20.333333333333343"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
+                                        <directionalEdgeInsets key="directionalLayoutMargins" top="20" leading="20" bottom="20" trailing="20"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
@@ -204,10 +209,10 @@
                         <viewLayoutGuide key="safeArea" id="UGF-4Z-ENe"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="UFo-IO-hP1" firstAttribute="bottom" secondItem="UGF-4Z-ENe" secondAttribute="bottom" constant="34" id="6qf-bQ-7yy"/>
+                            <constraint firstItem="UFo-IO-hP1" firstAttribute="bottom" secondItem="UXN-3M-4En" secondAttribute="bottom" id="6qf-bQ-7yy"/>
                             <constraint firstItem="UFo-IO-hP1" firstAttribute="leading" secondItem="UGF-4Z-ENe" secondAttribute="leading" id="ACP-kH-Jm3"/>
                             <constraint firstItem="UGF-4Z-ENe" firstAttribute="trailing" secondItem="UFo-IO-hP1" secondAttribute="trailing" id="UAL-SV-Obq"/>
-                            <constraint firstItem="UGF-4Z-ENe" firstAttribute="top" secondItem="UFo-IO-hP1" secondAttribute="top" constant="103" id="kVK-Ge-4f5"/>
+                            <constraint firstAttribute="top" secondItem="UFo-IO-hP1" secondAttribute="top" id="kVK-Ge-4f5"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="cG4-Ke-pO1"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qjH-TX-el9">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <accessibilityOverrides dynamicTypePreference="2"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
@@ -29,7 +30,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="c2O-gq-chj">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c2O-gq-chj">
                                                 <rect key="frame" x="124.66666666666667" y="73.666666666666686" width="143.66666666666663" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hfm-zz-MAa">
@@ -213,10 +214,6 @@
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vXt-LS-7yP">
                                                 <rect key="frame" x="96.666666666666686" y="20" width="200" height="150"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="150" id="8Hm-nO-C1M"/>
-                                                    <constraint firstAttribute="width" constant="200" id="aCE-tG-97u"/>
-                                                </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c2u-Zm-dcC">
                                                 <rect key="frame" x="176" y="190" width="41.333333333333343" height="20.333333333333343"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qjH-TX-el9">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -20,53 +21,53 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Q4M-ni-CT3">
-                                        <rect key="frame" x="0.0" y="48.000000000000028" width="393" height="451.66666666666674"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="501.66666666666669"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8C-Qo-3MS">
-                                                <rect key="frame" x="176" y="0.0" width="41.333333333333343" height="20.333333333333332"/>
+                                                <rect key="frame" x="176" y="20" width="41.333333333333343" height="20.333333333333329"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="c2O-gq-chj">
-                                                <rect key="frame" x="124.66666666666667" y="40.333333333333314" width="143.66666666666663" height="200"/>
+                                                <rect key="frame" x="124.66666666666667" y="60.333333333333343" width="143.66666666666663" height="200.00000000000003"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RKU-eg-RbN">
-                                                <rect key="frame" x="176" y="260.33333333333331" width="41.333333333333343" height="20.333333333333314"/>
+                                                <rect key="frame" x="176" y="280.33333333333331" width="41.333333333333343" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fvb-2J-amU">
-                                                <rect key="frame" x="176" y="300.66666666666669" width="41.333333333333343" height="20.333333333333314"/>
+                                                <rect key="frame" x="176" y="320.66666666666669" width="41.333333333333343" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BW8-L7-wBb">
-                                                <rect key="frame" x="176" y="341" width="41.333333333333343" height="20.333333333333314"/>
+                                                <rect key="frame" x="176" y="361" width="41.333333333333343" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CKA-nB-glD">
-                                                <rect key="frame" x="176" y="381.33333333333331" width="41.333333333333343" height="20.333333333333314"/>
+                                                <rect key="frame" x="176" y="401.33333333333331" width="41.333333333333343" height="20.333333333333314"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="28" translatesAutoresizingMaskIntoConstraints="NO" id="i8t-35-Ff9">
-                                                <rect key="frame" x="48.666666666666657" y="421.66666666666669" width="296" height="30"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="i8t-35-Ff9">
+                                                <rect key="frame" x="36.666666666666657" y="441.66666666666669" width="320" height="40"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="EY6-eP-7fV">
-                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="40"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="Mrz-Sj-Ohv"/>
-                                                            <constraint firstAttribute="width" constant="30" id="e1a-kp-7Yi"/>
+                                                            <constraint firstAttribute="height" constant="40" id="EzT-NM-iA5"/>
+                                                            <constraint firstAttribute="width" constant="50" id="re8-n1-Gwv"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nGK-9Z-2JX">
-                                                        <rect key="frame" x="58" y="0.0" width="180" height="30"/>
+                                                        <rect key="frame" x="70" y="0.0" width="180" height="40"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="한국의 출품작 보러가기"/>
                                                         <connections>
@@ -74,20 +75,21 @@
                                                         </connections>
                                                     </button>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="m6e-Nn-8Yh">
-                                                        <rect key="frame" x="266" y="0.0" width="30" height="30"/>
+                                                        <rect key="frame" x="270" y="0.0" width="50" height="40"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="30" id="ETf-1c-bkc"/>
-                                                            <constraint firstAttribute="width" constant="30" id="z9Y-WP-Rq9"/>
+                                                            <constraint firstAttribute="height" constant="40" id="BUg-hL-f9i"/>
+                                                            <constraint firstAttribute="width" constant="50" id="lV5-Zd-Chn"/>
                                                         </constraints>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <directionalEdgeInsets key="directionalLayoutMargins" top="20" leading="20" bottom="20" trailing="20"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="Q4M-ni-CT3" firstAttribute="width" secondItem="oh7-Xm-iTr" secondAttribute="width" id="Vg3-Z0-j6i"/>
-                                    <constraint firstItem="Q4M-ni-CT3" firstAttribute="top" secondItem="NvT-hm-gLZ" secondAttribute="top" constant="48" id="WTH-UG-2nq"/>
+                                    <constraint firstItem="Q4M-ni-CT3" firstAttribute="top" secondItem="NvT-hm-gLZ" secondAttribute="top" id="WTH-UG-2nq"/>
                                     <constraint firstAttribute="trailing" secondItem="Q4M-ni-CT3" secondAttribute="trailing" id="cKk-Zl-yCS"/>
                                     <constraint firstItem="Q4M-ni-CT3" firstAttribute="leading" secondItem="mTF-4F-E58" secondAttribute="leading" id="mwG-yB-aeQ"/>
                                     <constraint firstAttribute="bottom" secondItem="Q4M-ni-CT3" secondAttribute="bottom" id="pe7-lr-IsV"/>
@@ -172,7 +174,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="234.33333333333334"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vXt-LS-7yP">
-                                                <rect key="frame" x="50.333333333333343" y="0.0" width="292.66666666666663" height="194"/>
+                                                <rect key="frame" x="50" y="0.0" width="293" height="194"/>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c2u-Zm-dcC">
                                                 <rect key="frame" x="176" y="214" width="41.333333333333343" height="20.333333333333343"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -211,7 +211,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="erR-tk-yGc">
                                         <rect key="frame" x="0.0" y="0.0" width="393" height="230.33333333333334"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vXt-LS-7yP">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vXt-LS-7yP">
                                                 <rect key="frame" x="96.666666666666686" y="20" width="200" height="150"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="150" id="8Hm-nO-C1M"/>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -21,43 +21,76 @@
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Q4M-ni-CT3">
-                                        <rect key="frame" x="0.0" y="0.0" width="393" height="501.66666666666669"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="526"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8C-Qo-3MS">
-                                                <rect key="frame" x="176" y="20" width="41.333333333333343" height="20.333333333333329"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J8C-Qo-3MS">
+                                                <rect key="frame" x="163.33333333333334" y="19.999999999999996" width="66.333333333333343" height="33.666666666666657"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="poster" translatesAutoresizingMaskIntoConstraints="NO" id="c2O-gq-chj">
-                                                <rect key="frame" x="124.66666666666667" y="60.333333333333343" width="143.66666666666663" height="200.00000000000003"/>
+                                                <rect key="frame" x="124.66666666666667" y="73.666666666666686" width="143.66666666666663" height="200"/>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RKU-eg-RbN">
-                                                <rect key="frame" x="176" y="280.33333333333331" width="41.333333333333343" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fvb-2J-amU">
-                                                <rect key="frame" x="176" y="320.66666666666669" width="41.333333333333343" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BW8-L7-wBb">
-                                                <rect key="frame" x="176" y="361" width="41.333333333333343" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CKA-nB-glD">
-                                                <rect key="frame" x="176" y="401.33333333333331" width="41.333333333333343" height="20.333333333333314"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hfm-zz-MAa">
+                                                <rect key="frame" x="150" y="293.66666666666669" width="93.333333333333314" height="24"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="방문객" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5uH-IA-aQn">
+                                                        <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RKU-eg-RbN">
+                                                        <rect key="frame" x="52" y="0.0" width="41.333333333333343" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Bl-Ln-Dox">
+                                                <rect key="frame" x="150" y="337.66666666666669" width="93.333333333333314" height="24"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pdh-EP-S2r">
+                                                        <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fvb-2J-amU">
+                                                        <rect key="frame" x="52" y="0.0" width="41.333333333333343" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8qK-Rx-GdE">
+                                                <rect key="frame" x="138.66666666666666" y="381.66666666666669" width="115.66666666666666" height="24"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="개최 기간" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="426-DR-lhr">
+                                                        <rect key="frame" x="0.0" y="0.0" width="74.333333333333329" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BW8-L7-wBb">
+                                                        <rect key="frame" x="74.333333333333343" y="0.0" width="41.333333333333343" height="24"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CKA-nB-glD">
+                                                <rect key="frame" x="176" y="425.66666666666669" width="41.333333333333343" height="20.333333333333314"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="i8t-35-Ff9">
-                                                <rect key="frame" x="36.666666666666657" y="441.66666666666669" width="320" height="40"/>
+                                                <rect key="frame" x="36.666666666666657" y="466" width="320" height="40"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="flag" translatesAutoresizingMaskIntoConstraints="NO" id="EY6-eP-7fV">
                                                         <rect key="frame" x="0.0" y="0.0" width="50" height="40"/>
@@ -84,7 +117,7 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <directionalEdgeInsets key="directionalLayoutMargins" top="20" leading="20" bottom="20" trailing="20"/>
+                                        <directionalEdgeInsets key="directionalLayoutMargins" top="20" leading="15" bottom="20" trailing="15"/>
                                     </stackView>
                                 </subviews>
                                 <constraints>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -128,9 +128,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="ABl-Jr-iQu">
-                                <rect key="frame" x="0.0" y="59" width="393" height="759"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="ABl-Jr-iQu">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="itemCell" id="2HL-J4-468">
@@ -149,6 +148,12 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="kT9-Ts-6CW"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ABl-Jr-iQu" firstAttribute="top" secondItem="nT5-vl-oet" secondAttribute="top" id="VwA-dv-Xel"/>
+                            <constraint firstItem="ABl-Jr-iQu" firstAttribute="leading" secondItem="kT9-Ts-6CW" secondAttribute="leading" id="ZvE-fB-lOf"/>
+                            <constraint firstItem="ABl-Jr-iQu" firstAttribute="bottom" secondItem="nT5-vl-oet" secondAttribute="bottom" id="brN-Ot-A6Y"/>
+                            <constraint firstItem="ABl-Jr-iQu" firstAttribute="trailing" secondItem="kT9-Ts-6CW" secondAttribute="trailing" id="jVn-PJ-yqK"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="한국의 출품작" id="plc-si-xbT"/>
                     <connections>

--- a/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
+++ b/Expo1900/Expo1900/View/Base.lproj/Main.storyboard
@@ -218,9 +218,9 @@
                                                     <constraint firstAttribute="width" constant="200" id="aCE-tG-97u"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c2u-Zm-dcC">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c2u-Zm-dcC">
                                                 <rect key="frame" x="176" y="190" width="41.333333333333343" height="20.333333333333343"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 |<img src="https://avatars.githubusercontent.com/u/126065608?v=4" width="200" height="200">|<img src="https://github.com/mireu79/ios-exposition-universelle/assets/125941932/45dff9f5-f1a9-4398-82c9-5764daf9083d" width="200" height="200">|
 |[쥬봉 GitHub](https://github.com/jyubong)|[미르 GitHub](https://github.com/mireu79)|
 
+
 ## 📅 타임라인
 |날짜|내용|
 |------|---|
@@ -30,13 +31,13 @@
 |23.11.08|- error 구현 및 alert창으로 사용자에게 보이게 error 처리 <br> - back button accessibilitylabel 설정 <br> - step3 3차 PR|
 |23.11.10|- 코드 리팩토링(Error 메세지, 알럿창 함수 네이밍 수정) <br> - image에 Dynmic Type 적용 <br> - README 작성 |
 
+
 ## 👀 시각화 구조
 ### UML
 ![Expo1900UML](https://hackmd.io/_uploads/ByjnUUo7p.png)
 
 
-## 🖥️ 실행 화면
-
+## 💻 실행 화면
 | 첫번째 화면 | 두번째, 세번째 화면 | error 발생 |
 | -------- | -------- | -------- |
 | <img src="https://hackmd.io/_uploads/BkqjwSjmT.gif" width=296> | <img src="https://hackmd.io/_uploads/BkFnvBoma.gif" width=296> | ![](https://hackmd.io/_uploads/ByzhYriQT.gif) |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [팀원](#-팀원)
 - [타임라인](#-타임라인)
 - [시각화 구조](#-시각화-구조)
+- [실행 화면](#-실행-화면)
 - [트러블 슈팅](#-트러블-슈팅)
 - [참고 링크](#-참고-링크)
 
@@ -14,7 +15,7 @@
 |쥬봉이🐱|미르🐉|
 |---|---|
 |<img src="https://avatars.githubusercontent.com/u/126065608?v=4" width="200" height="200">|<img src="https://github.com/mireu79/ios-exposition-universelle/assets/125941932/45dff9f5-f1a9-4398-82c9-5764daf9083d" width="200" height="200">|
-|[GitHub](https://github.com/jyubong)|[GitHub](https://github.com/mireu79)|
+|[쥬봉 GitHub](https://github.com/jyubong)|[미르 GitHub](https://github.com/mireu79)|
 
 ## 📅 타임라인
 |날짜|내용|
@@ -24,9 +25,29 @@
 |23.11.01|- 코드 리팩토링(네이밍 수정)|
 |23.11.02|- 스토리보드 UI 구현 <br> - JSON 데이터 디코딩 <br> - tableView, cell 구현(modern cell configuration) <br> - 화면 전환 구현(스토리보드 segue), 데이터 전달(prepare) <br> - step2 2차 PR|
 |23.11.03|- 코드 리팩토링(네이밍 수정, 네임스페이스 등) <br> - 화면 전환시 다음 뷰컨트롤러의 메서드를 활용하여 데이터 전달로 변경|
-
+|23.11.06|- Accessibility Inspector (WWDC 2019) 보기 <br> - Writing Great Accessibility Labels (WWDC 2019) 보기 <br> - Dynmiac Type, Accessibility 개념과 필요성에 대해 공부 |
+|23.11.07|- 오토레이아웃 적용(스토리보드) <br> - Dynmic Type 적용(스토리보드)(list cell 코드) |
+|23.11.08|- error 구현 및 alert창으로 사용자에게 보이게 error 처리 <br> - back button accessibilitylabel 설정 <br> - step3 3차 PR|
+|23.11.10|- 코드 리팩토링(Error 메세지, 알럿창 함수 네이밍 수정) <br> - image에 Dynmic Type 적용 <br> - README 작성 |
 
 ## 👀 시각화 구조
+### UML
+![Expo1900UML](https://hackmd.io/_uploads/ByjnUUo7p.png)
+
+
+## 🖥️ 실행 화면
+
+| 첫번째 화면 | 두번째, 세번째 화면 | error 발생 |
+| -------- | -------- | -------- |
+| <img src="https://hackmd.io/_uploads/BkqjwSjmT.gif" width=296> | <img src="https://hackmd.io/_uploads/BkFnvBoma.gif" width=296> | ![](https://hackmd.io/_uploads/ByzhYriQT.gif) |
+
+| 첫번째 화면 회전 | 두번째 화면 회전 |
+| -------- | -------- |
+| ![image](https://hackmd.io/_uploads/Hyf-KSimT.png)| ![](https://hackmd.io/_uploads/H1H5_roQa.gif) |
+
+| 첫번째 화면 더 큰 글씨 | 두번째 화면 더 큰 글씨 | 세번째 화면 더 큰 글씨 |
+| -------- | -------- | -------- |
+| ![](https://hackmd.io/_uploads/HyJ28Hi7T.gif) | ![](https://hackmd.io/_uploads/SJBkvSjXp.gif) |![](https://hackmd.io/_uploads/rJ_cUSoXT.gif)|
 
 
 ## 🔥 트러블 슈팅
@@ -61,17 +82,68 @@ override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
     ~~~swift
     var content = cell.defaultContentConfiguration()
 
+    let imageWidth = 60
+    let imageSize = CGSize(width: imageWidth, height: imageWidth)
     content.image = UIImage(named: item.imageName)
-
-    let imageSize = CGSize(width: 60, height: 60)
     content.imageProperties.maximumSize = imageSize
     content.imageProperties.reservedLayoutSize = imageSize
 
     cell.contentConfiguration = content
     ~~~
+    
+3. 이미지에 Dynmic Type 적용문제
+    - Label에 Dynmic Type 적용을 하여 글씨가 커질수 있도록 하였지만, 이미지는 크기가 멈춰있어서 어색한 부분이 있어 이미지에도 스토리보드를 통해 `Adjust image Size` 적용시켜 수정하였습니다. 다만, Detail화면에서 cell마다 이미지가 따로 적용되어 Constant를 `>=`를 통하여 사이즈가 일정이상 커지면 이미지가 커질 수 있도록 적용하였습니다.
+    ![스크린샷 2023-11-10 오후 3.09.23(2)](https://hackmd.io/_uploads/SJtLYSomT.png)
+
+    -  다만, 세로가 긴 이미지의 경우 4:3비율을 고정값으로 줘서 이미지가 더이상 커지지 않는 이슈가 발생하여 아래와 같이 코드로 크기를 조정하는 방향으로 바꾸었습니다.
+    -  UIImage를 extension하여 원하는 높이를 설정하면 `UIGraphicsImageRenderer(size: )를 이용`하여 image 비율에 맞는 새로운 image를 생성하는 메서드를 만들어 이를 image view에 넣어주었습니다.
+    ``` swift
+    extension UIImage {
+        func resized(height: CGFloat) -> UIImage {
+            let ratio = self.size.width / self.size.height
+            let newWidth = height * ratio
+            let size = CGSize(width: newWidth, height: height)
+        
+            let renderer = UIGraphicsImageRenderer(size: size)
+            let image = renderer.image { _ in
+                draw(in: CGRect(origin: .zero, size: size))
+            }
+        
+            return image
+        }
+    }
+    ```
+
 
 ## 📚 참고 링크
 [공식문서 prepare](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621490-prepare)   
 [공식문서 UITableView](https://developer.apple.com/documentation/uikit/uitableview)   
 [공식문서 JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder)   
-[공식문서 UIListContentConfiguration](https://developer.apple.com/documentation/uikit/uilistcontentconfiguration)
+[공식문서 UIListContentConfiguration](https://developer.apple.com/documentation/uikit/uilistcontentconfiguration)   
+[공식문서 supportedInterfaceOrientationsFor](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623107-application)   
+[공식문서 H.I.G](https://developer.apple.com/design/human-interface-guidelines/typography)   
+[공식문서 UIGraphicsImageRenderer](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer)   
+[공식문서 indexPathForSelectedRow](https://developer.apple.com/documentation/uikit/uitableview/1615000-indexpathforselectedrow)   
+[WWDC20 Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)   
+
+---
+### 팀 회고
+<details>
+<summary>우리팀이 잘한 점</summary>
+
+- 의견조합이 잘이뤄졌고, 다양한 방법으로 시도하여 구현하려고 했다.
+</details>
+
+<details>
+<summary>우리팀이 개선할 점</summary>
+
+- 코드 구현에 있어 자신있게 자신의 생각을 말할 수 있도록 해야겠다고 생각했다.
+- 오토레이아웃을 더 공부해야겠다.
+</details>
+
+<details>
+<summary>서로에게 피드백</summary>
+
+- 쥬봉이 : 의견을 나누는데 있어 미르가 의견을 잘 들어주고 고민하는 부분에 있어서 결단을 내려주어 프로젝트가 원활히 진행될 수 있었다.
+- 미르 : 코드구현에 있어 제가 처음본 개념들을 쥬봉이가 숙지를 잘하고 있어 저를 이해시켜주어 공부가 많이 됐다.
+</details>


### PR DESCRIPTION
@delmaSong 
안녕하세요 델마 step3 PR입니다👐🏻
이번에도 잘 부탁드립니다! 

---
### 실행화면
|첫번째 화면|두번째-세번째화면|
|-|-|
|<img src="https://velog.velcdn.com/images/nane030/post/da15744b-a23d-4d6f-a487-61401b4c230d/image.gif" height="500">|<img src="https://velog.velcdn.com/images/nane030/post/b30f0638-aa0e-4ad2-a58f-e9b32f199887/image.gif" height="500">|

---
### 고민이 되었던 점
1. 첫 화면 세로로 보이게 구현
- `첫 화면은 세로로만 볼 수 있도록 합니다`라는 step3 과정을 통해 전체화면이 아닌 첫화면에 세로만 보이게 제약을 두어 구현하려고 했습니다.

    - `AppDelegate` 클래스에서 뷰컨트롤러에서 사용할 인터페이스 방향을 지정해주는 메서드인 [supportedInterfaceOrientationsFor](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623107-application) 를 이용하여 `ExpositionHomeViewController`에 `viewWillAppear`에는 `AppDelegate`의 프로퍼티인`sholdSupportAllOrientation`를 화면에 띄워 false를 주었고, `viewWillDisappear`에는 `sholdSupportAllOrientation`를 화면에 띄워 true를 주어 첫번째 화면에 세로로 설정해주었습니다.

~~~swift
class AppDelegate: UIResponder, UIApplicationDelegate {
    
    var sholdSupportAllOrientation = true
    
    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
        return sholdSupportAllOrientation ? .all : .portrait
    }
}
~~~
|첫번째 화면|두번째 화면|
|-|-|
|<img src ="https://hackmd.io/_uploads/r1OjHsuXa.png" width="500">|<img src="https://github.com/yagom-academy/ios-exposition-universelle/assets/126065608/615ff818-c83e-431d-9f64-cf3079eedce4" height="500">|

2. 오토레이아웃 설정
- 오토레이아웃을 최대한 `스토리보드`로 설정해주었습니다.
- **scroll view** : edge부분까지 scroll이 되어야하기때문에 superview를 기준으로 하여 0으로 설정하였습니다.
- **stack view**
    - scroll이 가로로 되어야되므로 width를 scroll view frame guide와 동일하게 설정하였습니다.
    - top은 content frame에 맞추어 navigation bar 아래에 맞춰지도록 설정하였습니다. 
    - 그 외에는 super view에 맞춰주었습니다.
- **stavk view padding** : stack view 내부 요소들도 top, botton, leadig, trailing과 간격을 주기 위해 `stack view layout margings - language directional`으로 padding을 주었습니다.
- **image view** : cell image view 외에는 스토리보드로 설정하였습니다.
    - 첫화면 포스터는 고유의 크기를 유지했습니다.
    - 버튼 옆의 image는 높이와 너비를 제한했습니다.
    - detail view에서는 높이와 너비를 제한하고 aspect Fit으로 설정한 크기내에서 원래의 비율을 유지하도록 설정하였습니다.
    - cell image view는 cell configuaration을 사용하여 60*60 안에서 기본 비율을 유지하도록 설정했습니다. 

        ```swift
        let imageWidth = 60
        let imageSize = CGSize(width: imageWidth, height: imageWidth)
        content.image = UIImage(named: item.imageName)
        content.imageProperties.maximumSize = imageSize
        content.imageProperties.reservedLayoutSize = imageSize
        ```
- label
    - 글씨가 잘리는 것을 막기 위해 numberOfLines를 0으로 설정하였습니다.
    - 첫화면 title label은 중앙 정렬을 해주었습니다.

3. Dynamic Type
- view에 사용자가 원하는 글씨사이즈로 볼수 있도록 하는 Dynamic Type을 적용하는 조건이 있어 코드로 구현을 할지 스토리보드로 나타내줄지에 대한 고민을 했었습니다.

    - 오토레이아웃이나 화면전환을 스토리보드로 구현하였다보니 통일성을 주기위해 Dynamic Type 또한 스토리보드에서 적용하였습니다.
    ![스크린샷 2023-11-08 오후 2.23.09(2).png](https://hackmd.io/_uploads/S1U5sqdmp.png)
    
     - 다만, 테이블 뷰의 List를 선택했을때 Detail 화면을 보여주는 경우 custoem cell로 구현을 하지않고, content configuration을 사용하여 원하는 image View를 설정하였다보니 Detail 화면의 Font의 경우엔 코드로 구현을 해줬습니다.
     ([Dynamic Type Size 참고](https://developer.apple.com/design/human-interface-guidelines/typography))
~~~swift
 content.textProperties.font = UIFont.preferredFont(forTextStyle: .title1)
        
content.secondaryTextProperties.font = UIFont.preferredFont(forTextStyle: .body)
~~~


4. accessibility 설정
[Writing Great Accessibility Labels (WWDC 2019)](https://developer.apple.com/videos/play/wwdc2019/254/)에 따르면
voice over시 유저가 들었을 때 이해할 수 있는 label을 사용하는 것이 중요합니다.
accessibility label의 경우 기본적으로 label의 내용이 설정됩니다.([accessibilitylabel 공식 문서](https://developer.apple.com/documentation/objectivec/nsobject/1615181-accessibilitylabel))
back button이 '메인 버튼', '한국의 출품작'처럼 이전 화면 title을 따르는데, 이를 들었을 때 조금 더 이해할 수 있는 label로 만들고자 하였습니다.
```swift
func setUpBackButtonAccessibilityLabel(to label: String) {
    let title = navigationItem.title
    let backButton = UIBarButtonItem(title: title, style: .plain, target: self, action: nil)

    navigationItem.backBarButtonItem = backButton
    navigationItem.backBarButtonItem?.accessibilityLabel = label
}
```
- `navigationItem.backBarButtonItem은 backButton이 있는 화면이 아닌 이전 화면에서 설정`해주어야 합니다.([backBarButtonItem 공식 문서](https://developer.apple.com/documentation/uikit/uinavigationitem/1624958-backbarbuttonitem)) 그래서 UIViewController을 extension하여 위 코드의 메서드를 구현했고, home viewcontroller와 list controller의 viewDidRoad에서 호출하고 있습니다.
- navigationItem.backBarButtonItem으로 UIKit에서 만든 back button에 접근 가능하다고 생각했으나 실행이 되지 않아 해결 방법으로 `새로운 back button을 만들어 설정`해주었습니다.


5. error발생시 alert 보여주도록 구현
- `json data를 decode할때 guard let에서 error를 던져주도록` 변경하였습니다.
- DecoderError enum을 만들어 assetNameError(DataAsset관련 에러)와 jsonDataError(decode관련 에러)를 case로 두고 있습니다.
```swift
struct AssetDecoder<Element: Decodable> {
    func parse(assetName: String) throws -> Element {
        guard let data = NSDataAsset(name: assetName)?.data else {
            throw DecoderError.assetNameError
        }
        
        let decoder = JSONDecoder()
        
        guard let jsonData = try? decoder.decode(Element.self, from: data) else {
            throw DecoderError.jsonDataError
        }
        
        return jsonData
    }
}
```
- ViewController에서 do-catch로 에러를 처리하도록 수정하였으며, `catch에서 alert를 띄어 유저가 error상황에 대해 인지`하도록 하였습니다.
- `UIViewController를 확장하여 error alert를 구현`하였습니다.
``` swift
func showAlert(_ error: Error) {
    let alertTitle: String = "오류"
    var message: String {
        switch error {
        case DecoderError.assetNameError:
            return "애셋네임을 알 수 없습니다."
        case DecoderError.jsonDataError:
            return "제이슨 데이터를 알 수 없습니다."
        default:
            return "시스템오류가 발생했습니다."
        }
    }
    let cancelTiltle: String = "취소"
    let retryTitle: String = "재시도"

    let alert = UIAlertController(title: alertTitle, message: message, preferredStyle: .alert)

    let cancelAction = UIAlertAction(title: cancelTiltle, style: .default)
    let retryAction = UIAlertAction(title: retryTitle, style: .default)

    alert.addAction(retryAction)
    alert.addAction(cancelAction)

    present(alert, animated: true)
}
```
- error에 따라 message가 변경되도록 연산프로퍼티로 구현하였습니다.
- `재시도, 취소 버튼`을 만들어 유저가 선택할 수 있도록 하였습니다.
    - 재시도 버튼 : 네트워크 상황시 데이터를 다시 가져오도록 하는 버튼이며, 현재 프로젝트에서는 정해진 Json data를 가져오는 것이기때문에 추가 실행을 구현하지 않고 일단 alert가 닫히도록만 구현하였습니다.
    - 취소 버튼 : 데이터가 제대로 decode되지 않은 상태로 남는 버튼입니다. 그래서 alert가 닫히도록만 구현하였습니다.

|asset error|json error|
|-|-|
|<img src="https://github.com/yagom-academy/ios-exposition-universelle/assets/126065608/9b136ed6-830f-4f25-bb54-b59d1cf03ee1" height="500">|<img src="https://github.com/yagom-academy/ios-exposition-universelle/assets/126065608/5269c8aa-44a6-401b-9eb0-a1ec582e3543" height="500">|




### 조언을 구하고 싶은 부분
1. Dynamic type을 Image에도 적용하는 것이 좋을까요?
현재 구현에서는 label만 dynamic type을 적용해주었는데 image view 또한 adjusts image size를 선택하면 변환이 되는 것을 확인하였습니다. 하지만 크기가 fix된 image에 경우에는 변환이 되지 않는데, 이 부분은 크기를 view의 frame 사이즈 기준으로 설정하는 등의 다른 방식으로 가능할 것 같습니다.

2. accessibility 적용 부분에서 조언을 구하고 싶습니다.
- 현재는 accessibility를 back bar button에만 수정해주고 있는데, 이 부분 외에 적용해주면 좋을 부분들이 있을까요? 그리고 Image에는 accessibility를 적용하고 있지 않은데, 어느 정도까지 적용을 해주면 좋을지 아직은 감이 잡히지 않습니다.
- back button에 accessibility를 적용하는 부분에서 navigationItem.backBarButtonItem으로 button을 가져올 수 있을 것으로 예상했으나 lldb 확인결과 nil로 확인되었습니다. 그래서 새로운 버튼을 넣어서 accessibility를 적용해주었는데, 이 방법이 아닌 UIKit이 만들어준 기본 backBarButton을 바로 사용해서 적용해볼 방법이 없을까요? 시도를 해보았으나 모두 실패하였습니다.

3. 고민되었던 점들이 어느정도 해결은 되었지만, 확신이 들지않아 전반적인 코드리뷰를 통해 조언을 얻고 싶습니다.

